### PR TITLE
Convert resource_owner_id to resource_owner_uid

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -168,7 +168,6 @@ module Doorkeeper
     option :access_token_expires_in,       default: 7200
     option :authorization_code_expires_in, default: 600
     option :orm,                           default: :active_record
-    option :resource_owner_property,       default: :id
     option :native_redirect_uri,           default: 'urn:ietf:wg:oauth:2.0:oob'
     option :active_record_options,         default: {}
     option :realm,                         default: 'Doorkeeper'

--- a/lib/doorkeeper/models/access_token.rb
+++ b/lib/doorkeeper/models/access_token.rb
@@ -25,15 +25,10 @@ module Doorkeeper
                       on: :create,
                       if: :use_refresh_token?
 
-    def self.resource_owner_property
-      Doorkeeper.configuration.resource_owner_property
-    end
-    private_class_method :resource_owner_property
-
     def self.extract_resource_owner_id(resource_owner_or_id)
       return nil if resource_owner_or_id.nil?
-      if resource_owner_or_id.respond_to?(resource_owner_property)
-        resource_owner_or_id.send(resource_owner_property)
+      if resource_owner_or_id.respond_to?(:to_param)
+        resource_owner_or_id.to_param
       else
         resource_owner_or_id
       end

--- a/lib/doorkeeper/models/active_record/application.rb
+++ b/lib/doorkeeper/models/active_record/application.rb
@@ -13,18 +13,13 @@ module Doorkeeper
     end
     has_many :authorized_applications, through: :authorized_tokens, source: :application
 
-    def self.resource_owner_property
-      Doorkeeper.configuration.resource_owner_property
-    end
-    private_class_method :resource_owner_property
-
     def self.column_names_with_table
       self.column_names.map { |c| "#{table_name}.#{c}" }
     end
 
     def self.authorized_for(resource_owner)
       joins(:authorized_applications).
-        where(AccessToken.table_name => { resource_owner_id: resource_owner.send(resource_owner_property), revoked_at: nil }).
+        where(AccessToken.table_name => { resource_owner_id: resource_owner.to_param, revoked_at: nil }).
         group(column_names_with_table.join(','))
     end
   end

--- a/lib/doorkeeper/models/mongo_mapper/application.rb
+++ b/lib/doorkeeper/models/mongo_mapper/application.rb
@@ -18,13 +18,8 @@ module Doorkeeper
       write_attribute :scopes, value if value.present?
     end
 
-    def self.resource_owner_property
-      Doorkeeper.configuration.resource_owner_property
-    end
-    private_class_method :resource_owner_property
-
     def self.authorized_for(resource_owner)
-      ids = AccessToken.where(resource_owner_id: resource_owner.send(resource_owner_property), revoked_at: nil).map(&:application_id)
+      ids = AccessToken.where(resource_owner_id: resource_owner.to_param, revoked_at: nil).map(&:application_id)
       find(ids)
     end
 

--- a/lib/doorkeeper/models/mongoid2/application.rb
+++ b/lib/doorkeeper/models/mongoid2/application.rb
@@ -14,13 +14,8 @@ module Doorkeeper
 
     has_many :authorized_tokens, class_name: 'Doorkeeper::AccessToken'
 
-    def self.resource_owner_property
-      Doorkeeper.configuration.resource_owner_property
-    end
-    private_class_method :resource_owner_property
-
     def self.authorized_for(resource_owner)
-      ids = AccessToken.where(resource_owner_id: resource_owner.send(resource_owner_property), revoked_at: nil).map(&:application_id)
+      ids = AccessToken.where(resource_owner_id: resource_owner.to_param, revoked_at: nil).map(&:application_id)
       find(ids)
     end
   end

--- a/lib/doorkeeper/models/mongoid3_4/application.rb
+++ b/lib/doorkeeper/models/mongoid3_4/application.rb
@@ -14,13 +14,8 @@ module Doorkeeper
 
     has_many :authorized_tokens, class_name: 'Doorkeeper::AccessToken'
 
