### PR TITLE
owner generator removed as columns and indexes already exists

### DIFF
--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -5,13 +5,10 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       t.string  :uid,          :null => false
       t.string  :secret,       :null => false
       t.string  :redirect_uri, :null => false
-      t.integer :owner_id,    :null => true
-      t.string  :owner_type, :null => true
       t.timestamps
     end
 
     add_index :oauth_applications, :uid, :unique => true
-    add_index :oauth_applications, [:owner_id, :owner_type]
 
     create_table :oauth_access_grants do |t|
       t.integer  :resource_owner_id, :null => false


### PR DESCRIPTION
Thanks for this gem!
Owner_id and owner_type are already added when the initial migration generator is run. 
https://github.com/applicake/doorkeeper/blob/master/lib/generators/doorkeeper/templates/migration.rb#L8
So I removed the generator, template and spec as the generated migration would throw an error.
