### PR TITLE
Please allow to contain a query parameter for hybridauth.

### DIFF
--- a/app/validators/redirect_uri_validator.rb
+++ b/app/validators/redirect_uri_validator.rb
@@ -14,7 +14,6 @@ class RedirectUriValidator < ActiveModel::EachValidator
         return if native_redirect_uri?(uri)
         record.errors.add(attribute, :fragment_present) unless uri.fragment.nil?
         record.errors.add(attribute, :relative_uri) if uri.scheme.nil? || uri.host.nil?
-        record.errors.add(attribute, :has_query_parameter) unless uri.query.nil?
       end
     end
   rescue URI::InvalidURIError

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,6 @@ en:
           attributes:
             redirect_uri:
               fragment_present: 'cannot contain a fragment.'
-              has_query_parameter: 'cannot contain a query parameter.'
               invalid_uri: 'must be a valid URI.'
               relative_uri: 'must be an absolute URI.'
   mongoid:
@@ -16,7 +15,6 @@ en:
           attributes:
             redirect_uri:
               fragment_present: 'cannot contain a fragment.'
-              has_query_parameter: 'cannot contain a query parameter.'
               invalid_uri: 'must be a valid URI.'
               relative_uri: 'must be an absolute URI.'
   mongo_mapper:
@@ -26,7 +24,6 @@ en:
           attributes:
             redirect_uri:
               fragment_present: 'cannot contain a fragment.'
-              has_query_parameter: 'cannot contain a query parameter.'
               invalid_uri: 'must be a valid URI.'
               relative_uri: 'must be an absolute URI.'
   doorkeeper:

--- a/spec/lib/oauth/authorization/uri_builder_spec.rb
+++ b/spec/lib/oauth/authorization/uri_builder_spec.rb
@@ -32,6 +32,11 @@ module Doorkeeper::OAuth::Authorization
         uri = subject.uri_with_fragment 'http://example.com/', parameter: 'value'
         expect(uri).to eq('http://example.com/#parameter=value')
       end
+
+      it 'preserves original query parameters' do
+        uri = subject.uri_with_fragment 'http://example.com/?query1=value1', parameter: 'value'
+        expect(uri).to eq('http://example.com/?query1=value1#parameter=value')
+      end
     end
   end
 end

--- a/spec/validators/redirect_uri_validator_spec.rb
+++ b/spec/validators/redirect_uri_validator_spec.rb
@@ -41,7 +41,6 @@ describe RedirectUriValidator do
 
   it 'is invalid when the uri has a query parameter' do
     subject.redirect_uri = 'http://example.com/abcd?xyz=123'
-    expect(subject).not_to be_valid
-    expect(subject.errors[:redirect_uri].first).to eq('cannot contain a query parameter.')
+    expect(subject).to be_valid
   end
 end


### PR DESCRIPTION
PHP's OAuth library hybridauth's callback uri contains `?` (e.g. `path_to_hybridauth/?hauth.done=Provider`).

But doorkeeper gem's `oauth/applications` cannot accept '?' and show error: `Cannot contain a query parameter.`
