### PR TITLE
Add a facade to more easily get token from request

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ class Api::V1::ProductsController < Api::V1::ApiController
 end
 ```
 
-### ActionController::Metal integration and other integrations
+### ActionController::Metal integration
 
 The `doorkeeper_for` filter is intended to work with ActionController::Metal
 too. You only need to include the required `ActionController` modules:
@@ -203,6 +203,25 @@ class MetalController < ActionController::Metal
   include Doorkeeper::Helpers::Filter
 
   doorkeeper_for :all
+end
+```
+
+### Route Constraints and other integrations
+
+You can leverage the `Doorkeeper.authenticate` facade to easily extract a
+`Doorkeeper::OAuth::Token` based on the current request. You can then ensure
+that token is still good, find its associated `#resource_owner_id`, etc.
+
+```ruby
+module Constraint
+  class Authenticated
+
+    def matches?(request)
+      token = Doorkeeper.authenticate(request)
+      token && token.accessible?
+    end
+
+  end
 end
 ```
 

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -54,4 +54,8 @@ module Doorkeeper
   def self.installed?
     configured? && database_installed?
   end
+
+  def self.authenticate(request, methods = Doorkeeper.configuration.access_token_methods)
+    OAuth::Token.authenticate(request, *methods)
+  end
 end

--- a/spec/lib/doorkeeper_spec.rb
+++ b/spec/lib/doorkeeper_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper_integration'
+
+describe Doorkeeper do
+  describe 'authenticate' do
+    let(:token) { double('Token') }
+    let(:request) { double('ActionDispatch::Request') }
+    before do
+      allow(Doorkeeper::OAuth::Token).to receive(:authenticate).
+        with(request, *token_strategies) { token }
+    end
+
+    context 'with specific access token strategies' do
+      let(:token_strategies) { [:first_way, :second_way] }
+
+      it 'authenticates the token from the request' do
+        expect(Doorkeeper.authenticate(request, token_strategies)).to eq(token)
+      end
+    end
+
+    context 'with default access token strategies' do
+      let(:token_strategies) { Doorkeeper.configuration.access_token_methods }
+
+      it 'authenticates the token from the request' do
+        expect(Doorkeeper.authenticate(request)).to eq(token)
+      end
+    end
+  end
+end


### PR DESCRIPTION
If you wish to use Doorkeeper outside of a Rails controller you must dig deep
into the internals of Doorkeeper to extract a token from an incoming request.
I needed to do this, for example, in a custom route constraint. This PR adds a
small facade which makes doing this simpler.
