### PR TITLE
Fixed Rails 4 deprecation warning re: :conditions option in has_many

### DIFF
--- a/lib/doorkeeper/models/active_record/application.rb
+++ b/lib/doorkeeper/models/active_record/application.rb
@@ -2,7 +2,7 @@ module Doorkeeper
   class Application < ActiveRecord::Base
     self.table_name = :oauth_applications
 
-    if Rails.version.to_f >= 4
+    if ActiveRecord::VERSION::MAJOR >= 4
       has_many :authorized_tokens, -> { where(revoked_at: nil) }, :class_name => "AccessToken"
     else
       has_many :authorized_tokens, :class_name => "AccessToken", :conditions => { :revoked_at => nil }      


### PR DESCRIPTION
DEPRECATION WARNING: The following options in your Doorkeeper::Application.has_many :authorized_tokens declaration are deprecated: :conditions. Please use a scope block instead. For example, the following:

```
has_many :spam_comments, conditions: { spam: true }, class_name: 'Comment'
```

should be rewritten as the following:

```
has_many :spam_comments, -> { where spam: true }, class_name: 'Comment'
```
