### PR TITLE
Moving the Ownership injection for the application ownership enabled cas...

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -2,6 +2,7 @@ module Doorkeeper
   def self.configure(&block)
     @config = Config::Builder.new(&block).build
     enable_orm
+    setup_application_owner if @config.enable_application_owner?
   end
 
   def self.configuration
@@ -17,6 +18,11 @@ module Doorkeeper
     require 'doorkeeper/models/application'
   end
 
+  def self.setup_application_owner
+    require File.join(File.dirname(__FILE__), 'models', 'ownership')
+    Doorkeeper::Application.send :include, Doorkeeper::Models::Ownership
+  end
+
   class Config
     class Builder
       def initialize(&block)
@@ -29,8 +35,7 @@ module Doorkeeper
       end
 
       def enable_application_owner(opts={})
-        require File.join(File.dirname(__FILE__), 'models', 'ownership')
-        Doorkeeper::Application.send :include, Doorkeeper::Models::Ownership
+        @config.instance_variable_set("@enable_application_owner", true)
         confirm_application_owner if opts[:confirmation].present? && opts[:confirmation]
       end
 
@@ -132,6 +137,10 @@ module Doorkeeper
 
     def refresh_token_enabled?
       !!@refresh_token_enabled
+    end
+
+    def enable_application_owner?
+      !!@enable_application_owner
     end
 
     def confirm_application_owner?


### PR DESCRIPTION
The basic issue being fixed is described in detail [here](https://github.com/applicake/doorkeeper/pull/78#issuecomment-7650658).

The application owner changes include Doorkeeper::Models::Ownership into Doorkeeper::Application when application ownership is enabled.  This works fine as long as Doorkeeper::Application has already been loaded by a require.  In the current code this include happens inside the Doorkeeper::Config::Builder

As part of the ORM changes the Doorkeeper::Application require was moved until after the Doorkeeper::Config::Builder had run.  So the Doorkeeper::Application class isn't available inside the builder, and starting up an application with enable_application_owner uncommented in the initializer fails.

This doesn't show up in the tests as a failure (and I can't figure out a way to make it show up) because the require statement only needs to be issued once, and then the enable_application_owner in the Doorkeeper::Config::Builder will succeed.  So the tests run green.

This fix does two things:

1) Adds an instance variable to the configuration to track whether the enable_application_owner option is specified in the initializer
2) Calls the code to include Doorkeeper::Models::Ownership in Doorkeeper::Application if that instance variable is true.

Everything runs green on both AR and Mongoid.

Please let me know if you have any questions.
