### PR TITLE
include the scope string in the code response

### DIFF
--- a/lib/doorkeeper/oauth/code_response.rb
+++ b/lib/doorkeeper/oauth/code_response.rb
@@ -25,7 +25,8 @@ module Doorkeeper
               :access_token => auth.token.token,
               :token_type   => auth.token.token_type,
               :expires_in   => auth.token.expires_in,
-              :state        => pre_auth.state
+              :state        => pre_auth.state,
+              :scope        => pre_auth.scope
             })
           else
             uri_with_query pre_auth.redirect_uri, :code => auth.token.token, :state => pre_auth.state


### PR DESCRIPTION
Optional according to 
http://tools.ietf.org/html/rfc6749#section-4.2.2

This is required if the scopes requested aren't granted (such as if a client requested "a b", but our oauth provider only accepts "a"
