### PR TITLE
Do not try to load unavailable Request class for the current phase.

### DIFF
--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -9,24 +9,21 @@ module Doorkeeper
   module Request
     extend self
 
-    # Available authorization strategies:
-    # :code, :token
     def authorization_strategy(strategy)
-      get_strategy strategy
+      get_strategy strategy, %w[code token]
     rescue NameError
       raise Errors::InvalidAuthorizationStrategy
     end
 
-    # Available token strategies:
-    # :password, :client_credentials, :authorization_code, :refresh_token
     def token_strategy(strategy)
-      get_strategy strategy
+      get_strategy strategy, %w[password client_credentials authorization_code refresh_token]
     rescue NameError
       raise Errors::InvalidTokenStrategy
     end
 
-    def get_strategy(strategy)
+    def get_strategy(strategy, available)
       raise Errors::MissingRequestStrategy unless strategy.present?
+      raise NameError unless available.include?(strategy.to_s)
       "Doorkeeper::Request::#{strategy.to_s.camelize}".constantize
     end
   end

--- a/spec/lib/server_spec.rb
+++ b/spec/lib/server_spec.rb
@@ -15,6 +15,10 @@ describe Doorkeeper::Server do
       expect { subject.authorization_request(:duh) }.to raise_error(Doorkeeper::Errors::InvalidAuthorizationStrategy)
     end
 
+    it 'raises error when strategy does not match phase' do
+      expect { subject.token_request(:code) }.to raise_error(Doorkeeper::Errors::InvalidTokenStrategy)
+    end
+
     it 'builds the request with selected strategy' do
       stub_const 'Doorkeeper::Request::Code', fake_class
       fake_class.should_receive(:build).with(subject)


### PR DESCRIPTION
If you send grant_type=code for token request for example, you'll see runtime
exceptions such as:

```
undefined method `pre_auth'; for #<Doorkeeper::TokensController:0x007fe04b7aa778>
```

Since grant_type comes as a request parameter, it's better to explicitly
limit the available request implementations rather than trying to load the
class and rescue constant lookup failures.
