### PR TITLE
Implemented AccessToken.revoke_for to allow individual token revocation

### DIFF
--- a/lib/doorkeeper/models/access_token.rb
+++ b/lib/doorkeeper/models/access_token.rb
@@ -35,6 +35,14 @@ module Doorkeeper
       .map(&:revoke)
     end
 
+    def self.revoke_for(application_id, resource_owner, token)
+      where(:application_id => application_id,
+            :token => token,
+            :resource_owner_id => resource_owner.id,
+            :revoked_at => nil)
+      .map(&:revoke)
+    end
+
     def self.matching_token_for(application, resource_owner_or_id, scopes)
       resource_owner_id = resource_owner_or_id.respond_to?(:to_key) ? resource_owner_or_id.id : resource_owner_or_id
       token = last_authorized_token_for(application, resource_owner_id)

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -76,6 +76,38 @@ module Doorkeeper
       end
     end
 
+    describe '.revoke_for' do
+      let(:resource_owner) { double(:id => 100) }
+      let(:application)    { FactoryGirl.create :application }
+      let(:default_attributes) do
+        { :application => application, :resource_owner_id => resource_owner.id }
+      end
+
+      it 'revokes a single token for given application and resource owner' do
+        access_token = FactoryGirl.create :access_token, default_attributes
+        AccessToken.revoke_for application.id, resource_owner, access_token.token
+        AccessToken.all.each do |token|
+          if token.eql?(access_token)
+            expect(token).to be_revoked
+          else
+            expect(token).not_to be_revoked
+          end
+        end
+      end
+
+      it 'matches application' do
+        access_token = FactoryGirl.create :access_token, default_attributes.merge(:application => FactoryGirl.create(:application))
+        AccessToken.revoke_for application.id, resource_owner, access_token.token
+        expect(AccessToken.all).not_to be_empty
+      end
+
+      it 'matches resource owner' do
+        access_token = FactoryGirl.create :access_token, default_attributes.merge(:resource_owner_id => 90)
+        AccessToken.revoke_for application.id, resource_owner, access_token.token
+        expect(AccessToken.all).not_to be_empty
+      end
+    end
+
     describe '.matching_token_for' do
       let(:resource_owner_id) { 100 }
       let(:application)       { FactoryGirl.create :application }


### PR DESCRIPTION
This would be the first step in resolving issue #303. Feedback on how/if an endpoint should be created? Perhaps something like the originally suggested POST /oauth/revoke with {id: 'test', token: 'tdet3325xe5vD65S'}?

---

Alternatively, if a controller endpoint is being implemented. This may be unnecessary as one could just use "doorkeeper_token.revoke" relying on Doorkeeper::Models::Revocable and Doorkeeper::Helpers:Filter::ClassMethods. If so, the question still stands, where to put the endpoint? "Delete /token" perhaps?
