### PR TITLE
Relax jquery-rails gem dependency

### DIFF
--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "railties", ">= 3.1"
-  s.add_dependency "jquery-rails", "~> 3.0.4"
+  s.add_dependency "jquery-rails", ">= 2.0.2"
 
   s.add_development_dependency "sqlite3", "~> 1.3.5"
   s.add_development_dependency "rspec-rails", ">= 2.11.4"


### PR DESCRIPTION
Looks like the gem dependency has been added in #262, but i don't see jquery used anywhere in doorkeeper UI.

Either way, as a Rails engine, doorkeeper gem should not force jquery_rails version upon main application.