-    def self.resource_owner_property
-      Doorkeeper.configuration.resource_owner_property
-    end
-    private_class_method :resource_owner_property
-
     def self.authorized_for(resource_owner)
-      ids = AccessToken.where(resource_owner_id: resource_owner.send(resource_owner_property), revoked_at: nil).map(&:application_id)
+      ids = AccessToken.where(resource_owner_id: resource_owner.to_param, revoked_at: nil).map(&:application_id)
       find(ids)
     end
   end

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -12,7 +12,7 @@ module Doorkeeper
         def issue_token
           @token ||= AccessGrant.create!(
             application_id: pre_auth.client.id,
-            resource_owner_id: resource_owner.send(configuration.resource_owner_property),
+            resource_owner_id: resource_owner.to_param,
             expires_in: configuration.authorization_code_expires_in,
             redirect_uri: pre_auth.redirect_uri,
             scopes: pre_auth.scopes.to_s

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -12,7 +12,7 @@ module Doorkeeper
         def issue_token
           @token ||= AccessToken.create!(
             application_id: pre_auth.client.id,
-            resource_owner_id: resource_owner.send(configuration.resource_owner_property),
+            resource_owner_id: resource_owner.to_param,
             scopes: pre_auth.scopes.to_s,
             expires_in: configuration.access_token_expires_in,
             use_refresh_token: false

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -11,11 +11,6 @@ Doorkeeper.configure do
     #   User.find_by_id(session[:user_id]) || redirect_to(new_user_session_url)
   end
 
-  # The field that will be used for the resource_owner identification
-  # Default we use the id field but its also possible to use another field (uid for example)
-  # This allows to use multiple user models with doorkeeper
-  # resource_owner_property :id
-
   # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
   # admin_authenticator do
   #   # Put your admin authentication logic here.

--- a/script/run_all
+++ b/script/run_all
@@ -3,50 +3,41 @@ set -e
 
 echo "rails=3.2.8 orm=active_record"
 rails=3.2.8 orm=active_record bundle update --quiet
-rails=3.2.8 orm=active_record resource_owner_property=id bundle exec rake
-rails=3.2.8 orm=active_record resource_owner_property=uid bundle exec rake
+rails=3.2.8 orm=active_record bundle exec rake
 
 echo "rails=3.2.8 orm=mongoid2"
 rails=3.2.8 orm=mongoid2 bundle update --quiet
-rails=3.2.8 orm=mongoid2 resource_owner_property=id bundle exec rake
-rails=3.2.8 orm=mongoid2 resource_owner_property=uid bundle exec rake
+rails=3.2.8 orm=mongoid2 bundle exec rake
 
 echo "rails=3.2.8 orm=mongoid3"
 rails=3.2.8 orm=mongoid3 bundle update --quiet
-rails=3.2.8 orm=mongoid3 resource_owner_property=id bundle exec rake
-rails=3.2.8 orm=mongoid3 resource_owner_property=uid bundle exec rake
+rails=3.2.8 orm=mongoid3 bundle exec rake
 
 echo "rails=3.2.8 orm=mongo_mapper"
 rails=3.2.8 orm=mongo_mapper bundle update --quiet
-rails=3.2.8 orm=mongo_mapper resource_owner_property=id bundle exec rake
-rails=3.2.8 orm=mongo_mapper resource_owner_property=uid bundle exec rake
+rails=3.2.8 orm=mongo_mapper bundle exec rake
 
 echo "rails=3.2.19 orm=active_record"
 rails=3.2.19 orm=active_record bundle update --quiet
-rails=3.2.19 orm=active_record resource_owner_property=id bundle exec rake
-rails=3.2.19 orm=active_record resource_owner_property=uid bundle exec rake
+rails=3.2.19 orm=active_record bundle exec rake
 
 echo "rails=3.2.19 orm=mongoid2"
 rails=3.2.19 orm=mongoid2 bundle update --quiet
-rails=3.2.19 orm=mongoid2 resource_owner_property=id bundle exec rake
-rails=3.2.19 orm=mongoid2 resource_owner_property=uid bundle exec rake
+rails=3.2.19 orm=mongoid2 bundle exec rake
 
 echo "rails=3.2.19 orm=mongoid3"
 rails=3.2.19 orm=mongoid3 bundle update --quiet
-rails=3.2.19 orm=mongoid3 resource_owner_property=id bundle exec rake
-rails=3.2.19 orm=mongoid3 resource_owner_property=uid bundle exec rake
+rails=3.2.19 orm=mongoid3 bundle exec rake
 
 echo "rails=3.2.19 orm=mongo_mapper"
 rails=3.2.19 orm=mongo_mapper bundle update --quiet
-rails=3.2.19 orm=mongo_mapper resource_owner_property=id bundle exec rake
-rails=3.2.19 orm=mongo_mapper resource_owner_property=uid bundle exec rake
+rails=3.2.19 orm=mongo_mapper bundle exec rake
 
 echo "rails=4.1.4 orm=active_record"
 rails=4.1.4 orm=active_record bundle update --quiet
-rails=4.1.4 orm=active_record resource_owner_property=id bundle exec rake
-rails=4.1.4 orm=active_record resource_owner_property=uid bundle exec rake
+rails=4.1.4 orm=active_record bundle exec rake
 
 echo "rails=4.1.4 orm=mongoid4"
 rails=4.1.4 orm=mongoid4 bundle update --quiet
-rails=4.1.4 orm=mongoid4 resource_owner_property=id bundle exec rake
-rails=4.1.4 orm=mongoid4 resource_owner_property=uid bundle exec rake
+rails=4.1.4 orm=mongoid4 bundle exec rake
+

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -13,7 +13,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
   end
 
   let(:client) { FactoryGirl.create :application }
-  let(:user)   { User.create!(name: 'Joe', password: 'sekret', uid: '456154941321') }
+  let(:user)   { User.create!(name: 'Joe', password: 'sekret') }
 
   before do
     allow(controller).to receive(:current_resource_owner).and_return(user)
@@ -49,7 +49,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     end
 
     it 'issues the token for the current resource owner' do
-      expect(Doorkeeper::AccessToken.first.resource_owner_id.to_s).to eq(user.send(RESOURCE_OWNER_PROPERTY).to_s)
+      expect(Doorkeeper::AccessToken.first.resource_owner_id.to_s).to eq(user.to_param.to_s)
     end
   end
 
@@ -174,7 +174,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     end
 
     it 'issues the token for the current resource owner' do
-      expect(Doorkeeper::AccessToken.first.resource_owner_id.to_s).to eq(user.send(RESOURCE_OWNER_PROPERTY).to_s)
+      expect(Doorkeeper::AccessToken.first.resource_owner_id.to_s).to eq(user.to_param.to_s)
     end
   end
 

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -9,7 +9,6 @@ when :mongoid2, :mongoid3, :mongoid4
 
     field :name, type: String
     field :password, type: String
-    field :uid, type: String
   end
 when :mongo_mapper
   class User
@@ -18,13 +17,12 @@ when :mongo_mapper
 
     key :name,     String
     key :password, String
-    key :uid,      String
   end
 end
 
 class User
   if ::Rails.version.to_i < 4
-    attr_accessible :name, :password, :uid
+    attr_accessible :name, :password
   end
 
   def self.authenticate!(name, password)

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -11,11 +11,6 @@ Doorkeeper.configure do
     User.where(id: session[:user_id]).first || redirect_to(root_url, alert: 'Needs sign in.')
   end
 
-  # The field that will be used for the resource_owner identification
-  # Default we use the id field but its also possible to use another field (uid for example)
-  # This allows to use multiple user models with doorkeeper
-  resource_owner_property :uid
-
   # If you want to restrict the access to the web interface for
   # adding oauth authorized applications you need to declare the
   # block below

--- a/spec/dummy/db/migrate/20120312140401_add_password_to_users.rb
+++ b/spec/dummy/db/migrate/20120312140401_add_password_to_users.rb
@@ -1,6 +1,5 @@
 class AddPasswordToUsers < ActiveRecord::Migration
   def change
     add_column :users, :password, :string
-    add_column :users, :uid, :string
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -60,7 +60,6 @@ ActiveRecord::Schema.define(version: 20130902175349) do
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
     t.string   'password'
-    t.string   'uid'
   end
 
 end

--- a/spec/factories/access_grant.rb
+++ b/spec/factories/access_grant.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :access_grant, class: Doorkeeper::AccessGrant do
-    sequence(:resource_owner_id) { |n| n }
+    sequence(:resource_owner_id) { |n| "#{n}" }
     application
     redirect_uri 'https://app.com/callback'
     expires_in 100

--- a/spec/factories/access_token.rb
+++ b/spec/factories/access_token.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :access_token, class: Doorkeeper::AccessToken do
-    sequence(:resource_owner_id) { |n| n }
+    sequence(:resource_owner_id) { |n| "#{n}" }
     application
     expires_in 2.hours
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper_integration'
 describe Doorkeeper, 'configuration' do
   subject { Doorkeeper.configuration }
 
-  before(:each) do
-    Doorkeeper.configuration.stub(:resource_owner_property).and_call_original
-  end
-
   describe 'resource_owner_authenticator' do
     it 'sets the block that is accessible via authenticate_resource_owner' do
       block = proc {}
@@ -176,20 +172,6 @@ describe Doorkeeper, 'configuration' do
   describe 'wildcard_redirect_uri' do
     it 'is disabled by default' do
       Doorkeeper.configuration.wildcard_redirect_uri.should be_falsey
-    end
-  end
-
-  describe 'resource_owner_property' do
-    it 'is \':id\' by default' do
-      expect(Doorkeeper.configuration.resource_owner_property).to eq(:id)
-    end
-
-    it 'can change the value' do
-      Doorkeeper.configure do
-        orm DOORKEEPER_ORM
-        resource_owner_property :uid
-      end
-      expect(subject.resource_owner_property).to eq(:uid)
     end
   end
 

--- a/spec/lib/oauth/code_request_spec.rb
+++ b/spec/lib/oauth/code_request_spec.rb
@@ -14,7 +14,7 @@ module Doorkeeper::OAuth
       )
     end
 
-    let(:owner) { double :owner, id: 8900, uid: "45951213" }
+    let(:owner) { double :owner, id: 8900 }
 
     subject do
       CodeRequest.new(pre_auth, owner)

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -5,11 +5,7 @@ module Doorkeeper::OAuth
     let(:server) { double :server, default_scopes: Doorkeeper::OAuth::Scopes.new, access_token_expires_in: 2.hours, refresh_token_enabled?: false }
     let(:credentials) { Client::Credentials.new(client.uid, client.secret) }
     let(:client) { FactoryGirl.create(:application) }
-    let(:owner)  { double :owner, id: 99, uid: '1564631897' }
-
-    before(:each) do
-      Doorkeeper.configuration.stub(:resource_owner_property).and_return(:uid)
-    end
+    let(:owner)  { double :owner, id: 99 }
 
     subject do
       PasswordAccessTokenRequest.new(server, credentials, owner)
@@ -49,7 +45,7 @@ module Doorkeeper::OAuth
     end
 
     it 'creates token even when there is already one (default)' do
-      FactoryGirl.create(:access_token, application_id: client.id, resource_owner_id: owner.uid)
+      FactoryGirl.create(:access_token, application_id: client.id, resource_owner_id: owner.to_param)
       expect do
         subject.authorize
       end.to change { Doorkeeper::AccessToken.count }.by(1)
@@ -57,8 +53,7 @@ module Doorkeeper::OAuth
 
     it 'skips token creation if there is already one' do
       Doorkeeper.configuration.stub(:reuse_access_token).and_return(true)
-      Doorkeeper.configuration.stub(:resource_owner_property).and_return(:uid)
-      FactoryGirl.create(:access_token, application_id: client.id, resource_owner_id: owner.uid)
+      FactoryGirl.create(:access_token, application_id: client.id, resource_owner_id: owner.to_param)
       expect do
         subject.authorize
       end.to_not change { Doorkeeper::AccessToken.count }

--- a/spec/lib/oauth/token_request_spec.rb
+++ b/spec/lib/oauth/token_request_spec.rb
@@ -15,7 +15,7 @@ module Doorkeeper::OAuth
     end
 
     let :owner do
-      double :owner, id: 7866, uid: "12495415613"
+      double :owner, id: 7866
     end
 
     subject do

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -52,11 +52,7 @@ module Doorkeeper
 
       context 'with default parameters' do
 
-        if RESOURCE_OWNER_PROPERTY == 'id'
-          let(:resource_owner_id) { 100 }
-        else
-          let(:resource_owner_id) { "124651321" }
-        end
+        let(:resource_owner_id) { "100" }
         let(:application)    { FactoryGirl.create :application }
         let(:default_attributes) do
           { application: application, resource_owner_id: resource_owner_id }
@@ -130,10 +126,10 @@ module Doorkeeper
     end
 
     describe '.revoke_all_for' do
-      let(:resource_owner) { double(id: 100, uid: "126498132") }
+      let(:resource_owner) { double(to_param: 100) }
       let(:application)    { FactoryGirl.create :application }
       let(:default_attributes) do
-        { application: application, resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY) }
+        { application: application, resource_owner_id: resource_owner.to_param }
       end
 
       it 'revokes all tokens for given application and resource owner' do
