### PR TITLE
fix issue 340

### DIFF
--- a/lib/doorkeeper/oauth/code_response.rb
+++ b/lib/doorkeeper/oauth/code_response.rb
@@ -18,7 +18,7 @@ module Doorkeeper
       # TODO: configure the test oauth path?
       def redirect_uri
         if URIChecker.native_uri? pre_auth.redirect_uri
-          {action: :show, code: auth.token.token}
+          { action: :show, code: auth.token.token }
         else
           if response_on_fragment
             uri_with_fragment(


### PR DESCRIPTION
touch #340

NOTICE: This fix can‘t testing with dummy app. cause duplicate calling `use_doorkeeper` would conflict naming routes. but it works.
