### PR TITLE
Application is not required for access_token

### DIFF
--- a/lib/doorkeeper/models/active_record/access_token.rb
+++ b/lib/doorkeeper/models/active_record/access_token.rb
@@ -13,7 +13,7 @@ module Doorkeeper
     private_class_method :delete_all_for
 
     def self.last_authorized_token_for(application, resource_owner_id)
-      where(application_id: application.id,
+      where(application_id: application.try(:id),
             resource_owner_id: resource_owner_id,
             revoked_at: nil).
         order('created_at desc').

--- a/lib/doorkeeper/models/mongo_mapper/access_token.rb
+++ b/lib/doorkeeper/models/mongo_mapper/access_token.rb
@@ -30,7 +30,7 @@ module Doorkeeper
     private_class_method :delete_all_for
 
     def self.last_authorized_token_for(application, resource_owner_id)
-      where(application_id: application.id,
+      where(application_id: application.try(:id),
             resource_owner_id: resource_owner_id,
             revoked_at: nil).
         sort(:created_at.desc).

--- a/lib/doorkeeper/models/mongoid2/access_token.rb
+++ b/lib/doorkeeper/models/mongoid2/access_token.rb
@@ -25,7 +25,7 @@ module Doorkeeper
     private_class_method :delete_all_for
 
     def self.last_authorized_token_for(application, resource_owner_id)
-      where(application_id: application.id,
+      where(application_id: application.try(:id),
             resource_owner_id: resource_owner_id,
             revoked_at: nil).
         order_by([:created_at, :desc]).

--- a/lib/doorkeeper/models/mongoid3_4/access_token.rb
+++ b/lib/doorkeeper/models/mongoid3_4/access_token.rb
@@ -32,7 +32,7 @@ module Doorkeeper
     private_class_method :delete_all_for
 
     def self.last_authorized_token_for(application, resource_owner_id)
-      where(application_id: application.id,
+      where(application_id: application.try(:id),
             resource_owner_id: resource_owner_id,
             revoked_at: nil).
         order_by([:created_at, :desc]).


### PR DESCRIPTION
As client authorization is now optional, we should embrace the cases where application is nil.

When `reuse_access_token` is enabled per #383, if you [don't send client_id and client_secret](https://github.com/doorkeeper-gem/doorkeeper/issues/397), it was causing NoMethodError due to application being nil. This bug has been there before #383 but the feature shed light on it.

However, I'm still not sure if this is the best way to fix the issue, as it can create an access token even when you have an invalid pair of `client_id` and `client_secret` and now you get an access token for unknown application. I personally think that, if an invalid pair of `client_id` and `client_secret` is given, that should be an error.

Until we decide what is right, this PR should provide a quick fix.
