### PR TITLE
Requests with insufficient scope should respond 403 Forbidden

### DIFF
--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -31,6 +31,7 @@ require 'doorkeeper/oauth/token_request'
 require 'doorkeeper/oauth/client'
 require 'doorkeeper/oauth/token'
 require 'doorkeeper/oauth/invalid_token_response'
+require 'doorkeeper/oauth/forbidden_token_response'
 
 require 'doorkeeper/models/scopes'
 require 'doorkeeper/models/expirable'

--- a/lib/doorkeeper/doorkeeper_for.rb
+++ b/lib/doorkeeper/doorkeeper_for.rb
@@ -1,13 +1,15 @@
 module Doorkeeper
   class InvalidSyntax < StandardError; end
   class DoorkeeperFor
+    attr_reader :scopes
+
     def initialize(options)
       options ||= {}
       fail InvalidSyntax unless options.is_a? Hash
       @filter_options = {}
 
       options.each do |k, v|
-        self.send(k, v)
+        send("#{k}=", v)
       end
     end
 
@@ -23,29 +25,29 @@ module Doorkeeper
 
     private
 
-    def scopes(scopes)
+    def scopes=(scopes)
       @scopes = scopes.map(&:to_s)
     end
 
-    def if(if_block)
+    def if=(if_block)
       @filter_options[:if] = if_block
     end
 
-    def unless(unless_block)
+    def unless=(unless_block)
       @filter_options[:unless] = unless_block
     end
 
     # TODO: move this to Token class
     def validate_token_scopes(token)
-      return true if @scopes.blank?
-      token.scopes.any? { |scope| @scopes.include? scope }
+      return true if scopes.blank?
+      token.scopes.any? { |scope| scopes.include? scope }
     end
   end
 
   class AllDoorkeeperFor < DoorkeeperFor
     private
 
-    def except(actions)
+    def except=(actions)
       @filter_options[:except] = actions
     end
   end

--- a/lib/doorkeeper/oauth/forbidden_token_response.rb
+++ b/lib/doorkeeper/oauth/forbidden_token_response.rb
@@ -1,0 +1,29 @@
+module Doorkeeper
+  module OAuth
+    class ForbiddenTokenResponse < ErrorResponse
+      def self.from_scopes(scopes, attributes = {})
+        new(attributes.merge(scopes: scopes))
+      end
+
+      def initialize(attributes = {})
+        super(attributes.merge(name: :invalid_scope, state: :forbidden))
+        @scopes = attributes[:scopes]
+      end
+
+      def status
+        :forbidden
+      end
+
+      def headers
+        headers = super
+        headers.delete 'WWW-Authenticate'
+        headers
+      end
+
+      def description
+        scope = { scope: [:doorkeeper, :scopes] }
+        @description ||= @scopes.map { |r| I18n.translate r, scope }.join('\n')
+      end
+    end
+  end
+end

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -181,8 +181,8 @@ describe 'Doorkeeper_for helper' do
       token = double(Doorkeeper::AccessToken, accessible?: true, scopes: ['public'], revoked?: false, expired?: false)
       expect(Doorkeeper::AccessToken).to receive(:authenticate).with(token_string).and_return(token)
       get :index, access_token: token_string
-      expect(response.status).to eq 401
-      expect(response.header['WWW-Authenticate']).to match(/^Bearer/)
+      expect(response.status).to eq 403
+      expect(response.header).to_not include('WWW-Authenticate')
     end
   end
 

--- a/spec/lib/oauth/forbidden_token_response_spec.rb
+++ b/spec/lib/oauth/forbidden_token_response_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'active_model'
+require 'doorkeeper'
+require 'doorkeeper/oauth/forbidden_token_response'
+
+module Doorkeeper::OAuth
+  describe ForbiddenTokenResponse do
+    describe '#name' do
+      it  { expect(subject.name).to eq(:invalid_scope) }
+    end
+
+    describe '#status' do
+      it { expect(subject.status).to eq(:forbidden) }
+    end
+
+    describe :from_scopes do
+      it 'should have a list of acceptable scopes' do
+        response = ForbiddenTokenResponse.from_scopes(["public"])
+        expect(response.description).to include('public')
+      end
+    end
+  end
+end

--- a/spec/requests/protected_resources/private_api_spec.rb
+++ b/spec/requests/protected_resources/private_api_spec.rb
@@ -45,7 +45,7 @@ feature 'Private API' do
     @token.update_column :scopes, nil
     with_access_token_header @token.token
     visit '/full_protected_resources/1.json'
-    response_status_should_be 401
+    response_status_should_be 403
   end
 
   scenario 'access token with default scope' do


### PR DESCRIPTION
This resolves #243 by returning `403 Forbidden` along with scope descriptions when a token has the incorrect scopes to access a resource. 
