### PR TITLE
Update Rails and Bundler dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-before_install:
-  - gem install bundler -v '= 1.5.1'
 rvm:
   - 1.9.3
   - 2.0


### PR DESCRIPTION
- Move to latest Rails releases for 3.1.x - 4.1.x.
- Travis now runs Bundler 1.5.3 by default, so just use it.
