### PR TITLE
Fix as_json method since application is not required for access_token

### DIFF
--- a/lib/doorkeeper/models/access_token.rb
+++ b/lib/doorkeeper/models/access_token.rb
@@ -79,7 +79,7 @@ module Doorkeeper
         resource_owner_id: resource_owner_id,
         scopes: scopes,
         expires_in_seconds: expires_in_seconds,
-        application: { uid: application.uid }
+        application: { uid: application.try(:uid) }
       }
     end
 


### PR DESCRIPTION
Hello,

If an `access_token` was created without `application credentials` for the `password` grant type, then its `application` attribute should be `null` on the JSON response of the following request : 

```
GET /oauth/token/info
Authorization: Bearer ba0cd596456341ec09e8a978f5e33ecdbae13b8cadfdbf583a8d01011aff7ad1
```

Instead, it actually raises an error : 

``` bash
Started GET "/oauth/token/info" for 127.0.0.1 at 2014-07-04 10:06:39 +0200
Processing by Doorkeeper::TokenInfoController#show as */*
  MOPED: 127.0.0.1:27017 COMMAND      database=admin command={:ismaster=>1} runtime: 0.4620ms
  MOPED: 127.0.0.1:27017 QUERY        database=kml_api_development collection=oauth_access_tokens selector={"$query"=>{"token"=>"ca9a09356cacec2c6aec9036834eca67c95699311f105a822052b092ed559dad"}, "$orderby"=>{:_id=>1}} flags=[] limit=-1 skip=0 batch_size=nil fields=nil runtime: 0.9890ms
Completed 500 Internal Server Error in 4ms

NoMethodError (undefined method `uid' for nil:NilClass):
  /Users/smnbrd/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/doorkeeper-92f2acd1b529/lib/doorkeeper/models/access_token.rb:82:in `as_json'
```

With the fix it returns the expected JSON response : 

``` json
{
    "resource_owner_id": "53b663fb68696b0a06000000",
    "scopes": [],
    "expires_in_seconds": 344125,
    "application": {
        "uid": null
    }
}
```
