### PR TITLE
Fix broken jquery-rails requirement.

### DIFF
--- a/lib/doorkeeper/engine.rb
+++ b/lib/doorkeeper/engine.rb
@@ -1,3 +1,5 @@
+require 'jquery-rails'
+
 module Doorkeeper
   class Engine < Rails::Engine
     initializer "doorkeeper.routes" do


### PR DESCRIPTION
The application that I'm working on doesn't have a dependency on jquery-rails and as a result it is not included in my Gemfile or asset paths:

``` ruby
supporter(main)$ bin/rails c
irb(main):001:0> Rails.configuration.assets.paths.select { |path| path.to_s =~ /jquery/ }
=> []
```

When I try and precompile my assets `rake` complains that it cannot find jquery or jquery_ujs. At the moment doorkeeper includes jquery-rails in the gemspec which makes those assets available in the context of doorkeeper but not in apps consuming doorkeeper.

``` ruby
doorkeeper(fix_jquery_rails)$ bundle exec rails c
irb(main):001:0> Rails.configuration.assets.paths.select { |path| path.to_s =~ /jquery/ }
=> ["/Users/troll/Code/doorkeeper/vendor/gems/ruby/2.0.0/gems/jquery-rails-3.0.4/vendor/assets/javascripts"]
```

The fix is as simple as requiring jquery-rails in the engine (which I've implemented). An alternate solution is to remove the dependency on jquery-rails as there is no jquery being used...
