### PR TITLE
Remove non-ASCII char from initializer template

### DIFF
--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -66,7 +66,7 @@ Doorkeeper.configure do
   #   client.superapp? or resource_owner.admin?
   # end
 
-  # WWW-Authenticate Realm (default "Doorkeeper").
+  # WWW-Authenticate Realm (default "Doorkeeper").
   # realm "Doorkeeper"
 
   # Allow dynamic query parameters (disabled by default)


### PR DESCRIPTION
Upon installing Doorkeeper I got a warning from my linter that there were non-ASCII characters in a US-ASCII encoded file generated by Doorkeeper. Running `iconv` against the file found the culprit, which has been replaced by a standard space character within this commit.
