### PR TITLE
AccessToken#to_json - application can be blank

### DIFF
--- a/lib/doorkeeper/models/access_token.rb
+++ b/lib/doorkeeper/models/access_token.rb
@@ -79,7 +79,7 @@ module Doorkeeper
         resource_owner_id: resource_owner_id,
         scopes: scopes,
         expires_in_seconds: expires_in_seconds,
-        application: { uid: application.uid }
+        application: { uid: application.try(:uid) }
       }
     end
 

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -180,15 +180,43 @@ module Doorkeeper
         last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
         expect(last_token).to eq(token)
       end
+    end
 
-      it 'returns as_json hash'   do
-        token = FactoryGirl.create :access_token, default_attributes
-        token_hash = { resource_owner_id: token.resource_owner_id,
-                       scopes: token.scopes,
-                       expires_in_seconds: token.expires_in_seconds,
-                       application: { uid: token.application.uid }
+    describe '#as_json' do
+      let(:resource_owner) { double(id: 100) }
+      let(:application)    { FactoryGirl.create :application }
+      let(:token)          { FactoryGirl.create :access_token, default_attributes }
+
+      let(:default_attributes) do
+        { application: application, resource_owner_id: resource_owner.id }
+      end
+
+      it 'returns hash' do
+        token_hash = {
+          resource_owner_id: token.resource_owner_id,
+          scopes: token.scopes,
+          expires_in_seconds: token.expires_in_seconds,
+          application: { uid: token.application.uid }
         }
+
         expect(token.as_json).to eq token_hash
+      end
+
+      describe 'when application is nil' do
+        let(:default_attributes) do
+          { application: nil, resource_owner_id: resource_owner.id }
+        end
+
+        it 'returns hash' do
+          token_hash = {
+            resource_owner_id: token.resource_owner_id,
+            scopes: token.scopes,
+            expires_in_seconds: token.expires_in_seconds,
+            application: {uid: nil}
+          }
+
+          expect(token.as_json).to eq token_hash
+        end
       end
     end
 


### PR DESCRIPTION
Method #to_json on AccessToken should work when application is not
present.
