### PR TITLE
Adding MongoDB dependency to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ env:
 gemfile:
   - gemfiles/gemfile.rails-3.1.x
   - gemfiles/gemfile.rails-3.2.x
+services:
+  - mongodb


### PR DESCRIPTION
At some point in the near future Travis CI is changing its startup process to exclude a number of processes it had been auto-starting on its workers.  You can find more info [here](http://about.travis-ci.org/blog/august-2012-upcoming-ci-environment-updates/).  

Doorkeeper requires MongoDB for its test suite (at least in some configurations) so I just added MongoDB as a required service.  This should ensure that Travis continues to run green for Doorkeeper when they make this change.
