### PR TITLE
Doorkeeper is using ActiveRecord version of as_json in ORM agnostic code

### DIFF
--- a/lib/doorkeeper/models/access_token.rb
+++ b/lib/doorkeeper/models/access_token.rb
@@ -46,11 +46,12 @@ module Doorkeeper
     end
 
     def as_json(options={})
-      super(
-        :only => [:resource_owner_id, :scopes],
-        :methods => :expires_in_seconds,
-        :include => { :application => { :only => :uid } }
-      )
+      {
+        :resource_owner_id => self.resource_owner_id,
+        :scopes => self.scopes,
+        :expires_in_seconds => self.expires_in_seconds,
+        :application => { :uid => self.application.uid }
+      }
     end
 
     private

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -140,10 +140,10 @@ module Doorkeeper
       it 'returns as_json hash'   do
         token = FactoryGirl.create :access_token, default_attributes
         token_hash = {
-                      "resource_owner_id" => token.resource_owner_id,
-                      "scopes" => token.scopes,
+                      :resource_owner_id => token.resource_owner_id,
+                      :scopes => token.scopes,
                       :expires_in_seconds => token.expires_in_seconds, 
-                      :application => { "uid" => token.application.uid }
+                      :application => { :uid => token.application.uid }
                      }
         token.as_json.should eq token_hash
       end


### PR DESCRIPTION
The method as_json in lib/doorkeeper/models/access_token.rb is calling 'super', expecting the ActiveRecord implementation of as_json.  Given Mongoid (and possibly soon MongoMapper) support, this is not a correct expectation.  The Mongoid (and MongoMapper) versions of as_json don't behave exactly the same way as the AR version, and hence the Mongoid tests are now failing.

This choice is also not ideal because the ActiveRecord implementation mixes symbols and strings for keys, which is just kind of weird.

As the hash is small and simple, we can just replace it with our own hash that we build manually.  This allows us to use one implementation for all ORMs.  I chose to use symbols for all of the keys, and have updated both the implementation and the test accordingly.

With this change the Mongoid tests are passing again.