@@ -158,11 +154,7 @@ module Doorkeeper
     end
 
     describe '.matching_token_for' do
-      if RESOURCE_OWNER_PROPERTY == 'id'
-        let(:resource_owner_id) { 100 }
-      else
-        let(:resource_owner_id) { "124651321" }
-      end
+      let(:resource_owner_id) { '100' }
       let(:application)       { FactoryGirl.create :application }
       let(:scopes)            { Doorkeeper::OAuth::Scopes.from_string('public write') }
       let(:default_attributes) do
@@ -176,7 +168,7 @@ module Doorkeeper
       end
 
       it 'accepts resource owner as object' do
-        resource_owner = double(to_key: true, id: 100, uid: "124651321")
+        resource_owner = double(to_param: 100)
         token = FactoryGirl.create :access_token, default_attributes
         last_token = AccessToken.matching_token_for(application, resource_owner, scopes)
         expect(last_token).to eq(token)

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -127,33 +127,33 @@ module Doorkeeper
     end
 
     describe :authorized_for do
-      let(:resource_owner) { double(:resource_owner, id: 10, uid: "1234561321695") }
+      let(:resource_owner) { double(:resource_owner, id: 10) }
 
       it 'is empty if the application is not authorized for anyone' do
         expect(Application.authorized_for(resource_owner)).to be_empty
       end
 
       it 'returns only application for a specific resource owner' do
