### PR TITLE
Remove the warning about has_many expression in Rails 4

### DIFF
--- a/lib/doorkeeper/models/active_record/application.rb
+++ b/lib/doorkeeper/models/active_record/application.rb
@@ -2,7 +2,11 @@ module Doorkeeper
   class Application < ActiveRecord::Base
     self.table_name = :oauth_applications
 
-    has_many :authorized_tokens, :class_name => "AccessToken", :conditions => { :revoked_at => nil }
+    if ::Rails.version < "4"
+      has_many :authorized_tokens, :class_name => "AccessToken", :conditions => { :revoked_at => nil }
+    else
+      has_many :authorized_tokens, lambda { where(:revoked_at => nil) }, :class_name => "AccessToken"
+    end
     has_many :authorized_applications, :through => :authorized_tokens, :source => :application
 
     def self.column_names_with_table


### PR DESCRIPTION
This commit removes warning of has_many with :condition option.
:conditions option is deprecated in `has_many' in Rails 4.0
