### PR TITLE
Refresh token flow to access token request

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -9,7 +9,10 @@ class AccessToken < ActiveRecord::Base
 
   validates :application_id, :resource_owner_id, :token, :presence => true
 
+  attr_accessor :use_refresh_token
+
   before_validation :generate_token, :on => :create
+  before_validation :generate_refresh_token, :on => :create, :if => :use_refresh_token?
 
   def self.authorized_for(application_id, resource_owner_id)
     accessible.where(:application_id => application_id, :resource_owner_id => resource_owner_id).first
@@ -35,10 +38,22 @@ class AccessToken < ActiveRecord::Base
     self[:scopes].split(" ").map(&:to_sym)
   end
 
+  def scopes_string
+    self[:scopes]
+  end
+
+  def use_refresh_token?
+    self.use_refresh_token
+  end
+
   private
 
   def expired_time
     self.created_at + expires_in.seconds
+  end
+
+  def generate_refresh_token
+    self.refresh_token = unique_random_string_for(:refresh_token)
   end
 
   def generate_token

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -25,6 +25,10 @@ module Doorkeeper
       def build
         @config
       end
+
+      def use_refresh_token
+        @config.instance_variable_set("@refresh_token_enabled", true)
+      end
     end
 
     module Option
@@ -96,5 +100,9 @@ module Doorkeeper
     option :admin_authenticator,          :as      => :authenticate_admin
     option :access_token_expires_in,      :default => 7200
     option :authorization_scopes,         :as      => :scopes, :builder_class => ScopesBuilder
+
+    def refresh_token_enabled?
+      !!@refresh_token_enabled
+    end
   end
 end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -23,4 +23,7 @@ Doorkeeper.configure do
 
   # Access token expiration time (default 2 hours)
   # access_token_expires_in 2.hours
+
+  # Issue access tokens with refresh token (disabled by default)
+  # use_refresh_token
 end

--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -23,6 +23,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       t.integer  :resource_owner_id, :null => false
       t.integer  :application_id,    :null => false
       t.string   :token,             :null => false
+      t.string   :refresh_token
       t.integer  :expires_in
       t.datetime :revoked_at
       t.datetime :created_at,        :null => false

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -28,4 +28,7 @@ Doorkeeper.configure do
 
   # Access token expiration time (default 2 hours)
   # access_token_expires_in 2.hours
+
+  # Issue access tokens with refresh token (disabled by default)
+  use_refresh_token
 end

--- a/spec/dummy/db/migrate/20111206151426_create_doorkeeper_tables.rb
+++ b/spec/dummy/db/migrate/20111206151426_create_doorkeeper_tables.rb
@@ -23,6 +23,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       t.integer  :resource_owner_id, :null => false
       t.integer  :application_id,    :null => false
       t.string   :token,             :null => false
+      t.string   :refresh_token
       t.integer  :expires_in
       t.datetime :revoked_at
       t.datetime :created_at,        :null => false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(:version => 20111206151426) do
     t.integer  "resource_owner_id", :null => false
     t.integer  "application_id",    :null => false
     t.string   "token",             :null => false
+    t.string   "refresh_token"
     t.integer  "expires_in"
     t.datetime "revoked_at"
     t.datetime "created_at",        :null => false

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -49,4 +49,15 @@ describe Doorkeeper, "configuration" do
       subject.scopes[:public].default.should == true
     end
   end
+
+  describe "use_refresh_token" do
+    it "is false by default" do
+      subject.refresh_token_enabled?.should be_false
+    end
+
+    it "can change the value" do
+      Doorkeeper.configure { use_refresh_token }
+      subject.refresh_token_enabled?.should be_true
+    end
+  end
 end

--- a/spec/requests/authorization/access_token_request_spec.rb
+++ b/spec/requests/authorization/access_token_request_spec.rb
@@ -15,9 +15,10 @@ feature "Access Token Request" do
 
     parsed_response.should_not have_key('error')
 
