### PR TITLE
Upgrading doorkeeper to Mongoid 4 and Moped 2.

### DIFF
--- a/lib/doorkeeper/models/mongoid3/access_grant.rb
+++ b/lib/doorkeeper/models/mongoid3/access_grant.rb
@@ -10,7 +10,7 @@ module Doorkeeper
 
     self.store_in collection: :oauth_access_grants
 
-    field :resource_owner_id, :type => Moped::BSON::ObjectId
+    field :resource_owner_id, :type => BSON::ObjectId
     field :application_id, :type => Hash
     field :token, :type => String
     field :expires_in, :type => Integer

--- a/lib/doorkeeper/models/mongoid3/access_token.rb
+++ b/lib/doorkeeper/models/mongoid3/access_token.rb
@@ -10,7 +10,7 @@ module Doorkeeper
 
     self.store_in collection: :oauth_access_tokens
 
-    field :resource_owner_id, :type => Moped::BSON::ObjectId
+    field :resource_owner_id, :type => BSON::ObjectId
     field :token, :type => String
     field :expires_in, :type => Integer
     field :revoked_at, :type => DateTime


### PR DESCRIPTION
Moped::BSON::ObjectId is removed.
