### PR TITLE
Make redirect uri optional as per spec

### DIFF
--- a/app/validators/redirect_uri_validator.rb
+++ b/app/validators/redirect_uri_validator.rb
@@ -6,6 +6,7 @@ class RedirectUriValidator < ActiveModel::EachValidator
   end
 
   def validate_each(record, attribute, value)
+    return if value.nil? && !Doorkeeper.configuration.require_redirect_uri
     uri = ::URI.parse(value)
     return if test_redirect_uri?(uri)
     record.errors.add(attribute, :fragment_present) unless uri.fragment.nil?

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -153,6 +153,7 @@ module Doorkeeper
     option :authorization_code_expires_in,:default => 600
     option :orm, :default => :active_record
     option :test_redirect_uri, :default => 'urn:ietf:wg:oauth:2.0:oob'
+    option :require_redirect_uri, :default => true
 
 
     def refresh_token_enabled?

--- a/lib/doorkeeper/models/application.rb
+++ b/lib/doorkeeper/models/application.rb
@@ -5,7 +5,8 @@ module Doorkeeper
     has_many :access_grants, :dependent => :destroy, :class_name => "Doorkeeper::AccessGrant"
     has_many :access_tokens, :dependent => :destroy, :class_name => "Doorkeeper::AccessToken"
 
-    validates :name, :secret, :uid, :redirect_uri, :presence => true
+    validates :name, :secret, :uid, :presence => true
+    validates :redirect_uri, :presence => true, :if => lambda { Doorkeeper.configuration.require_redirect_uri }
     validates :uid, :uniqueness => true
     validates :redirect_uri, :redirect_uri => true
 

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -15,6 +15,10 @@ module Doorkeeper
         @client = client
         @grant  = grant
         @redirect_uri = parameters[:redirect_uri]
+
+        unless Doorkeeper.configuration.require_redirect_uri
+          @redirect_uri ||= grant && grant.redirect_uri
+        end
       end
 
       def authorize
@@ -75,7 +79,11 @@ module Doorkeeper
       end
 
       def validate_redirect_uri
-        grant.redirect_uri == redirect_uri
+        if grant.redirect_uri.present?
+          grant.redirect_uri == redirect_uri
+        else
+          !Doorkeeper.configuration.require_redirect_uri
+        end
       end
     end
   end

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -3,6 +3,7 @@ module Doorkeeper
     module Helpers
       module URIChecker
         def self.valid?(url)
+          return false if url.nil?
           uri = as_uri(url)
           uri.fragment.nil? && !uri.host.nil? && !uri.scheme.nil?
         rescue URI::InvalidURIError
@@ -16,7 +17,7 @@ module Doorkeeper
         end
 
         def self.valid_for_authorization?(url, client_url)
-          valid?(url) && matches?(url, client_url)
+          valid?(url) && valid?(client_url) && matches?(url, client_url)
         end
 
         def self.as_uri(url)

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -18,6 +18,11 @@ module Doorkeeper
         @redirect_uri  = attrs[:redirect_uri]
         @scope         = attrs[:scope]
         @state         = attrs[:state]
+
+        # If the request has not specified a redirect, use the client-supplied one.
+        unless Doorkeeper.configuration.require_redirect_uri
+          @redirect_uri ||=  client && client.redirect_uri
+        end
       end
 
       def authorizable?
@@ -53,8 +58,27 @@ module Doorkeeper
 
       # TODO: test uri should be matched against the client's one
       def validate_redirect_uri
+        # As per spec section 4.2.1, the redirect_uri:
+        #  - is optional if application has defined its own redirect uri
+        #  - must match the application redirect if both are given
+        #  - can be used without extra validation if the app does not specify a redirect uri
+        # The test uri is also always valid.
         return false unless redirect_uri.present?
-        Helpers::URIChecker.test_uri?(redirect_uri) ||
+
+        is_test || optional_redirect_uri_valid || redirect_uris_match
+      end
+
+      private 
+
+      def is_test
+        Helpers::URIChecker.test_uri?(redirect_uri)
+      end
+
+      def optional_redirect_uri_valid
+        !Doorkeeper.configuration.require_redirect_uri && client.redirect_uri.nil? && Helpers::URIChecker.valid?(redirect_uri)
+      end
+
+      def redirect_uris_match
         Helpers::URIChecker.valid_for_authorization?(redirect_uri, client.redirect_uri)
       end
     end

