### PR TITLE
Limit lines to 120 characters and not 80

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+LineLength:
+  Exclude:
+    - app/spec/**/*


### PR DESCRIPTION
## Limit lines to 120 characters

Each time I received an email through the Doorkeeper mailing list saying "Line is too long. [XX/80]" I wanted to make this PR.

An 80 character limit has no relevance any more with modern computer displays. The old computers can easily display over **200** characters across the screen.