-        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY).to_s + "1")
-        token = FactoryGirl.create(:access_token, resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY))
+        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.to_param.to_s + "1")
+        token = FactoryGirl.create(:access_token, resource_owner_id: resource_owner.to_param)
         expect(Application.authorized_for(resource_owner)).to eq([token.application])
       end
 
       it 'excludes revoked tokens' do
-        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY), revoked_at: 2.days.ago)
+        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.to_param, revoked_at: 2.days.ago)
         expect(Application.authorized_for(resource_owner)).to be_empty
       end
 
       it 'returns all applications that have been authorized' do
-        token1 = FactoryGirl.create(:access_token, resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY))
-        token2 = FactoryGirl.create(:access_token, resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY))
+        token1 = FactoryGirl.create(:access_token, resource_owner_id: resource_owner.to_param)
+        token2 = FactoryGirl.create(:access_token, resource_owner_id: resource_owner.to_param)
         expect(Application.authorized_for(resource_owner)).to eq([token1.application, token2.application])
       end
 
       it 'returns only one application even if it has been authorized twice' do
         application = FactoryGirl.create(:application)
-        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY), application: application)
-        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY), application: application)
+        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.to_param, application: application)
+        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.to_param, application: application)
         expect(Application.authorized_for(resource_owner)).to eq([application])
       end
 

