### PR TITLE
Add a configuration for ActiveRecord.establish_connection

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -153,7 +153,7 @@ module Doorkeeper
     option :authorization_code_expires_in,:default => 600
     option :orm, :default => :active_record
     option :test_redirect_uri, :default => 'urn:ietf:wg:oauth:2.0:oob'
-
+    option :active_record_options, :default => {}
 
     def refresh_token_enabled?
       !!@refresh_token_enabled

--- a/lib/doorkeeper/models/active_record/access_grant.rb
+++ b/lib/doorkeeper/models/active_record/access_grant.rb
@@ -1,5 +1,9 @@
 module Doorkeeper
   class AccessGrant < ActiveRecord::Base
+    if Doorkeeper.configuration.active_record_options[:establish_connection]
+      establish_connection Doorkeeper.configuration.active_record_options[:establish_connection]
+    end
+
     self.table_name = :oauth_access_grants
   end
 end

--- a/lib/doorkeeper/models/active_record/access_token.rb
+++ b/lib/doorkeeper/models/active_record/access_token.rb
@@ -1,5 +1,9 @@
 module Doorkeeper
   class AccessToken < ActiveRecord::Base
+    if Doorkeeper.configuration.active_record_options[:establish_connection]
+      establish_connection Doorkeeper.configuration.active_record_options[:establish_connection]
+    end
+
     self.table_name = :oauth_access_tokens
 
     def self.delete_all_for(application_id, resource_owner)

--- a/lib/doorkeeper/models/active_record/application.rb
+++ b/lib/doorkeeper/models/active_record/application.rb
@@ -1,5 +1,9 @@
 module Doorkeeper
   class Application < ActiveRecord::Base
+    if Doorkeeper.configuration.active_record_options[:establish_connection]
+      establish_connection Doorkeeper.configuration.active_record_options[:establish_connection]
+    end
+
     self.table_name = :oauth_applications
 
     if ActiveRecord::VERSION::MAJOR >= 4


### PR DESCRIPTION
In order to share doorkeeper models among the authorization server and
resource servers, you can now set a value for establish_connection in
doorkeeper.rb as follows:

``` ruby
active_record_options establish_connection: :another_database
```
