### PR TITLE
support the spec of 'invalid_token' response

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,10 @@ en:
 
         # Password Access token errors
         invalid_resource_owner: 'The provided resource owner credentials are not valid, or resource owner cannot be found'
+        invalid_token:
+          revoked: 'The access_token is revoked'
+          expired: 'The access_token is expired'
+          unknown: 'The access_token is invalid'
     flash:
       applications:
         create:

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -26,6 +26,7 @@ module Doorkeeper
     autoload :TokenRequest,               "doorkeeper/oauth/token_request"
     autoload :Client,                     "doorkeeper/oauth/client"
     autoload :Token,                      "doorkeeper/oauth/token"
+    autoload :InvalidTokenResponse,       "doorkeeper/oauth/invalid_token_response"
 
     module Helpers
       autoload :ScopeChecker, "doorkeeper/oauth/helpers/scope_checker"

--- a/lib/doorkeeper/oauth/invalid_token_response.rb
+++ b/lib/doorkeeper/oauth/invalid_token_response.rb
@@ -1,0 +1,35 @@
+module Doorkeeper
+  module OAuth
+    class InvalidTokenResponse < ErrorResponse
+      def self.from_access_token(access_token, attributes = {})
+        reason = case
+          when access_token.nil?
+            :unknown
+          when access_token.respond_to?(:revoked?) && access_token.revoked?
+            :revoked
+          when access_token.respond_to?(:expired?) && access_token.expired?
+            :expired
+          end
+
+        new(attributes.merge(:reason => reason))
+      end
+
+      def initialize(attributes = {})
+        super(attributes.merge(:name => :invalid_token, :state => :unauthorized))
+        @reason = attributes[:reason] || :unknown
+      end
+
+      def description
+        @description ||= I18n.translate @reason, :scope => [:doorkeeper, :errors, :messages, :invalid_token]
+      end
+
+      def authenticate_info
+        %{Bearer error="#{body[:error]}", error_description="#{body[:error_description]}"}
+      end
+
+      def headers
+        super.merge('WWW-Authenticate' => authenticate_info)
+      end
+    end
+  end
+end

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -29,6 +29,7 @@ shared_examples "specified for particular actions" do
     it "does not allow into index action" do
       get :index, :access_token => token_string
       expect(response.status).to eq 401
+      expect(response.headers["WWW-Authenticate"]).to match /Bearer/
     end
 
     it "allows into show action" do
@@ -60,6 +61,7 @@ shared_examples "specified with except" do
     it "does not allow into show action" do
       get :show, :id => "14", :access_token => token_string
       expect(response.status).to eq 401
+      expect(response.headers["WWW-Authenticate"]).to match /Bearer/
     end
   end
 end
@@ -102,6 +104,7 @@ describe "Doorkeeper_for helper" do
       Doorkeeper::AccessToken.should_receive(:authenticate).exactly(2).times
       request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
       get :index
+      controller.send(:remove_instance_variable, :@token)
       get :index
     end
   end
@@ -129,11 +132,13 @@ describe "Doorkeeper_for helper" do
       it "does not allow into index action" do
         get :index, :access_token => token_string
         expect(response.status).to eq 401
+        expect(response.headers["WWW-Authenticate"]).to match /Bearer/
       end
 
       it "does not allow into show action" do
         get :show, :id => "4", :access_token => token_string
         expect(response.status).to eq 401
+        expect(response.headers["WWW-Authenticate"]).to match /Bearer/
       end
     end
   end
@@ -178,6 +183,7 @@ describe "Doorkeeper_for helper" do
       Doorkeeper::AccessToken.should_receive(:authenticate).with(token_string).and_return(token)
       get :index, :access_token => token_string
       expect(response.status).to eq 401
+      expect(response.headers["WWW-Authenticate"]).to match /Bearer/
     end
   end
 
@@ -200,6 +206,7 @@ describe "Doorkeeper_for helper" do
         parsed_body = JSON.parse(response.body)
         expect(parsed_body).not_to be_nil
         expect(parsed_body['error']).to eq('Unauthorized')
+        expect(response.headers["WWW-Authenticate"]).to match /Bearer/
       end
 
     end
@@ -256,6 +263,7 @@ describe "Doorkeeper_for helper" do
       it "does not enable access if passed block evaluates to true" do
         get :show, :id => 3, :access_token => token_string
         expect(response.status).to eq 401
+        expect(response.headers["WWW-Authenticate"]).to match /Bearer/
       end
     end
   end

--- a/spec/lib/oauth/invalid_token_response_spec.rb
+++ b/spec/lib/oauth/invalid_token_response_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'active_model'
+require 'doorkeeper'
+require 'doorkeeper/oauth/invalid_token_response'
+
+module Doorkeeper::OAuth
+  describe InvalidTokenResponse do
+    its(:name)  { should == :invalid_token }
+    its(:status) { should == :unauthorized }
+
+    describe :from_access_token do
+      it 'revoked' do
+        response = InvalidTokenResponse.from_access_token stub(:revoked? => true, :expired? => true)
+        expect(response.description).to match /revoked/
+      end
+
+      it 'expired' do
+        response = InvalidTokenResponse.from_access_token stub(:revoked? => false, :expired? => true)
+        expect(response.description).to match /expired/
+      end
+    end
+
+    describe '.authenticate_info' do
+      subject { InvalidTokenResponse.from_access_token stub(:revoked? => true) }
+      its(:authenticate_info) { should == 'Bearer error="invalid_token", error_description="The access_token is revoked"' }
+    end
+    describe '.headers' do
+      subject { InvalidTokenResponse.from_access_token stub(:revoked? => true) }
+      its(:headers) { should have_key 'WWW-Authenticate' }
+    end
+  end
+end


### PR DESCRIPTION
WWW-Authenticate header is required when authenticate error.
see it: http://tools.ietf.org/html/rfc6750\#section-3
