### PR TITLE
Testing ways to handle nonce

### DIFF
--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -6,6 +6,10 @@ module Doorkeeper
       if pre_auth.authorizable?
         if Doorkeeper::AccessToken.matching_token_for(pre_auth.client, current_resource_owner.id, pre_auth.scopes) || skip_authorization?
           auth = authorization.authorize
+          # This is sure to break things
+          if params['nonce'] && auth.auth.resource_owner.respond_to?(:nonce)
+            auth.auth.resource_owner.update_attributes!(nonce: params['nonce'])
+          end
           redirect_to auth.redirect_uri
         else
           render :new


### PR DESCRIPTION
Didn't break any specs but I'm _sure_ there's a better way to do this and that the resource_owner isn't the place to be storing the nonce in the first place. Looking for ideas.

Working on https://github.com/playon/doorkeeper-openid_connect and trying to support clients who expect a nonce sent back. 

From the [OpenID Connect spec](http://openid.net/specs/openid-connect-core-1_0.html#IDToken)

> nonce
>    String value used to associate a Client session with an ID Token, and to mitigate replay attacks. The value is passed through unmodified from the Authentication Request to the ID Token. If present in the ID Token, Clients MUST verify that the nonce Claim Value is equal to the value of the nonce parameter sent in the Authentication Request. If present in the Authentication Request, Authorization Servers MUST include a nonce Claim in the ID Token with the Claim Value being the nonce value sent in the Authentication Request. Authorization Servers SHOULD perform no other processing on nonce values used. The nonce value is a case sensitive string. 

So, in short, the client sends a nonce param in the authorization request. Later in the flow during the token request, the provider sends back the nonce in it's response.
