### PR TITLE
Made client optional for password grant type

### DIFF
--- a/lib/doorkeeper/models/access_token.rb
+++ b/lib/doorkeeper/models/access_token.rb
@@ -8,7 +8,7 @@ module Doorkeeper
 
     belongs_to :application, :class_name => "Doorkeeper::Application", :inverse_of => :access_tokens
 
-    validates :application_id, :token, :presence => true
+    validates :token, :presence => true
     validates :token, :uniqueness => true
     validates :refresh_token, :uniqueness => true, :if => :use_refresh_token?
 

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -3,7 +3,6 @@ module Doorkeeper::OAuth
     include Doorkeeper::Validations
     include Doorkeeper::OAuth::Helpers
 
-    validate :client,         :error => :invalid_client
     validate :resource_owner, :error => :invalid_resource_owner
     validate :scopes,         :error => :invalid_scope
 
@@ -41,17 +40,15 @@ module Doorkeeper::OAuth
   private
 
     def issue_token
+      application_id = client.id if client
+
       @access_token = Doorkeeper::AccessToken.create!({
-        :application_id     => client.id,
+        :application_id     => application_id,
         :resource_owner_id  => resource_owner.id,
         :scopes             => scopes.to_s,
         :expires_in         => server.access_token_expires_in,
         :use_refresh_token  => server.refresh_token_enabled?
       })
-    end
-
-    def validate_client
-      !!client
     end
 
     def validate_scopes

--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -25,7 +25,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
 
     create_table :oauth_access_tokens do |t|
       t.integer  :resource_owner_id
-      t.integer  :application_id,    :null => false
+      t.integer  :application_id
       t.string   :token,             :null => false
       t.string   :refresh_token
       t.integer  :expires_in

--- a/spec/dummy/db/migrate/20130902165751_create_doorkeeper_tables.rb
+++ b/spec/dummy/db/migrate/20130902165751_create_doorkeeper_tables.rb
@@ -25,7 +25,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
 
     create_table :oauth_access_tokens do |t|
       t.integer  :resource_owner_id
-      t.integer  :application_id,    :null => false
+      t.integer  :application_id
       t.string   :token,             :null => false
       t.string   :refresh_token
       t.integer  :expires_in

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(:version => 20130902175349) do
 
   create_table "oauth_access_tokens", :force => true do |t|
     t.integer  "resource_owner_id"
-    t.integer  "application_id",    :null => false
+    t.integer  "application_id"
     t.string   "token",             :null => false
     t.string   "refresh_token"
     t.integer  "expires_in"

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -16,16 +16,22 @@ module Doorkeeper::OAuth
       end.to change { client.access_tokens.count }.by(1)
     end
 
+    it 'issues a new token without a client' do
+      expect do
+        subject.client = nil
+        subject.authorize
+      end.to change { Doorkeeper::AccessToken.count }.by(1)
+    end
+
     it "requires the owner" do
       subject.resource_owner = nil
       subject.validate
       subject.error.should == :invalid_resource_owner
     end
 
-    it 'requires the client' do
+    it 'optionally accepts the client' do
       subject.client = nil
-      subject.validate
-      subject.error.should == :invalid_client
+      subject.should be_valid
     end
 
     describe "with scopes" do

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -46,11 +46,6 @@ module Doorkeeper
         subject.resource_owner_id = nil
         should be_valid
       end
-
-      it "is invalid without application_id" do
-        subject.application_id = nil
-        should_not be_valid
-      end
     end
 
     describe '.revoke_all_for' do


### PR DESCRIPTION
This pull request is an attempt to bring Doorkeeper more in line with the OAuth 2.0 spec, specifically [section 4.3](http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-4.3). It should address issue #288.

The `client_id` and `client_secret` parameters are no longer required when creating an access token using the Resource Owner Password Credentials flow.

```
   grant_type
         REQUIRED.  Value MUST be set to "password".
   username
         REQUIRED.  The resource owner username, encoded as UTF-8.
   password
         REQUIRED.  The resource owner password, encoded as UTF-8.
   scope
         OPTIONAL.  The scope of the access request as described by Section 3.3.
```

Consequently, the relationship between the access token and application models was changed, by removing the hard dependency between the two.
