### PR TITLE
Allow only registered scopes in the authorization request. Fixes #14

### DIFF
--- a/lib/doorkeeper/config/scopes.rb
+++ b/lib/doorkeeper/config/scopes.rb
@@ -17,6 +17,10 @@ module Doorkeeper
       end.first
     end
 
+    def exists? (scope)
+      self[scope].present?
+    end
+
     def add (scope)
       raise IllegalElement unless valid_element?(scope)
       @scopes << scope

--- a/lib/doorkeeper/oauth/authorization_request.rb
+++ b/lib/doorkeeper/oauth/authorization_request.rb
@@ -109,7 +109,7 @@ module Doorkeeper::OAuth
     end
 
     def validate_scope
-      scope.present? && scope !~ /[\n|\r|\t]/
+      scope.present? && scope !~ /[\n|\r|\t]/ && scope.split(" ").all? { |s| Doorkeeper.configuration.scopes.exists?(s) }
     end
   end
 end

--- a/spec/lib/config/scopes_spec.rb
+++ b/spec/lib/config/scopes_spec.rb
@@ -53,6 +53,29 @@ module Doorkeeper
       end
     end
 
+    describe :exists do
+      subject do
+        Scopes.new.tap do |scopes|
+          scopes.add scope_double("public", false)
+        end
+      end
+
+      it 'returns true if scope with given name is present' do
+        subject.exists?("public").should be_true
+      end
+
+      it 'returns false if scope with given name does not exist' do
+        subject.exists?("other").should be_false
+      end
+
+      it 'handles symbols and strings' do
+        subject.exists?(:public).should be_true
+        subject.exists?("public").should be_true
+        subject.exists?(:other).should be_false
+        subject.exists?("other").should be_false
+      end
+    end
+
     describe :all do
       let :scopes_array do
         create_scopes_array "scope1", true,


### PR DESCRIPTION
If scope parameter defined while requesting authentication has some scope that is not registered in the system then the request is treated as invalid and invalid_scope error is returned.