--- a/spec/requests/applications/authorized_applications_spec.rb
+++ b/spec/requests/applications/authorized_applications_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_integration'
 
 feature 'Authorized applications' do
   background do
-    @user   = User.create!(name: 'Joe', password: 'sekret', uid: '12315679132')
+    @user   = User.create!(name: 'Joe', password: 'sekret')
     @client = client_exists(name: 'Amazing Client App')
     resource_owner_is_authenticated @user
     client_is_authorized @client, @user
@@ -15,7 +15,7 @@ feature 'Authorized applications' do
 
   scenario 'do not display other user\'s authorized applications' do
     client = client_exists(name: 'Another Client App')
-    client_is_authorized client, User.create!(name: 'Joe', password: 'sekret', uid: '15412')
+    client_is_authorized client, User.create!(name: 'Joe', password: 'sekret')
     visit '/oauth/authorized_applications'
     i_should_not_see 'Another Client App'
   end

--- a/spec/requests/flows/refresh_token_spec.rb
+++ b/spec/requests/flows/refresh_token_spec.rb
@@ -74,7 +74,7 @@ feature 'Refresh Token Flow' do
       # enable password auth to simulate other devices
       config_is_set(:resource_owner_from_credentials) { User.authenticate! params[:username], params[:password] }
       create_resource_owner
