### PR TITLE
Fix access token response headers

### DIFF
--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -1,5 +1,9 @@
 class Doorkeeper::TokensController < Doorkeeper::ApplicationController
   def create
+    response.headers.merge!({
+      'Pragma'        => 'no-cache',
+      'Cache-Control' => 'no-store',
+    })
     if token.authorize
       render :json => token.authorization
     else

--- a/spec/requests/authorization/access_token_request_spec.rb
+++ b/spec/requests/authorization/access_token_request_spec.rb
@@ -13,6 +13,9 @@ feature "Access Token Request" do
     token.should_not be_nil
     token.scopes.should == [:public]
 
+    should_have_header 'Pragma', 'no-cache'
+    should_have_header 'Cache-Control', 'no-store'
+
     parsed_response.should_not have_key('error')
 
     parsed_response['access_token'].should  == token.token
@@ -26,6 +29,9 @@ feature "Access Token Request" do
 
     token = AccessToken.where(:application_id => @client.id).first
     token.should be_nil
+
+    should_have_header 'Pragma', 'no-cache'
+    should_have_header 'Cache-Control', 'no-store'
 
     parsed_response.should_not have_key('access_token')
     parsed_response['error'].should == 'invalid_grant'

--- a/spec/support/helpers/request_spec_helper.rb
+++ b/spec/support/helpers/request_spec_helper.rb
@@ -26,6 +26,10 @@ module RequestSpecHelper
   def current_uri
     URI.parse(page.current_url)
   end
+
+  def should_have_header(header, value)
+    headers[header].should == value
+  end
 end
 
 RSpec.configuration.send :include, RequestSpecHelper, :type => :request


### PR DESCRIPTION
Add Pragma and Cache-Control response headers to token endpoint

```
 HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 Cache-Control: no-store
 Pragma: no-cache

 {
   "access_token":"2YotnFZFEjr1zCsicMWpAA",
   "token_type":"example",
   "expires_in":3600,
   "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA",
   "example_parameter":"example_value"
 }
```

Closes #6