-    parsed_response['access_token'].should == token.token
-    parsed_response['expires_in'].should   == token.expires_in
-    parsed_response['token_type'].should   == "bearer"
+    parsed_response['access_token'].should  == token.token
+    parsed_response['token_type'].should    == "bearer"
+    parsed_response['expires_in'].should    == token.expires_in
+    parsed_response['refresh_token'].should be_nil
   end
 
   scenario "get error for invalid grant code" do

--- a/spec/requests/refresh_token/refresh_token_spec.rb
+++ b/spec/requests/refresh_token/refresh_token_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+feature "Refresh token" do
+  before do
+    Doorkeeper.configure { use_refresh_token }
+    client_exists
+  end
+
+  context "issuing a refresh token" do
+    before do
+      authorization_code_exists(:client => @client)
+    end
+
+    scenario "client gets the refresh token and refreshses it" do
+      post token_endpoint_url(:code => @authorization.token, :client => @client)
+      refresh_token = parsed_response['refresh_token']
+      access_token  = parsed_response['access_token']
+
+      access_token.should_not be_nil
+      refresh_token.should_not be_nil
+      @authorization.reload.should be_revoked
+
+      post refresh_token_endpoint_url(:client => @client, :refresh_token => refresh_token)
+      new_access_token = parsed_response['access_token'].should_not be_nil
+      new_refresh_token = parsed_response['refresh_token'].should_not be_nil
+
+      access_token.should_not  == new_access_token
+      refresh_token.should_not == new_refresh_token
+    end
+  end
+
+  context "refreshing the token" do
+    before do
+      @token = Factory(:access_token, :application => @client, :resource_owner_id => 1, :use_refresh_token => true)
+    end
+
+    scenario "client request a token with refresh token" do
+      post refresh_token_endpoint_url(:client => @client, :refresh_token => @token.refresh_token)
+      parsed_response['refresh_token'].should_not be_nil
+      @token.reload.should be_revoked
+    end
+
+    scenario "client gets an error for invalid refresh token" do
+      post refresh_token_endpoint_url(:client => @client, :refresh_token => "invalid")
+      parsed_response['error'].should == "invalid_grant"
+      parsed_response['refresh_token'].should be_nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ RSpec.configure do |config|
 
   config.infer_base_class_for_anonymous_controllers = false
 
-  config.after(:each) do
+  config.after do
     Doorkeeper.configure {}
   end
 end

--- a/spec/support/helpers/access_token_request_helper.rb
+++ b/spec/support/helpers/access_token_request_helper.rb
@@ -11,6 +11,10 @@ module AccessTokenRequestHelper
     page.driver.header header, value
   end
 
+  def with_access_token_header(token)
+    page.driver.header 'Authorization', "Bearer #{token}"
+  end
+
   def response_status_should_be(status)
     page.driver.response.status.to_i.should == status
   end

--- a/spec/support/helpers/url_helper.rb
+++ b/spec/support/helpers/url_helper.rb
@@ -21,6 +21,17 @@ module UrlHelper
     "/oauth/authorize?#{build_query(parameters)}"
   end
 
+  def refresh_token_endpoint_url(options = {})
+    parameters = {
+      :refresh_token => options[:refresh_token],
+      :client_id     => options[:client_id]     || options[:client].uid,
+      :client_secret => options[:client_secret] || options[:client].secret,
+      :redirect_uri  => options[:redirect_uri]  || options[:client].redirect_uri,
+      :grant_type    => options[:grant_type]    || "refresh_token",
+    }
+    "/oauth/token?#{build_query(parameters)}"
+  end
+
   def build_query(hash)
     Rack::Utils.build_query(hash)
   end


### PR DESCRIPTION
Introduce refresh token flow described in [OAuth2 #1.5](http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-1.5)

Refresh token is disabled by default, but it can be enabled with:

``` ruby
Doorkeeper.configure do
  # Issue access tokens with refresh token (disabled by default)
  use_refresh_token
end
```

It uses [refresh token rotation](http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-10.4) which means that it issues a new refresh token on every access token refresh response.
