### PR TITLE
Fixed issue with invalid client credentials in password grant

### DIFF
--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -3,16 +3,20 @@ module Doorkeeper::OAuth
     include Doorkeeper::Validations
     include Doorkeeper::OAuth::Helpers
 
+    validate :client,         :error => :invalid_client
     validate :resource_owner, :error => :invalid_resource_owner
     validate :scopes,         :error => :invalid_scope
 
-    attr_accessor :server, :resource_owner, :client, :access_token
+    attr_accessor :server, :resource_owner, :credentials, :access_token
+    attr_accessor :client
 
-    def initialize(server, client, resource_owner, parameters = {})
+    def initialize(server, credentials, resource_owner, parameters = {})
       @server          = server
       @resource_owner  = resource_owner
-      @client          = client
+      @credentials     = credentials
       @original_scopes = parameters[:scope]
+
+      @client = Doorkeeper::Application.authenticate(credentials.uid, credentials.secret) if credentials
     end
 
     def authorize
@@ -58,6 +62,10 @@ module Doorkeeper::OAuth
 
     def validate_resource_owner
       !!resource_owner
+    end
+
+    def validate_client
+      !credentials || !!client
     end
   end
 end

--- a/lib/doorkeeper/request/password.rb
+++ b/lib/doorkeeper/request/password.rb
@@ -2,17 +2,17 @@ module Doorkeeper
   module Request
     class Password
       def self.build(server)
-        new(server.client, server.resource_owner, server)
+        new(server.credentials, server.resource_owner, server)
       end
 
-      attr_accessor :client, :resource_owner, :server
+      attr_accessor :credentials, :resource_owner, :server
 
-      def initialize(client, resource_owner, server)
-        @client, @resource_owner, @server = client, resource_owner, server
+      def initialize(credentials, resource_owner, server)
+        @credentials, @resource_owner, @server = credentials, resource_owner, server
       end
 
       def request
-        @request ||= OAuth::PasswordAccessTokenRequest.new(Doorkeeper.configuration, client, resource_owner, server.parameters)
+        @request ||= OAuth::PasswordAccessTokenRequest.new(Doorkeeper.configuration, credentials, resource_owner, server.parameters)
       end
 
       def authorize

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -3,34 +3,44 @@ require 'spec_helper_integration'
 module Doorkeeper::OAuth
   describe PasswordAccessTokenRequest do
     let(:server) { double :server, :default_scopes => Doorkeeper::OAuth::Scopes.new, :access_token_expires_in => 2.hours, :refresh_token_enabled? => false }
+    let(:credentials) { Client::Credentials.new(client.uid, client.secret) }
     let(:client) { FactoryGirl.create(:application) }
     let(:owner)  { double :owner, :id => 99 }
 
     subject do
-      PasswordAccessTokenRequest.new(server, client, owner)
+      PasswordAccessTokenRequest.new(server, credentials, owner)
     end
 
     it 'issues a new token for the client' do
-      expect do
+      expect {
         subject.authorize
-      end.to change { client.access_tokens.count }.by(1)
+      }.to change { client.access_tokens.count }.by(1)
     end
 
     it 'issues a new token without a client' do
-      expect do
-        subject.client = nil
+      expect {
+        subject.credentials = nil
         subject.authorize
-      end.to change { Doorkeeper::AccessToken.count }.by(1)
+      }.to change { Doorkeeper::AccessToken.count }.by(1)
     end
 
-    it "requires the owner" do
+    it 'does not issue a new token with an invalid client' do
+      expect {
+        subject.client = nil
+        subject.authorize
+      }.to_not change { Doorkeeper::AccessToken.count }
+
+      subject.error.should == :invalid_client
+    end
+
+    it 'requires the owner' do
       subject.resource_owner = nil
       subject.validate
       subject.error.should == :invalid_resource_owner
     end
 
     it 'optionally accepts the client' do
-      subject.client = nil
+      subject.credentials = nil
       subject.should be_valid
     end
 

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -39,6 +39,16 @@ feature 'Resource Owner Password Credentials Flow' do
       should_have_json 'access_token',  token.token
     end
 
+    scenario "should issue new token without client credentials" do
+      expect {
+        post password_token_endpoint_url(:resource_owner => @resource_owner)
+      }.to change { Doorkeeper::AccessToken.count }.by(1)
+
+      token = Doorkeeper::AccessToken.first
+
+      should_have_json 'access_token',  token.token
+    end
+
     scenario "should issue a refresh token if enabled" do
       config_is_set(:refresh_token_enabled, true)
 
@@ -62,6 +72,16 @@ feature 'Resource Owner Password Credentials Flow' do
     scenario "should not issue new token without credentials" do
       expect {
         post password_token_endpoint_url( :client => @client)
+      }.to_not change { Doorkeeper::AccessToken.count }
+    end
+  end
+
+  context "with invalid client credentials" do
+    scenario "should not issue new token with bad client credentials" do
+      expect {
+        post password_token_endpoint_url( :client_id => @client.uid,
+                                          :client_secret => "bad_secret",
+                                          :resource_owner => @resource_owner)
       }.to_not change { Doorkeeper::AccessToken.count }
     end
   end


### PR DESCRIPTION
If client credentials are provided during the Resource Owner Password Grant flow, they will be validated. If invalid credentials are provided, the invalid client error will be presented. If no client credentials are provided, the flow will continue as usual.

This is a continuation of PR #296, based off of the concerns brought up by @sparksp
