### PR TITLE
Add options for default grant and response types.

### DIFF
--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -43,7 +43,7 @@ module Doorkeeper
     end
 
     def strategy
-      @strategy ||= server.token_request params[:grant_type]
+      @strategy ||= server.token_request(params[:grant_type] || Doorkeeper.configuration.default_grant_type)
     end
   end
 end

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -172,6 +172,8 @@ module Doorkeeper
     option :active_record_options,         default: {}
     option :realm,                         default: 'Doorkeeper'
     option :wildcard_redirect_uri,         default: false
+    option :default_grant_type
+    option :default_response_type
     option :grant_flows,
            default: %w(authorization_code implicit password client_credentials)
 

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -14,7 +14,7 @@ module Doorkeeper
       def initialize(server, client, attrs = {})
         @server        = server
         @client        = client
-        @response_type = attrs[:response_type]
+        @response_type = attrs[:response_type] || Doorkeeper.configuration.default_response_type
         @redirect_uri  = attrs[:redirect_uri]
         @scope         = attrs[:scope]
         @state         = attrs[:state]

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -74,6 +74,32 @@ describe Doorkeeper, 'configuration' do
     end
   end
 
+  describe 'default_grant_type' do
+    it 'is nil by default' do
+      expect(subject.default_grant_type).to be_nil
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure do
+        default_grant_type 'authorization_code'
+      end
+      expect(subject.default_grant_type).to eq('authorization_code')
+    end
+  end
+
+  describe 'default_response_type' do
+    it 'is nil by default' do
+      expect(subject.default_response_type).to be_nil
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure do
+        default_response_type 'code'
+      end
+      expect(subject.default_response_type).to eq('code')
+    end
+  end
+
   describe 'use_refresh_token' do
     it 'is false by default' do
       expect(subject.refresh_token_enabled?).to be_false

--- a/spec/requests/endpoints/token_spec.rb
+++ b/spec/requests/endpoints/token_spec.rb
@@ -61,4 +61,14 @@ feature 'Token endpoint' do
     should_have_json 'error', 'invalid_request'
     should_have_json 'error_description', translated_error_message('invalid_request')
   end
+
+  scenario 'uses default_grant_type if grant_type is missing' do
+    config_is_set(:default_grant_type, 'authorization_code')
+
+    post token_endpoint_url(code: @authorization.token, client: @client, grant_type: '')
+
+    should_have_json 'access_token', Doorkeeper::AccessToken.first.token
+    should_not_have_json 'error'
+    should_not_have_json 'error_description'
+  end
 end

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -56,6 +56,21 @@ feature 'Authorization Code Flow' do
     should_have_json_within 'expires_in', Doorkeeper::AccessToken.first.expires_in, 1
   end
 
+  scenario 'uses default_response_type if response_type is missing' do
+    config_is_set(:default_response_type, 'code')
+
+    visit authorization_endpoint_url(client: @client, response_type: '')
+    click_on 'Authorize'
+
+    access_grant_should_exist_for(@client, @resource_owner)
+
+    i_should_be_on_client_callback(@client)
+
+    url_should_have_param('code', Doorkeeper::AccessGrant.first.token)
+    url_should_not_have_param('state')
+    url_should_not_have_param('error')
+  end
+
   context 'with scopes' do
     background do
       default_scopes_exist  :public

--- a/spec/support/helpers/url_helper.rb
+++ b/spec/support/helpers/url_helper.rb
@@ -6,7 +6,7 @@ module UrlHelper
       client_secret: options[:client_secret] || (options[:client] ? options[:client].secret : nil),
       redirect_uri: options[:redirect_uri]  || (options[:client] ? options[:client].redirect_uri : nil),
       grant_type: options[:grant_type]    || 'authorization_code'
-    }
+    }.reject { |k, v| v.blank? }
     "/oauth/token?#{build_query(parameters)}"
   end
 


### PR DESCRIPTION
I'm currently only allowing one of each so it'd be nice to be able to provide defaults.

Considered automatically setting a default if only one type is available, but figured it'd better to leave it up to the user on wether or not to they don't want to require the parameters.
