### PR TITLE
Allow the access token to be sent via http header X-Access-Token

### DIFF
--- a/lib/doorkeeper/oauth/token.rb
+++ b/lib/doorkeeper/oauth/token.rb
@@ -3,8 +3,7 @@ module Doorkeeper
     class Token
       module Methods
         def from_access_token_param(request)
-          raise request.to_yaml
-          request.parameters[:access_token]
+          request.parameters[:access_token] || request.headers['X-Access-Token']
         end
 
         def from_bearer_param(request)


### PR DESCRIPTION
When I was building out client side calls with Spine, setting an access token header seemed cleaner than appending it to a URL.

Not sure if you're interested in this - but the change is trivial and wanted to send it your way if you like the idea.
