### PR TITLE
Renames errors_for to doorkeeper_errors_for

### DIFF
--- a/app/helpers/doorkeeper/form_errors_helper.rb
+++ b/app/helpers/doorkeeper/form_errors_helper.rb
@@ -1,5 +1,5 @@
 module Doorkeeper::FormErrorsHelper
-  def errors_for(object, method)
+  def doorkeeper_errors_for(object, method)
     if object.errors[method].present?
       object.errors[method].map do |msg|
         content_tag(:span, :class => "help-block") do

--- a/app/views/doorkeeper/applications/_form.html.erb
+++ b/app/views/doorkeeper/applications/_form.html.erb
@@ -7,7 +7,7 @@
     <%= f.label :name, class: 'col-sm-2 control-label', for: 'application_name' %>
     <div class="col-sm-10">
       <%= f.text_field :name, class: 'form-control' %>
-      <%= errors_for application, :name %>
+      <%= doorkeeper_errors_for application, :name %>
     </div>
   <% end %>
 
@@ -15,7 +15,7 @@
     <%= f.label :redirect_uri, class: 'col-sm-2 control-label', for: 'application_redirect_uri' %>
     <div class="col-sm-10">
       <%= f.text_area :redirect_uri, class: 'form-control' %>
-      <%= errors_for application, :redirect_uri %>
+      <%= doorkeeper_errors_for application, :redirect_uri %>
       <span class="help-block">
          Use one line per URI
         </span>


### PR DESCRIPTION
Renames the errors_for method to doorkeeper_errors_for in an attempt to "namespace" the method. In our case, we had a method name clash, as we have another helper with the generic "errors_for" method.

I felt this was a pretty minor change in Doorkeeper, whereas the alternative would've required a global replace in our current project.

Thanks.
