### PR TITLE
Allow token expiration to be disabled

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -77,7 +77,11 @@ module Doorkeeper
         end
 
         define_method attribute do |*args|
-          instance_variable_get(:"@#{attribute}") || options[:default]
+          if instance_variable_defined?(:"@#{attribute}")
+            instance_variable_get(:"@#{attribute}")
+          else
+            options[:default]
+          end
         end
 
         public attribute

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -21,7 +21,8 @@ Doorkeeper.configure do
   #   Admin.find_by_id(session[:admin_id]) || redirect_to(routes.new_admin_session_url)
   # end
 
-  # Access token expiration time (default 2 hours)
+  # Access token expiration time (default 2 hours).
+  # If you want to disable expiration, set this to nil.
   # access_token_expires_in 2.hours
 
   # Issue access tokens with refresh token (disabled by default)

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -34,6 +34,13 @@ describe Doorkeeper, "configuration" do
       end
       subject.access_token_expires_in.should == 4.hours
     end
+
+    it "can be set to nil" do
+      Doorkeeper.configure do
+        access_token_expires_in nil
+      end
+      subject.access_token_expires_in.should be_nil
+    end
   end
 
   describe "scopes" do


### PR DESCRIPTION
This patch allows access tokens to be configured to never expire by passing nil as the expiration time, along with a spec to test that it is actually set to be nil. I'm looking forward to using with the upcoming password grant for mobile access tokens.

I'm not convinced that nil is the best thing to pass here, but using a symbol like :never would require some special-case code in the configuration block for this option.
