### PR TITLE
Move render_options in filter after the error has been set

### DIFF
--- a/lib/doorkeeper/helpers/filter.rb
+++ b/lib/doorkeeper/helpers/filter.rb
@@ -7,9 +7,9 @@ module Doorkeeper
 
           before_filter doorkeeper_for.filter_options do
             unless doorkeeper_for.validate_token(doorkeeper_token)
-              render_options = doorkeeper_unauthorized_render_options
               @error = OAuth::InvalidTokenResponse.from_access_token(doorkeeper_token)
               headers.merge!(@error.headers.reject {|k, v| ['Content-Type'].include? k })
+              render_options = doorkeeper_unauthorized_render_options
 
               if render_options.nil? || render_options.empty?
                 head :unauthorized


### PR DESCRIPTION
Experimental.
Move render_options in filter after the error has been set in order for an `doorkeeper_unauthorized_render_options` override to catch the response and present it to the user.

``` ruby
  def doorkeeper_unauthorized_render_options
    { json: { error: @error.description }}
  end
```

Also `@error` is too generic, should we change name to something more in scope?
