### PR TITLE
Remove unused JavaScript include in layout

### DIFF
--- a/app/assets/javascripts/doorkeeper/application.js
+++ b/app/assets/javascripts/doorkeeper/application.js
@@ -1,2 +1,0 @@
-//= require jquery
-//= require jquery_ujs

--- a/app/views/layouts/doorkeeper/application.html.erb
+++ b/app/views/layouts/doorkeeper/application.html.erb
@@ -4,7 +4,6 @@
   <title>Doorkeeper</title>
   <%= stylesheet_link_tag    "http://twitter.github.com/bootstrap/1.4.0/bootstrap.min.css" %>
   <%= stylesheet_link_tag    "doorkeeper/application" %>
-  <%= javascript_include_tag "doorkeeper/application" %>
   <%= csrf_meta_tags %>
 </head>
 <body>


### PR DESCRIPTION
Since JavaScript is never used in any of the views, there's no reason to
load what is effectively just jQuery in the application layout.
