### PR TITLE
Doorkeeper migration fails because the owner columns are missing from the table definition in template

### DIFF
--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -5,6 +5,8 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       t.string  :uid,          :null => false
       t.string  :secret,       :null => false
       t.string  :redirect_uri, :null => false
+      t.integer :owner_id,    :null => true
+      t.string  :owner_type, :null => true
       t.timestamps
     end
 


### PR DESCRIPTION
The Doorkeeper migration fails upon installation of a new application because the migration template is inconsistent in how it includes the optional owner columns on the applications table.  It references them in an index definition, but they aren't actually included in the table definition.

This pull request adds the missing columns to the table definition.
