### PR TITLE
i18n for validator, flash messages

### DIFF
--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -15,7 +15,7 @@ module Doorkeeper
     def create
       @application = Application.new(params[:application])
       if @application.save
-        flash[:notice] = "Application created"
+        flash[:notice] = I18n.t(:notice, :scope => [:doorkeeper, :flash, :applications, :create])
         respond_with [:oauth, @application]
       else
         render :new
@@ -33,7 +33,7 @@ module Doorkeeper
     def update
       @application = Application.find(params[:id])
       if @application.update_attributes(params[:application])
-        flash[:notice] = "Application updated"
+        flash[:notice] = I18n.t(:notice, :scope => [:doorkeeper, :flash, :applications, :update])
         respond_with [:oauth, @application]
       else
         render :edit
@@ -42,7 +42,7 @@ module Doorkeeper
 
     def destroy
       @application = Application.find(params[:id])
-      flash[:notice] = "Application deleted" if @application.destroy
+      flash[:notice] = I18n.t(:notice, :scope => [:doorkeeper, :flash, :applications, :destroy]) if @application.destroy
       redirect_to oauth_applications_url
     end
   end

--- a/app/validators/redirect_uri_validator.rb
+++ b/app/validators/redirect_uri_validator.rb
@@ -2,11 +2,11 @@ require 'uri'
 
 class RedirectUriValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    uri = URI.parse(value)
-    record.errors[attribute] << "cannot contain a fragment." unless uri.fragment.nil?
-    record.errors[attribute] << "must be an absolute URL." if uri.scheme.nil? || uri.host.nil?
-    record.errors[attribute] << "cannot contain a query parameter." unless uri.query.nil?
+    uri = ::URI.parse(value)
+    record.errors.add(attribute, :fragment_present) unless uri.fragment.nil?
+    record.errors.add(attribute, :relative_uri) if uri.scheme.nil? || uri.host.nil?
+    record.errors.add(attribute, :has_query_parameter) unless uri.query.nil?
   rescue URI::InvalidURIError => e
-    record.errors[attribute] << "must be a valid URI."
+    record.errors.add(attribute, :invalid_uri)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,24 @@
 en:
+  activerecord:
+    errors:
+      models:
+        application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              has_query_parameter: 'cannot contain a query parameter.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+  mongoid:
+    errors:
+      models:
+        application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              has_query_parameter: 'cannot contain a query parameter.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
   doorkeeper:
     errors:
       messages:
@@ -21,3 +41,14 @@ en:
 
         # Password Access token errors
         invalid_resource_owner: 'The provided resource owner credentials are not valid, or resource owner cannot be found'
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'

--- a/spec/validators/redirect_uri_validator_spec.rb
+++ b/spec/validators/redirect_uri_validator_spec.rb
@@ -2,41 +2,39 @@ require 'spec_helper'
 require 'active_model'
 require 'validators/redirect_uri_validator'
 
+require 'spec_helper_integration'
+
 describe RedirectUriValidator do
   subject do
-    Class.new do
-      include ActiveModel::Validations
-      attr_accessor :uri
-      validates :uri, :redirect_uri => true
-    end.new
+    FactoryGirl.create(:application)
   end
 
   it 'is valid when the uri is a uri' do
-    subject.uri = "http://example.com/callback"
+    subject.redirect_uri = "http://example.com/callback"
     subject.should be_valid
   end
 
   it 'is invalid when the uri is not a uri' do
-    subject.uri = 123
+    subject.redirect_uri = ']'
     subject.should_not be_valid
-    subject.errors[:uri].first.should == "must be a valid URI."
+    subject.errors[:redirect_uri].first.should == "must be a valid URI."
   end
 
   it 'is invalid when the uri is relative' do
-    subject.uri = "/abcd"
+    subject.redirect_uri = "/abcd"
     subject.should_not be_valid
-    subject.errors[:uri].first.should == "must be an absolute URL."
+    subject.errors[:redirect_uri].first.should == "must be an absolute URI."
   end
 
   it 'is invalid when the uri has a fragment' do
-    subject.uri = "http://example.com/abcd#xyz"
+    subject.redirect_uri = "http://example.com/abcd#xyz"
     subject.should_not be_valid
-    subject.errors[:uri].first.should == "cannot contain a fragment."
+    subject.errors[:redirect_uri].first.should == "cannot contain a fragment."
   end
 
   it 'is invalid when the uri has a query parameter' do
-    subject.uri = "http://example.com/abcd?xyz=123"
+    subject.redirect_uri = "http://example.com/abcd?xyz=123"
     subject.should_not be_valid
-    subject.errors[:uri].first.should == "cannot contain a query parameter."
+    subject.errors[:redirect_uri].first.should == "cannot contain a query parameter."
   end
 end


### PR DESCRIPTION
This pull request moves the validator messages and flash messages to the locale file.  A couple of comments about the pull:
1. The validator uses the conventions established by the ORM libraries for the localization keys for model related strings.
2. As a result of (1), each validator message actually appears twice in the locale file - once in the 'activerecord' location and again in the 'mongoid' location.  This is unavoidable if we want to support both libraries and follow convention
3. The flash messages were added using the conventions of the Platformatec responders library (https://github.com/plataformatec/responders).  This is as close to a standard convention for Flash messages as I could find.
4. Because of these changes the RedirectUriValidator spec had to be updated to an integration spec and changed to use an Application factory.  It was proving impossible to get ActiveModel to accept a configured name in conjunction with the anonymous class.  ActionModel::Naming doesn't really support dynamic naming by its subclasses without a lot of work.

Tests all pass in ActiveRecord and Mongoid.
