### PR TITLE
Use attr_accessible if ProtectedAttributes gem is present

### DIFF
--- a/lib/doorkeeper/models/access_grant.rb
+++ b/lib/doorkeeper/models/access_grant.rb
@@ -8,7 +8,7 @@ module Doorkeeper
 
     belongs_to :application, :class_name => "Doorkeeper::Application", :inverse_of => :access_grants
 
-    if ::Rails.version.to_i < 4
+    if ::Rails.version.to_i < 4 || defined?(ProtectedAttributes)
       attr_accessible :resource_owner_id, :application_id, :expires_in, :redirect_uri, :scopes
     end
 

--- a/lib/doorkeeper/models/access_token.rb
+++ b/lib/doorkeeper/models/access_token.rb
@@ -13,7 +13,7 @@ module Doorkeeper
     validates :refresh_token, :uniqueness => true, :if => :use_refresh_token?
 
     attr_accessor :use_refresh_token
-    if ::Rails.version.to_i < 4
+    if ::Rails.version.to_i < 4 || defined?(ProtectedAttributes)
       attr_accessible :application_id, :resource_owner_id, :expires_in, :scopes, :use_refresh_token
     end
 

--- a/lib/doorkeeper/models/application.rb
+++ b/lib/doorkeeper/models/application.rb
@@ -11,7 +11,7 @@ module Doorkeeper
 
     before_validation :generate_uid, :generate_secret, :on => :create
 
-    if ::Rails.version.to_i < 4
+    if ::Rails.version.to_i < 4 || defined?(ProtectedAttributes)
       attr_accessible :name, :redirect_uri
     end
 


### PR DESCRIPTION
This fixes the  Rails 4 compatibility work for those who have "protected_attributes" gem installed.

We ran into this issue because a gem had a dependency on the `protected_attributes` gem for Rails 4 compatibility and it was listed in our Gemfile. It was causing odd issues described in issue #287.

This corrects the problem so now any user who happens to have the `protected_attributes` gem anywhere in their dependency graph can still use doorkeeper side-by-side without issues.
