### PR TITLE
Changed generation behavior on Application creation

### DIFF
--- a/lib/doorkeeper/models/application.rb
+++ b/lib/doorkeeper/models/application.rb
@@ -30,11 +30,11 @@ module Doorkeeper
     private
 
     def generate_uid
-      self.uid = UniqueToken.generate
+      self.uid ||= UniqueToken.generate
     end
 
     def generate_secret
-      self.secret = UniqueToken.generate
+      self.secret ||= UniqueToken.generate
     end
   end
 end

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -37,6 +37,15 @@ module Doorkeeper
         expect(response).to be_redirect
       end
 
+      it "does not allow mass assignment of uid or secret" do
+        application = FactoryGirl.create(:application)
+        put :update, id: application.id, application: {
+          uid: '1A2B3C4D',
+          secret: '1A2B3C4D' }
+
+        application.reload.uid.should_not eq '1A2B3C4D'
+      end
+
       it "updates application" do
         application = FactoryGirl.create(:application)
         put :update, id: application.id, application: {

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -8,6 +8,9 @@ module Doorkeeper
     let(:unset_require_owner) { Doorkeeper.configuration.instance_variable_set("@confirm_application_owner", false) }
     let(:new_application) { FactoryGirl.build(:application) }
 
+    let(:uid) { SecureRandom.hex(8) }
+    let(:secret) { SecureRandom.hex(8) }
+
     context "application_owner is enabled" do
       before do
         Doorkeeper.configure do
@@ -54,6 +57,12 @@ module Doorkeeper
       new_application.uid.should_not be_nil
     end
 
+    it 'generates uid on create unless one is set' do
+      new_application.uid = uid
+      new_application.save
+      new_application.uid.should eq(uid)
+    end
+
     it 'is invalid without uid' do
       new_application.save
       new_application.uid = nil
@@ -86,6 +95,12 @@ module Doorkeeper
       new_application.secret.should be_nil
       new_application.save
       new_application.secret.should_not be_nil
+    end
+
+    it 'generate secret on create unless one is set' do
+      new_application.secret = secret
+      new_application.save
+      new_application.secret.should eq(secret)
     end
 
     it 'is invalid without secret' do
@@ -142,7 +157,7 @@ module Doorkeeper
         Application.authorized_for(resource_owner).should == [application]
       end
 
-      it "should fail to mass assign a new application" do
+      it "should fail to mass assign a new application", if: ::Rails::VERSION::MAJOR < 4 do
         mass_assign = { :name => 'Something',
                         :redirect_uri => 'http://somewhere.com/something',
                         :uid => 123,


### PR DESCRIPTION
The callbacks that generate client uid and secret for the Application model will now check if one is already provided. If so, it will not generate a new uid or secret.

The motivation for this was to make creating seed data easier. Now, I would have to either skip the callbacks before validation or create the Application and then update the uid/secret with the desired values.
