### PR TITLE
Allow to overwrite scope in routes

### DIFF
--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -28,13 +28,13 @@ module Doorkeeper
 
       attr_accessor :routes
 
-      def initialize(routes, &options)
-        @routes, @options = routes, options
+      def initialize(routes, &block)
+        @routes, @block = routes, block
       end
 
       def generate_routes!(options)
-        @mapping = Mapper.new.map(&@options)
-        routes.scope 'oauth', :as => 'oauth' do
+        @mapping = Mapper.new.map(&@block)
+        routes.scope options[:scope] || 'oauth', :as => 'oauth' do
           map_route(:authorizations, :authorization_routes)
           map_route(:tokens, :token_routes)
           map_route(:applications, :application_routes)

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,19 @@
 Rails.application.routes.draw do
   use_doorkeeper
+  use_doorkeeper :scope => 'scope'
+
+  scope 'inner_space' do
+    use_doorkeeper :scope => 'scope' do
+      controllers :authorizations => 'custom_authorizations',
+                  :tokens => 'custom_authorizations',
+                  :applications => 'custom_authorizations',
+                  :token_info => 'custom_authorizations'
+
+      as :authorizations => 'custom_auth',
+         :tokens => 'custom_token',
+         :token_info => 'custom_token_info'
+    end
+  end
 
   scope 'space' do
     use_doorkeeper do

--- a/spec/routing/custom_controller_routes_spec.rb
+++ b/spec/routing/custom_controller_routes_spec.rb
@@ -1,6 +1,30 @@
 require 'spec_helper_integration'
 
 describe 'Custom controller for routes' do
+  it 'GET /space/scope/authorize routes to custom authorizations controller' do
+    get('/inner_space/scope/authorize').should route_to('custom_authorizations#new')
+  end
+
+  it 'POST /space/scope/authorize routes to custom authorizations controller' do
+    post('/inner_space/scope/authorize').should route_to('custom_authorizations#create')
+  end
+
+  it 'DELETE /space/scope/authorize routes to custom authorizations controller' do
+    delete('/inner_space/scope/authorize').should route_to('custom_authorizations#destroy')
+  end
+
+  it 'POST /space/scope/token routes to tokens controller' do
+    post('/inner_space/scope/token').should route_to('custom_authorizations#create')
+  end
+
+  it 'GET /space/scope/applications routes to applications controller' do
+    get('/inner_space/scope/applications').should route_to('custom_authorizations#index')
+  end
+
+  it 'GET /space/scope/token/info routes to the token_info controller' do
+    get('/inner_space/scope/token/info').should route_to('custom_authorizations#show')
+  end
+
   it 'GET /space/oauth/authorize routes to custom authorizations controller' do
     get('/space/oauth/authorize').should route_to('custom_authorizations#new')
   end
@@ -22,7 +46,7 @@ describe 'Custom controller for routes' do
   end
 
   it 'GET /space/oauth/token/info routes to the token_info controller' do
-    get('/space/oauth/token/info').should route_to('custom_authorizations#show')  
+    get('/space/oauth/token/info').should route_to('custom_authorizations#show')
   end
 
   it 'POST /outer_space/oauth/token is not be routable' do
@@ -40,5 +64,5 @@ describe 'Custom controller for routes' do
   it 'GET /outer_space/oauth/token_info is not routable' do
     get('/outer_space/oauth/token/info').should_not be_routable
   end
-    
+
 end

--- a/spec/routing/scoped_routes_spec.rb
+++ b/spec/routing/scoped_routes_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper_integration'
+
+describe 'Scoped routes' do
+  it 'GET /scope/authorize routes to authorizations controller' do
+    get('/scope/authorize').should route_to('doorkeeper/authorizations#new')
+  end
+
+  it 'POST /scope/authorize routes to authorizations controller' do
+    post('/scope/authorize').should route_to('doorkeeper/authorizations#create')
+  end
+
+  it 'DELETE /scope/authorize routes to authorizations controller' do
+    delete('/scope/authorize').should route_to('doorkeeper/authorizations#destroy')
+  end
+
+  it 'POST /scope/token routes to tokens controller' do
+    post('/scope/token').should route_to('doorkeeper/tokens#create')
+  end
+
+  it 'GET /scope/applications routes to applications controller' do
+    get('/scope/applications').should route_to('doorkeeper/applications#index')
+  end
+
+  it 'GET /scope/authorized_applications routes to authorized applications controller' do
+    get('/scope/authorized_applications').should route_to('doorkeeper/authorized_applications#index')
+  end
+
+  it 'GET /scope/token/info route to authorzed tokeninfo controller' do
+    get('/scope/token/info').should route_to('doorkeeper/token_info#show')
+  end
+
+end


### PR DESCRIPTION
This pull request allows to overwrite default scope 'oauth' in routes.
We had to migrate from another oauth gem and requirement was to keep url structure.
