### PR TITLE
Fix unknown method authenticate_admin! when accessing applications admin

### DIFF
--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
-  class ApplicationsController < ApplicationController
+  class ApplicationsController < Doorkeeper::ApplicationController
     respond_to :html
 
     before_filter :authenticate_admin!


### PR DESCRIPTION
(First, sorry for the notification spam, I am learning the git workflow when working with forked repositories.)

Looks like the ApplicationsController forgot to use Doorkeeper::ApplicationController as a base.
