### PR TITLE
Fix unknown method: authenticate_admin! when loading application admin

### DIFF
--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
-  class ApplicationsController < ApplicationController
+  class ApplicationsController < Doorkeeper::ApplicationController
     respond_to :html
 
     before_filter :authenticate_admin!


### PR DESCRIPTION
Saw this when integrating Doorkeeper in our app on Ruby 1.9.3-p125 and Rails 3.2.2. I'm surprised it didn't prefer Doorkeeper's ApplicationController over our app's, but, this pull fixes that.
