### PR TITLE
Allow users to skip controllers

### DIFF
--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -21,18 +21,23 @@ module Doorkeeper
       end
 
       def generate_routes!(options)
-        mapping = Mapper.new.map(&@options)
+        @mapping = Mapper.new.map(&@options)
         routes.scope 'oauth', :as => 'oauth' do
-          authorizaton_routes mapping[:authorizations]
-          token_routes mapping[:tokens]
-          application_routes mapping[:applications]
-          authorized_applications_routes mapping[:authorized_applications]
+          map_route(:authorizations, :authorization_routes)
+          map_route(:tokens, :token_routes)
+          map_route(:applications, :application_routes)
+          map_route(:authorized_applications, :authorized_applications_routes)
         end
       end
 
     private
+      def map_route(name, method)
+        unless @mapping.skipped?(name)
+          send method, @mapping[name]
+        end
+      end
 
-      def authorizaton_routes(mapping)
+      def authorization_routes(mapping)
         routes.scope :controller => mapping[:controllers] do
           routes.match 'authorize', :via => :get,    :action => :new, :as => mapping[:as]
           routes.match 'authorize', :via => :post,   :action => :create, :as => mapping[:as]

--- a/lib/doorkeeper/rails/routes/mapper.rb
+++ b/lib/doorkeeper/rails/routes/mapper.rb
@@ -15,6 +15,10 @@ module Doorkeeper
           @mapping.controllers.merge!(controller_names)
         end
 
+        def skip_controllers(*controller_names)
+          @mapping.skips = controller_names
+        end
+
         def as(alias_names = {})
           @mapping.as.merge!(alias_names)
         end

--- a/lib/doorkeeper/rails/routes/mapping.rb
+++ b/lib/doorkeeper/rails/routes/mapping.rb
@@ -2,7 +2,7 @@ module Doorkeeper
   module Rails
     class Routes
       class Mapping
-        attr_accessor :controllers, :as
+        attr_accessor :controllers, :as, :skips
 
         def initialize
           @controllers = {
@@ -16,6 +16,9 @@ module Doorkeeper
             :authorizations => :authorization,
             :tokens => :token,
           }
+
+          @skips = []
+
         end
 
         def [](routes)
@@ -23,6 +26,10 @@ module Doorkeeper
             :controllers => @controllers[routes],
             :as => @as[routes]
           }
+        end
+
+        def skipped?(controller)
+          return @skips.include?(controller)
         end
       end
     end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -12,7 +12,20 @@ Rails.application.routes.draw do
     end
   end
 
+  scope 'outer_space' do
+    use_doorkeeper do
+      controllers :authorizations => 'custom_authorizations',
+                  :tokens => 'custom_authorizations'
+
+      as :authorizations => 'custom_auth',
+         :tokens => 'custom_token'
+
+      skip_controllers :tokens, :applications
+    end
+  end
+
   get 'metal.json' => 'metal#index'
+
   get '/callback', :to => "home#callback"
   get '/sign_in',  :to => "home#sign_in"
   resources :semi_protected_resources

--- a/spec/routing/custom_controller_routes_spec.rb
+++ b/spec/routing/custom_controller_routes_spec.rb
@@ -20,4 +20,16 @@ describe 'Custom controller for routes' do
   it 'GET /space/oauth/applications routes to applications controller' do
     get('/space/oauth/applications').should route_to('custom_authorizations#index')
   end
+
+  it 'POST /outer_space/oauth/token is not be routable' do
+    post('/outer_space/oauth/token').should_not be_routable
+  end
+
+  it 'GET /outer_space/oauth/authorize routes to custom authorizations controller' do
+    get('/outer_space/oauth/authorize').should be_routable
+  end
+
+  it 'GET /outer_space/oauth/applications is not routable' do
+    get('/outer_space/oauth/applications').should_not be_routable
+  end
 end


### PR DESCRIPTION
In `use_doorkeeper` block you can specify a skip_controllers like:

  skip_controllers: :applications, :authorized_applications

That would not include routes for those controllers in the app.

Related to #81.
