### PR TITLE
Allow Cross Origin Resource Sharing on TokensController#create method

### DIFF
--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -49,6 +49,7 @@ module Doorkeeper
       def token_routes(mapping)
         routes.scope :controller => mapping[:controllers] do
           routes.match 'token', :via => :post, :action => :create, :as => mapping[:as]
+          routes.match 'token', :via => :options, :action => :create, :as => mapping[:as]
         end
       end
 


### PR DESCRIPTION
I used Doorkeeper for my API and found out that my mobile app could not send ajax request because of the cross domain policies in browsers. I'm sure you'll want to integrate that way better that what I did here, but it might help you to get started.

What do you think ? I may have miss something here since this is kinda new for me talking to an API though a full JS mobile app using Backbone.js.
