### PR TITLE
Add destroy action to applications endpoint

### DIFF
--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -31,5 +31,11 @@ module Doorkeeper
       flash[:notice] = "Application updated" if @application.update_attributes(params[:application])
       respond_with @application
     end
+    
+    def destroy
+      @application = Application.find(params[:id])
+      flash[:notice] = "Application deleted" if @application.destroy
+      respond_with @application
+    end
   end
 end

--- a/app/models/doorkeeper/application.rb
+++ b/app/models/doorkeeper/application.rb
@@ -4,8 +4,8 @@ module Doorkeeper
 
     self.table_name = :oauth_applications
 
-    has_many :access_grants
-    has_many :authorized_tokens, :class_name => "AccessToken", :conditions => { :revoked_at => nil }
+    has_many :access_grants, :dependent => :destroy
+    has_many :authorized_tokens, :dependent => :destroy, :class_name => "AccessToken", :conditions => { :revoked_at => nil }
     has_many :authorized_applications, :through => :authorized_tokens, :source => :application
 
     validates :name, :secret, :redirect_uri, :presence => true

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -67,6 +67,13 @@ module Doorkeeper
       new_application.secret = nil
       new_application.should_not be_valid
     end
+    
+    it 'should reduce application count on destroy' do
+      new_application.save
+      expect { new_application.destroy }.to change(Application, :count).by -1
+    end
+    
+    it 'should destroy authorized_tokens and access_grants on delete' 
 
     describe :authorized_for do
       let(:resource_owner) { double(:resource_owner, :id => 10) }

--- a/spec/requests/applications/applications_request_spec.rb
+++ b/spec/requests/applications/applications_request_spec.rb
@@ -68,3 +68,18 @@ feature 'Edit application' do
     i_should_see 'Whoops! Check your form for possible errors'
   end
 end
+
+feature 'Destroy application' do
+  let :app do
+    Factory :application, :name => 'Very Deletable'
+  end
+  
+  background do
+    visit "/oauth/applications/#{app.id}"
+  end
+  
+  scenario 'deleting an app' do
+    click_link 'Remove'
+    i_should_see "Application deleted"
+  end
+end


### PR DESCRIPTION
I thought it was odd that the views had delete/remove links without the implementation. I'm not very efficient with rspec yet so I left an unfinished test to verify child records are destroyed with the application.
