### PR TITLE
Fix uniqueness spec

### DIFF
--- a/spec/models/doorkeeper/access_grant_spec.rb
+++ b/spec/models/doorkeeper/access_grant_spec.rb
@@ -7,7 +7,7 @@ describe Doorkeeper::AccessGrant do
 
   it_behaves_like "an accessible token"
   it_behaves_like "a revocable token"
-  it_behaves_like "an unique token" do
+  it_behaves_like "a unique token" do
     let(:factory_name) { :access_grant }
   end
 

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -8,7 +8,7 @@ module Doorkeeper
 
     it_behaves_like "an accessible token"
     it_behaves_like "a revocable token"
-    it_behaves_like "an unique token" do
+    it_behaves_like "a unique token" do
       let(:factory_name) { :access_token }
     end
 
@@ -69,7 +69,7 @@ module Doorkeeper
         context 'the second token has same owner and different app' do
           let(:other_application) { FactoryGirl.create :application }
           let(:access_token2) { FactoryGirl.create :access_token, application: other_application, resource_owner_id: resource_owner_id }
-                   
+
           it 'fail' do
             expect(access_token1.same_credential?(access_token2)).to be_false
           end
@@ -79,7 +79,7 @@ module Doorkeeper
 
           let(:other_application) { FactoryGirl.create :application }
           let(:access_token2) { FactoryGirl.create :access_token, application: other_application, resource_owner_id: 42 }
-          
+
           it 'fail' do
             expect(access_token1.same_credential?(access_token2)).to be_false
           end
@@ -87,7 +87,7 @@ module Doorkeeper
 
         context 'the second token has different owner and same app' do
           let(:access_token2) { FactoryGirl.create :access_token, application: application, resource_owner_id: 42 }
-          
+
           it 'fail' do
             expect(access_token1.same_credential?(access_token2)).to be_false
           end

--- a/spec/support/shared/models_shared_examples.rb
+++ b/spec/support/shared/models_shared_examples.rb
@@ -27,14 +27,16 @@ shared_examples "a revocable token" do
   end
 end
 
-shared_examples "an unique token" do
+shared_examples "a unique token" do
   describe :token do
+    let(:iterations) { 3 }
+
     it "is unique" do
       tokens = []
-      3.times do
-        token = FactoryGirl.create(factory_name).token
-        expect(tokens).not_to include(token)
+      iterations.times do
+        tokens << FactoryGirl.create(factory_name).token
       end
+      expect(tokens.uniq.size).to eq(iterations)
     end
 
     it "is generated before validation" do


### PR DESCRIPTION
Before the spec wasn't doing anything (checking 3 times if an empty array doesn't contain a certain token)

I implemented a spec that checks if the token is really uniqe

Furthermore it's 'a unique' rather than 'an unique'
