### PR TITLE
Raise error if configuration is not set

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -1,4 +1,10 @@
 module Doorkeeper
+  class MissingConfiguration < StandardError
+    def initialize
+      super("Configuration for doorkeeper missing. Do you have doorkeeper initializer?")
+    end
+  end
+
   def self.configure(&block)
     @config = Config::Builder.new(&block).build
     enable_orm
@@ -6,7 +12,7 @@ module Doorkeeper
   end
 
   def self.configuration
-    @config
+    @config || (raise MissingConfiguration.new)
   end
 
   def self.enable_orm

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -152,4 +152,19 @@ describe Doorkeeper, "configuration" do
     end
 
   end
+
+  it 'raises an exception when configuration is not set' do
+    old_config = Doorkeeper.configuration
+    Doorkeeper.module_eval do
+      @config = nil
+    end
+
+    expect do
+      Doorkeeper.configuration
+    end.to raise_error Doorkeeper::MissingConfiguration
+
+    Doorkeeper.module_eval do
+      @config = old_config
+    end
+  end
 end


### PR DESCRIPTION
In case configuration for Doorkeeper was never set then trying to reach the configuration would result in an error. That way the users would easily see that they need to add doorkeeper initializer or change it in order for it to work instead of getting 'undefined_method for nil' errors.
