### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The gem is under constant development. It is based in the [version 22 of the OAu
 Put this in your Gemfile:
 
 ``` ruby
-gem 'doorkeeper', '~> 0.7.0'
+gem 'doorkeeper'
 ```
 
 Run the installation generator with:


### PR DESCRIPTION
0.7 has deprecated, not set version in `readme` as other gems do
