### PR TITLE
Make token.expires_in_seconds return nil when expires_in is nil

### DIFF
--- a/lib/doorkeeper/models/expirable.rb
+++ b/lib/doorkeeper/models/expirable.rb
@@ -10,6 +10,7 @@ module Doorkeeper
       end
 
       def expires_in_seconds
+        return nil if expires_in.nil?
         expires = (created_at + expires_in.seconds) - Time.now
         expires_sec = expires.seconds.round(0)
         expires_sec > 0 ? expires_sec : 0  

--- a/spec/lib/models/expirable_spec.rb
+++ b/spec/lib/models/expirable_spec.rb
@@ -41,6 +41,11 @@ describe 'Expirable' do
       subject.stub :expires_in => 30.seconds
       subject.expires_in_seconds.should == 0 
     end
+
+    it "should return nil when expires_in is nil" do
+      subject.stub :expires_in => nil
+      subject.expires_in_seconds.should be_nil
+    end
     
   end
 end


### PR DESCRIPTION
Current implementation of `expires_in_seconds` throws errors when `expires_in` is nil (i.e. token doesn't expire) with: `NoMethodError: undefined method`seconds' for nil:NilClass` 

This makes the TokenInfoController not worky with such tokens because the method in question is called in the JSON rendering. 

This patch just returns nil in `expires_in_seconds` in such case.
