### PR TITLE
Add created_at to token response

### DIFF
--- a/lib/doorkeeper/oauth/token_response.rb
+++ b/lib/doorkeeper/oauth/token_response.rb
@@ -12,6 +12,7 @@ module Doorkeeper
           'access_token'  => token.token,
           'token_type'    => token.token_type,
           'expires_in'    => token.expires_in,
+          'created_at'    => token.created_at,
           'refresh_token' => token.refresh_token,
           'scope'         => token.scopes_string
         }

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -20,6 +20,7 @@ module Doorkeeper::OAuth
         mock :access_token, {
           :token => 'some-token',
           :expires_in => '3600',
+          :created_at => '2013-04-05T20:31:12Z',
           :scopes_string => 'two scopes',
           :refresh_token => 'some-refresh-token',
           :token_type => 'bearer'
@@ -38,6 +39,10 @@ module Doorkeeper::OAuth
 
       it 'includes :expires_in' do
         subject['expires_in'].should == '3600'
+      end
+
+      it 'includes :created_at' do
+        subject['created_at'].should == '2013-04-05T20:31:12Z'
       end
 
       it 'includes :scope' do


### PR DESCRIPTION
Please excuse my naïvety.  I'm relatively new to OAuth, so I may be missing something here...

However, it seems to me that the token response should contain the time the token was created, so the true token expiration time can be determined (created_at + expires_in).  It appears that the value of expires_in that is returned is a static value, and does not change with the age of the token, so using that alone isn't enough to determine when a token actually expires.
