### PR TITLE
can work with rails4+mongoid3

### DIFF
--- a/lib/doorkeeper/models/mongoid3/access_grant.rb
+++ b/lib/doorkeeper/models/mongoid3/access_grant.rb
@@ -10,7 +10,7 @@ module Doorkeeper
 
     self.store_in collection: :oauth_access_grants
 
-    field :resource_owner_id, :type => Moped::BSON::ObjectId
+    field :resource_owner_id, :type => BSON::ObjectId
     field :application_id, :type => Hash
     field :token, :type => String
     field :expires_in, :type => Integer

--- a/lib/doorkeeper/models/mongoid3/access_token.rb
+++ b/lib/doorkeeper/models/mongoid3/access_token.rb
@@ -10,7 +10,7 @@ module Doorkeeper
 
     self.store_in collection: :oauth_access_tokens
 
-    field :resource_owner_id, :type => Moped::BSON::ObjectId
+    field :resource_owner_id, :type => BSON::ObjectId
     field :token, :type => String
     field :expires_in, :type => Integer
     field :revoked_at, :type => DateTime


### PR DESCRIPTION
otherwise will get exception:
lib/doorkeeper/models/mongoid3/access_grant.rb:13:in `<class:AccessGrant>': uninitialized constant Moped::BSON (NameError)
    from /Users/axu/.rvm/gems/ruby-2.1.0/bundler/gems/doorkeeper-16abb492d57a/lib/doorkeeper/models/mongoid3/access_grant.rb:5:in`module:Doorkeeper'
    from /Users/axu/.rvm/gems/ruby-2.1.0/bundler/gems/doorkeeper-16abb492d57a/lib/doorkeeper/models/mongoid3/access_grant.rb:4:in `<top (required)>'
    from /Users/axu/.rvm/gems/ruby-2.1.0/bundler/gems/doorkeeper-16abb492d57a/lib/doorkeeper/config.rb:19:in`enable_orm'
    from /Users/axu/.rvm/gems/ruby-2.1.0/bundler/gems/doorkeeper-16abb492d57a/lib/doorkeeper/config.rb:10:in `configure'
    from /Users/axu/prj/howtodo/code/htd.login/config/initializers/doorkeeper.rb:1:in`<top (required)>'
    from /Users/axu/.rvm/gems/ruby-2.1.0/gems/railties-4.0.2/lib/rails/engine.rb:609:in `block (2 levels) in <class:Engine>'
    from /Users/axu/.rvm/gems/ruby-2.1.0/gems/railties-4.0.2/lib/rails/engine.rb:608:in`each'
    from /Users/axu/.rvm/gems/ruby-2.1.0/gems/railties-4.0.2/lib/rails/engine.rb:608:in `block in <class:Engine>'
    from /Users/axu/.rvm/gems/ruby-2.1.0/gems/railties-4.0.2/lib/rails/initializable.rb:30:in`instance_exec'
    from /Users/axu/.rvm/gems/ruby-2.1.0/gems/railties-4.0.2/lib/rails/initializable.rb:30:in `run'
    from /Users/axu/.rvm/gems/ruby-2.1.0/gems/railties-4.0.2/lib/rails/initializable.rb:55:in`block in run_initializers'
    from /Users/axu/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/tsort.rb:226:in `block in tsort_each'
    from /Users/axu/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/tsort.rb:348:in`block (2 levels) in each_strongly_connected_component'
    from /Users/axu/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/tsort.rb:418:in `block (2 levels) in each_strongly_connected_component_from'
    from /Users/axu/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/tsort.rb:427:in`each_strongly_connected_component_from'
    from /Users/axu/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/tsort.rb:417:in `block in each_strongly_connected_component_from'
    from /Users/axu/.rvm/gems/ruby-2.1.0/gems/railties-4.0.2/lib/rails/initializable.rb:44:in`each'
    from /Users/axu/.rvm/gems/ruby-2.1.0/gems/railties-4.0.2/lib/rails/initializable.rb:44:in `tsort_each_child'
