### PR TITLE
Update CHANGELOG to reflect what is currently "unreleased"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.7.3 (Unreleased)
+
+- enhancements
+  - [#204] Allow to overwrite scope in routes
+- bug
+  - [#290] Support for Rails 4 when 'protected_attributes' gem is present.
+
+
 ## 0.7.2
 
 - enhancements


### PR DESCRIPTION
Took a quick second to add the "unreleased" 0.7.3 release notes as they stand today. I did not factor in any of the non PR-based commits though.