--- a/lib/doorkeeper/version.rb
+++ b/lib/doorkeeper/version.rb
@@ -1,3 +1,3 @@
 module Doorkeeper
-  VERSION = "0.6.7"
+  VERSION = "0.6.8"
 end

--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -4,7 +4,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       t.string  :name,         :null => false
       t.string  :uid,          :null => false
       t.string  :secret,       :null => false
-      t.string  :redirect_uri, :null => false
+      t.string  :redirect_uri, :null => true
       t.timestamps
     end
 

--- a/spec/dummy/db/migrate/20130311133351_make_redirect_uri_optional.rb
+++ b/spec/dummy/db/migrate/20130311133351_make_redirect_uri_optional.rb
@@ -1,0 +1,9 @@
+class MakeRedirectUriOptional < ActiveRecord::Migration
+  def up
+    change_column_null :oauth_applications, :redirect_uri, true
+  end
+
+  def down
+    change_column_null :oauth_applications, :redirect_uri, false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(:version => 20120524202412) do
     t.string   "name",         :null => false
     t.string   "uid",          :null => false
     t.string   "secret",       :null => false
-    t.string   "redirect_uri", :null => false
+    t.string   "redirect_uri", :null => true
     t.string   "owner_type",   :null => true, :default => "User"
     t.integer  "owner_id",     :null => true
     t.datetime "created_at",   :null => false

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -60,9 +60,27 @@ module Doorkeeper
       new_application.should_not be_valid
     end
 
-    it 'is invalid without redirect_uri' do
+    it 'is invalid with no redirect_uri when config forbids it' do
+      Doorkeeper.configure do
+          require_redirect_uri true
+      end
       new_application.save
       new_application.redirect_uri = nil
+      new_application.should_not be_valid
+    end
+
+    it 'is valid with no redirect_uri when config allows it' do
+      Doorkeeper.configure do
+          require_redirect_uri false
+      end
+      new_application.save
+      new_application.redirect_uri = nil
+      new_application.should be_valid
+    end
+
+    it 'is invalid with invalid redirect_uri' do
+      new_application.save
+      new_application.redirect_uri = "invalid_uri"
       new_application.should_not be_valid
     end
 

--- a/spec/requests/flows/implicit_grant_errors_spec.rb
+++ b/spec/requests/flows/implicit_grant_errors_spec.rb
@@ -14,7 +14,6 @@ feature 'Implicit Grant Flow Errors' do
 
   [
     [:client_id,     :invalid_client],
-    [:redirect_uri,  :invalid_redirect_uri],
   ].each do |error|
     scenario "displays #{error.last.inspect} error for invalid #{error.first.inspect}" do
       visit authorization_endpoint_url(:client => @client, error.first => "invalid", :response_type => "token")
@@ -27,5 +26,19 @@ feature 'Implicit Grant Flow Errors' do
       i_should_not_see "Authorize"
       i_should_see_translated_error_message error.last
     end
+  end
+
+  scenario "displays :invalid_redirect_uri error when :redirect_uri does not match application" do
+    visit authorization_endpoint_url(:client => @client, :redirect_uri => "invalid",  :response_type => "token")
+    i_should_not_see "Authorize"
+    i_should_see_translated_error_message :invalid_redirect_uri
+  end
+
+  scenario "displays :invalid_redirect_uri error when :redirect_uri is missing from client and request" do
+    @client.redirect_uri = nil
+    @client.save
+    visit authorization_endpoint_url(:client => @client, :redirect_uri => "invalid",  :response_type => "token")
+    i_should_not_see "Authorize"
+    i_should_see_translated_error_message :invalid_redirect_uri
   end
 end


### PR DESCRIPTION
Feel free to reject this PR if you think that it causes too many security problems, but we had need for the behaviour of having the redirect URI being optional, as in issue https://github.com/applicake/doorkeeper/issues/68

I've made it configurable, defaulting to off. If you switch it on, you may:
- Specify a redirect uri in the application AND the client, in which case they must match exactly
- Specify no redirect uri in the application, in which case it will redirect to wherever the client provides
- Specify no redirect uri in the client, in which case it will redirect to the value stored for the application

Best,
Hugh
