### PR TITLE
Remove application.js from layout

### DIFF
--- a/app/views/layouts/doorkeeper/application.html.erb
+++ b/app/views/layouts/doorkeeper/application.html.erb
@@ -3,7 +3,6 @@
 <head>
   <title>Doorkeeper</title>
   <%= stylesheet_link_tag    "doorkeeper/application" %>
-  <%= javascript_include_tag "doorkeeper/application" %>
   <%= csrf_meta_tags %>
 </head>
 <body>


### PR DESCRIPTION
This causes errors in production mode as application.js does not exist.
