### PR TITLE
Add IDs to the show views for integration testing

### DIFF
--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -6,13 +6,13 @@
 
 <div class="span10">
   <h4>Callback url:</h4>
-  <p><code><%= @application.redirect_uri %></code></p>
+  <p><code id="callback_url"><%= @application.redirect_uri %></code></p>
 
   <h4>Application Id:</h4>
-  <p><code><%= @application.uid %></code></p>
+  <p><code id="application_id"><%= @application.uid %></code></p>
 
   <h4>Secret:</h4>
-  <p><code><%= @application.secret %></code></p>
+  <p><code id="secret"><%= @application.secret %></code></p>
 
   <h4>Link to authorization code:</h4>
   <p><%= link_to 'Authorize', oauth_authorization_path(:client_id => @application.uid, :redirect_uri => @application.redirect_uri, :response_type => 'code' ) %></p>

--- a/app/views/doorkeeper/authorizations/show.html.erb
+++ b/app/views/doorkeeper/authorizations/show.html.erb
@@ -1,4 +1,4 @@
 <div class="span16">
   <h3>Authorization code:</h3>
-  <code><%= params[:code] %></code>
+  <code id="authorization_code"><%= params[:code] %></code>
 </div>


### PR DESCRIPTION
This will simplify integration tests with Capybara in people's apps, which seems like a common enough use-case. Now, it'll be easy to grab the contents of each code tag without having to generate and customize the views themselves.
