### PR TITLE
Rename application controller

### DIFF
--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -1,6 +1,5 @@
 module Doorkeeper
   class TokensController < ApplicationController
-    include Helpers::Controller
     include ActionController::RackDelegation
     include ActionController::Instrumentation
 


### PR DESCRIPTION
I ran into an issue between Doorkeeper and RSpec after 84f809aa98fcde3272d45e0381ebb6829df8f8f7.

I had overridden doorkeeper's `AuthorizationsController` with a custom one inheriting from `Doorkeeper::AuthorizationsController`. Unfortunately, when running my full RSpec suite it incorrectly set `Doorkeeper::AuthorizationsController`'s parent to my application's `ApplicationController`. Running specs for my controller individually produced the right inheritance.

I dug into RSpec a bit to see if I could at least figure out if that was intended behaviour, but I'm still not sure. This is a pretty simple workaround for that problem (and it's similar to how devise names it's [parent controller](https://github.com/plataformatec/devise/blob/master/app/controllers/devise_controller.rb) if that matters), but if you think this should be addressed by an issue with the RSpec team instead, I'll do that. 

I also noticed there was a redundant inclusion of the the `Doorkeeper::Helpers::Controller` module in TokensController, so I removed it.  
