### PR TITLE
Fix template source for locale

### DIFF
--- a/lib/generators/doorkeeper/install_generator.rb
+++ b/lib/generators/doorkeeper/install_generator.rb
@@ -5,7 +5,7 @@ class Doorkeeper::InstallGenerator < ::Rails::Generators::Base
 
   def install
     template "initializer.rb", "config/initializers/doorkeeper.rb"
-    copy_file "../../../../config/locales/en.yml", "config/locales/doorkeeper.en.yml"
+    copy_file File.expand_path("../../../../config/locales/en.yml", __FILE__), "config/locales/doorkeeper.en.yml"
     route "use_doorkeeper"
     readme "README"
   end


### PR DESCRIPTION
Refs #378

If you have a `[rails_root]/lib/templates` folder (e.g. simple_form), doorkeeper's install scripts copy from `[rails_root]/config/locales/en.yml` instead of `[gem_root]/config/locales/en.yml`.

This fix will provide an absolute path for the template so it won't be confused.
