### PR TITLE
explicit doorkeeper namespace declaration

### DIFF
--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
-  class ApplicationsController < ApplicationController
+  class ApplicationsController < Doorkeeper::ApplicationController
     layout 'doorkeeper/admin'
     respond_to :html
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
-  class AuthorizationsController < ApplicationController
+  class AuthorizationsController < Doorkeeper::ApplicationController
     before_filter :authenticate_resource_owner!
 
     def new

--- a/app/controllers/doorkeeper/authorized_applications_controller.rb
+++ b/app/controllers/doorkeeper/authorized_applications_controller.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
-  class AuthorizedApplicationsController < ApplicationController
+  class AuthorizedApplicationsController < Doorkeeper::ApplicationController
     before_filter :authenticate_resource_owner!
 
     def index

--- a/app/controllers/doorkeeper/token_info_controller.rb
+++ b/app/controllers/doorkeeper/token_info_controller.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
-  class TokenInfoController < ApplicationController
+  class TokenInfoController < Doorkeeper::ApplicationController
     def show
       if doorkeeper_token && doorkeeper_token.accessible?
         render json: doorkeeper_token, status: :ok

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
-  class TokensController < ApplicationController
+  class TokensController < Doorkeeper::ApplicationController
     include ActionController::RackDelegation
     include ActionController::Instrumentation
 


### PR DESCRIPTION
Linked to #439

If a constant is already loaded it will be used, e.g. Rails loads ApplicationController and the module declaration uses this instead of the Module namespaced one.
