### PR TITLE
Allow revoked_at to be set in the future, for future expiry

### DIFF
--- a/lib/doorkeeper/models/revocable.rb
+++ b/lib/doorkeeper/models/revocable.rb
@@ -6,7 +6,7 @@ module Doorkeeper
       end
 
       def revoked?
-        revoked_at.present?
+        !!(revoked_at && revoked_at <= DateTime.now)
       end
     end
   end

--- a/spec/lib/models/revocable_spec.rb
+++ b/spec/lib/models/revocable_spec.rb
@@ -18,9 +18,14 @@ describe 'Revocable' do
   end
 
   describe :revoked? do
-    it 'is revoked if :revoked_at is set' do
-      allow(subject).to receive(:revoked_at).and_return(double)
+    it 'is revoked if :revoked_at has passed' do
+      allow(subject).to receive(:revoked_at).and_return(DateTime.now - 1000)
       expect(subject).to be_revoked
+    end
+
+    it 'is not revoked if :revoked_at has not passed' do
+      allow(subject).to receive(:revoked_at).and_return(DateTime.now + 1000)
+      expect(subject).not_to be_revoked
     end
 
     it 'is not revoked if :revoked_at is not set' do


### PR DESCRIPTION
Hello,

I'm working with IFTTT integration on a project and they've requested that a refresh token is not revoked immediately. I have no idea how to implement this in doorkeeper without setting `revoked_at` to a future time. I noticed that the `revoked?` method merely checks if that field is set, and not if that time has yet passed. This PR attempts to rectify that behaviour.

If you know of a better way to keep refresh tokens around, I would love to hear about it.

Thanks!
