### PR TITLE
Don't modify the Authorization: header so that its value won't be modified.

### DIFF
--- a/lib/doorkeeper/doorkeeper_for.rb
+++ b/lib/doorkeeper/doorkeeper_for.rb
@@ -109,7 +109,7 @@ module Doorkeeper
 
     def authorization_bearer_token
       header = request.env['HTTP_AUTHORIZATION']
-      header.gsub!(/^Bearer /, '') unless header.nil?
+      header.gsub(/^Bearer /, '') if header && header.match(/^Bearer /)
     end
 
     def doorkeeper_unauthorized_render_options

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -99,6 +99,13 @@ describe "Doorkeeper_for helper" do
       request.env["HTTP_AUTHORIZATION"] = "Basic #{Base64.encode64("foo:bar")}"
       get :index
     end
+
+    it "doesn't change Authorization header value" do
+      Doorkeeper::AccessToken.should_receive(:find_by_token).exactly(2).times
+      request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
+      get :index
+      get :index
+    end
   end
 
   context "defined for all actions" do


### PR DESCRIPTION
This bug is somewhat brought in per pull request #54. The code originally ignored if the token didn't begin with "Bearer ", so changing the value didn't affect the behavior, but now that the code is stricter about the value, the code should not alter the environment value anyway.
