### PR TITLE
Skips authorization form if the client has been authorized by the resource owner

### DIFF
--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -2,7 +2,14 @@ class Doorkeeper::AuthorizationsController < Doorkeeper::ApplicationController
   before_filter :authenticate_resource_owner!
 
   def new
-    render :error unless authorization.valid?
+    if authorization.valid?
+      if authorization.access_token_exists?
+        authorization.authorize
+        redirect_to authorization.success_redirect_uri
+      end
+    else
+      render :error
+    end
   end
 
   def create

--- a/lib/doorkeeper/oauth/authorization_request.rb
+++ b/lib/doorkeeper/oauth/authorization_request.rb
@@ -31,6 +31,11 @@ module Doorkeeper::OAuth
       create_authorization if valid?
     end
 
+    def access_token_exists?
+      token = AccessToken.accessible.where(:application_id => client.id, :resource_owner_id => resource_owner.id)
+      !token.first.nil?
+    end
+
     def deny
       self.error = :access_denied
     end

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -18,12 +18,25 @@ describe Doorkeeper::AuthorizationsController do
   describe "#new" do
     include_context "authenticated resource owner"
 
-    describe "when authorization is valid" do
+    describe "when authorization is valid and no access token exists" do
       include_context "valid authorization request"
+
+      before { authorization.stub(:access_token_exists? => false) }
 
       it "renders :new" do
         get :new, :use_route => :doorkeeper
         should render_template(:new)
+      end
+    end
+
+    describe "when authorization is valid and an access token already exists" do
+      include_context "valid authorization request"
+
+      before { authorization.stub(:access_token_exists? => true) }
+
+      it "renders :new" do
+        get :new, :use_route => :doorkeeper
+        should redirect_to("http://something.com/cb?code=token")
       end
     end
 

--- a/spec/requests/authorization/authorization_request_spec.rb
+++ b/spec/requests/authorization/authorization_request_spec.rb
@@ -1,43 +1,40 @@
 require "spec_helper"
 
 feature "Authorization Request" do
-  let(:client) { Factory(:application) }
-
-  before do
-    Doorkeeper.stub(:authenticate_resource_owner => proc do User.create! end)
+  background do
+    resource_owner_is_authenticated
+    client_exists
   end
 
-  scenario "requesting with valid client" do
-    visit "/oauth/authorize?client_id=#{client.uid}&redirect_uri=#{client.redirect_uri}&response_type=code"
+  scenario "resource owner authorize the client" do
+    visit authorization_endpoint_url(:client => @client)
     click_on "Authorize"
 
     # Authorization code was created
-    grant = client.access_grants.first
+    grant = @client.access_grants.first
     grant.should_not be_nil
 
-    i_should_be_on_url redirect_uri_with_code(client.redirect_uri, grant.token)
+    i_should_be_on_url redirect_uri_with_code(@client.redirect_uri, grant.token)
   end
 
-  scenario "deny access to the client redirects with error" do
-    visit "/oauth/authorize?client_id=#{client.uid}&redirect_uri=#{client.redirect_uri}&response_type=code"
+  scenario "resource owner with previously authorized client" do
+    client_is_authorized(@client, User.last)
+    visit authorization_endpoint_url(:client => @client)
+
+    grant = @client.access_grants.first
+
+    # Skips authorization form and redirect with new grant
+    i_should_be_on_url redirect_uri_with_code(@client.redirect_uri, grant.token)
+  end
+
+  scenario "resource owner deny access to the client" do
+    visit authorization_endpoint_url(:client => @client)
     click_on "Deny"
-    i_should_be_on_url redirect_uri_with_error(client.redirect_uri, "access_denied")
+    i_should_be_on_url redirect_uri_with_error(@client.redirect_uri, "access_denied")
   end
 
-  scenario "requesting with invalid valid client_id" do
-    visit "/oauth/authorize?client_id=invalid&redirect_uri=#{client.redirect_uri}&response_type=code"
+  scenario "resource owner recieves an error with invalid client" do
+    visit authorization_endpoint_url(:client => @client, :client_id => "invalid")
     i_should_see "An error has occurred"
-  end
-
-  def redirect_uri_with_code(uri, code)
-    uri = URI.parse(uri)
-    uri.query = "code=#{code}"
-    uri.to_s
-  end
-
-  def redirect_uri_with_error(uri, error)
-    uri = URI.parse(uri)
-    uri.query = "error=#{error}"
-    uri.to_s
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
 
   config.infer_base_class_for_anonymous_controllers = false
 
-  config.include RequestSpecHelper, :type => :request
-
+  config.include RequestSpecHelper,          :type => :request
+  config.include AuthorizationRequestHelper, :type => :request
+  config.include AccessTokenRequestHelper,   :type => :request
 end
-

--- a/spec/support/helpers/access_token_request_helper.rb
+++ b/spec/support/helpers/access_token_request_helper.rb
@@ -1,0 +1,5 @@
+module AccessTokenRequestHelper
+  def client_is_authorized(client, resource_owner)
+    Factory(:access_token, :application => client, :resource_owner_id => resource_owner.id)
+  end
+end

--- a/spec/support/helpers/authorization_request_helper.rb
+++ b/spec/support/helpers/authorization_request_helper.rb
@@ -1,0 +1,29 @@
+module AuthorizationRequestHelper
+  def resource_owner_is_authenticated(resource_owner = nil)
+    resource_owner ||= User.create!
+    Doorkeeper.stub(:authenticate_resource_owner => proc { resource_owner })
+  end
+
+  def client_exists(client_attributes = {})
+    @client = Factory(:application, client_attributes)
+  end
+
+  def authorization_endpoint_url(options = {})
+    client_id     = options[:client_id]    ? options[:client_id]    : options[:client].uid
+    redirect_uri  = options[:redirect_uri] ? options[:redirect_uri] : options[:client].redirect_uri
+    response_type = options[:response_type] || "code"
+    "/oauth/authorize?client_id=#{client_id}&redirect_uri=#{redirect_uri}&response_type=#{response_type}"
+  end
+
+  def redirect_uri_with_code(uri, code)
+    uri = URI.parse(uri)
+    uri.query = "code=#{code}"
+    uri.to_s
+  end
+
+  def redirect_uri_with_error(uri, error)
+    uri = URI.parse(uri)
+    uri.query = "error=#{error}"
+    uri.to_s
+  end
+end


### PR DESCRIPTION
Even though the OAuth 2 spec does not mention this behavior, it is a common practice to skip the authorization form and redirect the resource owner straight to the client when the client was previously authorized.

This commit also includes a small refactor in the authorization request spec, moving common parts to its proper helpers