-      @token = FactoryGirl.create(:access_token, application: @client, resource_owner_id: @resource_owner.send(RESOURCE_OWNER_PROPERTY), use_refresh_token: true)
+      @token = FactoryGirl.create(:access_token, application: @client, resource_owner_id: @resource_owner.to_param, use_refresh_token: true)
     end
 
     scenario 'client request a token after creating another token with the same user' do

--- a/spec/requests/flows/revoke_token_spec.rb
+++ b/spec/requests/flows/revoke_token_spec.rb
@@ -13,7 +13,7 @@ feature 'Revoke Token Flow' do
     let(:authorization_access_token) do
       FactoryGirl.create(:access_token,
                          application: client_application,
-                         resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY),
+                         resource_owner_id: resource_owner.to_param,
                          use_refresh_token: true)
     end
 
@@ -72,7 +72,7 @@ feature 'Revoke Token Flow' do
       let(:token_to_revoke) do
         FactoryGirl.create(:access_token,
                            application: client_application,
-                           resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY),
+                           resource_owner_id: resource_owner.to_param,
                            use_refresh_token: true)
       end
 
@@ -97,7 +97,7 @@ feature 'Revoke Token Flow' do
       let(:token_to_revoke) do
         FactoryGirl.create(:access_token,
                            application: other_client_application,
-                           resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY),
+                           resource_owner_id: resource_owner.to_param,
                            use_refresh_token: true)
       end
 
@@ -117,11 +117,11 @@ feature 'Revoke Token Flow' do
     end
     context 'The access token to revoke app is the same than the authorization access token' do
 
-      let(:other_resource_owner) { User.create!(name: 'Matheo', password: 'pareto', uid: '13156132023') }
+      let(:other_resource_owner) { User.create!(name: 'Matheo', password: 'pareto') }
       let(:token_to_revoke) do
         FactoryGirl.create(:access_token,
                            application: client_application,
-                           resource_owner_id: other_resource_owner.send(RESOURCE_OWNER_PROPERTY),
+                           resource_owner_id: other_resource_owner.to_param,
                            use_refresh_token: true)
       end
 
@@ -145,7 +145,7 @@ feature 'Revoke Token Flow' do
       let(:token_to_revoke) do
         FactoryGirl.create(:access_token,
                            application: client_application,
-                           resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY),
+                           resource_owner_id: resource_owner.to_param,
                            use_refresh_token: true)
       end
 

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -2,7 +2,6 @@ ENV['RAILS_ENV'] ||= 'test'
 DOORKEEPER_ORM = (ENV['orm'] || :active_record).to_sym
 TABLE_NAME_PREFIX = ENV['table_name_prefix'] || nil
 TABLE_NAME_SUFFIX = ENV['table_name_suffix'] || nil
