### PR TITLE
Response token status should be `:ok`, not `:success`

### DIFF
--- a/lib/doorkeeper/oauth/token_response.rb
+++ b/lib/doorkeeper/oauth/token_response.rb
@@ -18,7 +18,7 @@ module Doorkeeper
       end
 
       def status
-        :success
+        :ok
       end
 
       def headers

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -11,8 +11,8 @@ module Doorkeeper::OAuth
       headers.fetch('Pragma').should == 'no-cache'
     end
 
-    it 'status is success' do
-      subject.status.should == :success
+    it 'status is ok' do
+      subject.status.should == :ok
     end
 
     describe '.body' do


### PR DESCRIPTION
The `/oauth/token` endpoint is returning a `500` status code because in `app/controllers/doorkeeper/tokens_controller.rb#create` the response status is being set to `:success`.  This should have been `:ok`.

Request:

```
> http post http://hackerleague.local/oauth/token \ 
       grant_type="authorization_code" \
       code="9cad1e0d683a5042a614937c8abe1dc8171ddc87f5c93ac6d830636598bf4846" \
       redirect_uri="http://4bag.localtunnel.com/oauth" \
       client_id="575bdce107637869bb0646032ec743860d1ed3359ca8cefa6c8aa1154d1392a8" \
       client_secret="d692364f151ce280d409a1512cd833574212b715287a0b1ee9d770b59e782338"
```

Response prior to patch:

```
HTTP/1.1 500 Internal Server Error
Cache-Control: no-store
Connection: close
Content-Length: 155
Content-Type: application/json; charset=utf-8
Date: Sat, 27 Oct 2012 21:31:15 GMT
Pragma: no-cache
Server: thin 1.2.11 codename Bat-Shit Crazy
X-Request-Id: 5fa3f07cada8e01525887e0aca009963
X-Runtime: 0.010722
X-UA-Compatible: IE=Edge

{
    "access_token": "3a8ae264aaadfd5d07e1327334d9765f0c6990c2e5c2e34581c2fe7133115061", 
    "expires_in": 7200, 
     "refresh_token": null, 
     "scope": "", 
     "token_type": "bearer"
}
```
