### PR TITLE
Add localization to authorized_applications destroy notice

### DIFF
--- a/app/controllers/doorkeeper/authorized_applications_controller.rb
+++ b/app/controllers/doorkeeper/authorized_applications_controller.rb
@@ -7,6 +7,6 @@ class Doorkeeper::AuthorizedApplicationsController < Doorkeeper::ApplicationCont
 
   def destroy
     Doorkeeper::AccessToken.revoke_all_for params[:id], current_resource_owner
-    redirect_to oauth_authorized_applications_url, :notice => "Application revoked."
+    redirect_to oauth_authorized_applications_url, :notice => I18n.t(:notice, :scope => [:doorkeeper, :flash, :authorized_applications, :destroy])
   end
 end


### PR DESCRIPTION
This replaces the hardcoded text and uses the already existing localization. 
