### PR TITLE
using defined? instead of explicit version to allow mongoid 4 to work

### DIFF
--- a/lib/doorkeeper/models/mongoid3_4/access_grant.rb
+++ b/lib/doorkeeper/models/mongoid3_4/access_grant.rb
@@ -12,7 +12,7 @@ module Doorkeeper
 
     self.store_in collection: :oauth_access_grants
 
-    if mongoid3?
+    if defined?(Moped::BSON)
       field :resource_owner_id, :type => Moped::BSON::ObjectId
     else
       field :resource_owner_id, :type => BSON::ObjectId

--- a/lib/doorkeeper/models/mongoid3_4/access_token.rb
+++ b/lib/doorkeeper/models/mongoid3_4/access_token.rb
@@ -12,7 +12,7 @@ module Doorkeeper
 
     self.store_in collection: :oauth_access_tokens
 
-    if mongoid3?
+    if defined?(Moped::BSON)
       field :resource_owner_id, :type => Moped::BSON::ObjectId
     else
       field :resource_owner_id, :type => BSON::ObjectId


### PR DESCRIPTION
It's not much, but it made mongoid 4 work for me, it was this or mongoid3? || mongoid4? I felt this more future proof.
