### PR TITLE
Ignore Authorization: headers that are not Bearer

### DIFF
--- a/lib/doorkeeper/doorkeeper_for.rb
+++ b/lib/doorkeeper/doorkeeper_for.rb
@@ -101,11 +101,15 @@ module Doorkeeper
     end
 
     def get_doorkeeper_token
-      token = params[:access_token] || params[:bearer_token] || request.env['HTTP_AUTHORIZATION']
+      token = params[:access_token] || params[:bearer_token] || authorization_bearer_token
       if token
-        token.gsub!(/Bearer /, '')
         AccessToken.find_by_token(token)
       end
+    end
+
+    def authorization_bearer_token
+      header = request.env['HTTP_AUTHORIZATION']
+      header.gsub!(/^Bearer /, '') unless header.nil?
     end
 
     def doorkeeper_unauthorized_render_options

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -83,7 +83,7 @@ describe "Doorkeeper_for helper" do
       get :index, :access_token => token_string
     end
 
-    it "beareer_token param" do
+    it "bearer_token param" do
       Doorkeeper::AccessToken.should_receive(:find_by_token).with(token_string)
       get :index, :bearer_token => token_string
     end
@@ -91,6 +91,12 @@ describe "Doorkeeper_for helper" do
     it "Authorization header" do
       Doorkeeper::AccessToken.should_receive(:find_by_token).with(token_string)
       request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
+      get :index
+    end
+
+    it "different kind of Authorization header" do
+      Doorkeeper::AccessToken.should_not_receive(:find_by_token)
+      request.env["HTTP_AUTHORIZATION"] = "Basic #{Base64.encode64("foo:bar")}"
       get :index
     end
   end


### PR DESCRIPTION
Currently doorkeeper_for hook looks up AccessToken when Authorization: header exists no matter what the type of the header is. It might be mostly harmless but the lookup is not necessary and I believe the behavior is incorrect. 

This patch prevents trying to load oauth tokens with such requests.