-RESOURCE_OWNER_PROPERTY = ENV['resource_owner_property'] || 'id'
 
 $LOAD_PATH.unshift File.dirname(__FILE__)
 
@@ -38,7 +37,6 @@ RSpec.configure do |config|
   config.before do
     DatabaseCleaner.start
     Doorkeeper.configure { orm DOORKEEPER_ORM }
-    Doorkeeper.configuration.stub(:resource_owner_property).and_return(RESOURCE_OWNER_PROPERTY)
   end
 
   config.after do

--- a/spec/support/helpers/access_token_request_helper.rb
+++ b/spec/support/helpers/access_token_request_helper.rb
@@ -2,7 +2,7 @@ module AccessTokenRequestHelper
   def client_is_authorized(client, resource_owner, access_token_attributes = {})
     attributes = {
       application: client,
-      resource_owner_id: resource_owner.send(RESOURCE_OWNER_PROPERTY)
+      resource_owner_id: resource_owner.to_param
     }.merge(access_token_attributes)
     FactoryGirl.create(:access_token, attributes)
   end

--- a/spec/support/helpers/authorization_request_helper.rb
+++ b/spec/support/helpers/authorization_request_helper.rb
@@ -1,6 +1,6 @@
 module AuthorizationRequestHelper
   def resource_owner_is_authenticated(resource_owner = nil)
-    resource_owner ||= User.create!(name: 'Joe', password: 'sekret', uid: '12315679132')
+    resource_owner ||= User.create!(name: 'Joe', password: 'sekret')
     Doorkeeper.configuration.instance_variable_set(:@authenticate_resource_owner, proc { resource_owner })
   end
 

--- a/spec/support/helpers/model_helper.rb
+++ b/spec/support/helpers/model_helper.rb
@@ -4,7 +4,7 @@ module ModelHelper
   end
 
   def create_resource_owner
-    @resource_owner = User.create!(name: 'Joe', password: 'sekret', uid: '12316515613')
+    @resource_owner = User.create!(name: 'Joe', password: 'sekret')
   end
 
   def authorization_code_exists(options = {})
@@ -14,13 +14,13 @@ module ModelHelper
   def access_grant_should_exist_for(client, resource_owner)
     grant = Doorkeeper::AccessGrant.first
     expect(grant.application).to eq(client)
-    grant.resource_owner_id  == resource_owner.send(RESOURCE_OWNER_PROPERTY)
+    grant.resource_owner_id  == resource_owner.to_param
   end
 
   def access_token_should_exist_for(client, resource_owner)
     grant = Doorkeeper::AccessToken.first
     expect(grant.application).to eq(client)
-    grant.resource_owner_id  == resource_owner.send(RESOURCE_OWNER_PROPERTY)
+    grant.resource_owner_id  == resource_owner.to_param
   end
 
   def access_grant_should_not_exist


### PR DESCRIPTION
This PR allows the user to specify the property that will be used as the `resource_owner_uid`. By default this was the resource_owner.id property but when multiple user models from different databases are used, this can result in conflicts. This PR solves this by letting the user decide which property to use as the unique identifier of the resource owner.

For example with two different user models this can be a secure random hex that garanties uniqueness over two different tables (Admin and Users).

In the initialiser the `resource_owner_property` defaults to `:id` but can be changes to any property on the resource_owner object (for example `:uid`). This makes sure there are no braking changes with previous versions/implementations.

The code is also change to reflect this, in different places `resource_owner.id` was called, this is being changed to either `resource_owner` (lower level methods that then extract the correct property to be used as `resource_owner_uid`) or `resource_owner.send(Doorkeeper.configure.resource_owner_property)`.

At the moment all the specs pass on ruby 2.1.2 with rails 3.2.8/3.2.19/4.1.4 for active_record, mongoid2, mongoid3 and mongoid4. A new command parameter is added called `resource_owner_property` so all the specs can be run with either the default `:id` property or `:uid` property.

**I still need some help with mongo_mapper, I don't have any experience and the specs are failing so if anybody can help, that would be awesome!**
