### PR TITLE
Extend Doorkeeper TokenResponse processing

### DIFF
--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -20,7 +20,7 @@ module Doorkeeper
 
       private
 
-      def on_successful_authorization
+      def before_successful_response
         grant.revoke
         find_or_create_access_token(grant.application,
                                     grant.resource_owner_id,

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -26,7 +26,7 @@ module Doorkeeper
 
       private
 
-      def on_successful_authorization
+      def before_successful_response
         find_or_create_access_token(client, resource_owner.id, scopes, server)
       end
 

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -27,7 +27,7 @@ module Doorkeeper
 
       private
 
-      def on_successful_authorization
+      def before_successful_response
         refresh_token.revoke
         create_access_token
       end

--- a/lib/doorkeeper/oauth/request_concern.rb
+++ b/lib/doorkeeper/oauth/request_concern.rb
@@ -4,8 +4,10 @@ module Doorkeeper
       def authorize
         validate
         if valid?
-          on_successful_authorization
+          before_successful_response
           @response = TokenResponse.new(access_token)
+          after_successful_response
+          @response
         else
           @response = ErrorResponse.from_request(self)
         end
@@ -36,7 +38,10 @@ module Doorkeeper
           server.refresh_token_enabled?)
       end
 
-      def on_successful_authorization
+      def before_successful_response
+      end
+
+      def after_successful_response
       end
     end
   end


### PR DESCRIPTION
Optionally include OpenID Connect `id_token` in `TokenResponse`.

I don't much like making Doorkeeper aware of an OpenID Connect extension, but I don't see another way to inject an extra property into the `TokenResponse` body.  I like the use of `on_successful_authorization` in the `RequestConcern` to abstract the `TokenRequest` implementation, but the `TokenResponse` seems coupled to knowledge of `AccessToken` in the `TokenResponse`.

I plan to provide an implementation to `AccessToken#id_token` in the OpenID Connect extension gem I'm working on (https://github.com/playon/doorkeeper-openid_connect), but thought this might allow alternate implementations as needed.  I'm open to alternate extensions that allow me to inject additional members into the JSON response to a `TokenRequest`.  This was just the most straightforward way I could see to do it (I am not a Rubyist).
