### PR TITLE
Prevent double submission of password based authentication

### DIFF
--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -23,14 +23,17 @@ class Doorkeeper::TokensController < Doorkeeper::ApplicationController
   end
 
   def token
-    case params[:grant_type]
-    when 'password'
-      owner = resource_owner_from_credentials
-      @token ||= Doorkeeper::OAuth::PasswordAccessTokenRequest.new(client, owner, params)
-    when 'client_credentials'
-      @token ||= Doorkeeper::OAuth::ClientCredentialsRequest.new(Doorkeeper.configuration, client, params)
-    else
-      @token ||= Doorkeeper::OAuth::AccessTokenRequest.new(client, params)
+    unless defined?(@token) && @token
+      case params[:grant_type]
+      when 'password'
+        owner = resource_owner_from_credentials
+        @token = Doorkeeper::OAuth::PasswordAccessTokenRequest.new(client, owner, params)
+      when 'client_credentials'
+        @token = Doorkeeper::OAuth::ClientCredentialsRequest.new(Doorkeeper.configuration, client, params)
+      else
+        @token = Doorkeeper::OAuth::AccessTokenRequest.new(client, params)
+      end
     end
+    @token
   end
 end


### PR DESCRIPTION
This is a simple fix to bypass calling resource_owner_from_credentials again in the the tokens controller after the token has been initialized. Otherwise every call to the create action results in the credentials being evaluated again.
