### PR TITLE
Fixed Doorkeeper::OAuth::Authorization::Code/Taken not found errors

### DIFF
--- a/spec/requests/applications/authorized_applications_spec.rb
+++ b/spec/requests/applications/authorized_applications_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper_integration'
+require 'doorkeeper/oauth/authorization'
 
 feature 'Authorized applications' do
   background do


### PR DESCRIPTION
All the specs passed by running `rspec`, but when using `rake` to run the specs, I got the following errors.

```
uninitialized constant Doorkeeper::OAuth::Authorization::Token/Code
```
