### PR TITLE
Allowed the Implicit grant flow to reuse access tokens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#450] When password is invalid in Password Credentials Grant, Doorkeeper
   returned 'invalid_resource_owner' instead of 'invalid_grant', as the spec
   declares. Fixes [#444].
+- [#480] For Implicit grant flow, access tokens are now being able to be reused. Fixes [#421].
 
 ## 1.4.0
 

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -10,12 +10,12 @@ module Doorkeeper
         end
 
         def issue_token
-          @token ||= AccessToken.create!(
-            application_id: pre_auth.client.id,
-            resource_owner_id: resource_owner.id,
-            scopes: pre_auth.scopes.to_s,
-            expires_in: configuration.access_token_expires_in,
-            use_refresh_token: false
+          @token ||= AccessToken.find_or_create_for(
+              pre_auth.client,
+              resource_owner.id,
+              pre_auth.scopes,
+              configuration.access_token_expires_in,
+              false
           )
         end
 

--- a/spec/lib/oauth/token_request_spec.rb
+++ b/spec/lib/oauth/token_request_spec.rb
@@ -8,7 +8,7 @@ module Doorkeeper::OAuth
         client: double(:application, id: 9990),
         redirect_uri: 'http://tst.com/cb',
         state: nil,
-        scopes: nil,
+        scopes: Scopes.from_string('public'),
         error: nil,
         authorizable?: true
       )
@@ -42,6 +42,33 @@ module Doorkeeper::OAuth
     it 'returns a error response' do
       allow(pre_auth).to receive(:authorizable?).and_return(false)
       expect(subject.authorize).to be_a(ErrorResponse)
+    end
+
+    context 'token reuse' do
+      it 'creates a new token if there are no matching tokens' do
+        Doorkeeper.configuration.stub(:reuse_access_token).and_return(true)
+        expect do
+          subject.authorize
+        end.to change { Doorkeeper::AccessToken.count }.by(1)
+      end
+
+      it 'creates a new token if scopes do not match' do
+        Doorkeeper.configuration.stub(:reuse_access_token).and_return(true)
+        FactoryGirl.create(:access_token, application_id: pre_auth.client.id,
+                           resource_owner_id: owner.id, scopes: '')
+        expect do
+          subject.authorize
+        end.to change { Doorkeeper::AccessToken.count }.by(1)
+      end
+
+      it 'skips token creation if there is a matching one' do
+        Doorkeeper.configuration.stub(:reuse_access_token).and_return(true)
+        FactoryGirl.create(:access_token, application_id: pre_auth.client.id,
+                           resource_owner_id: owner.id, scopes: 'public')
+        expect do
+          subject.authorize
+        end.to_not change { Doorkeeper::AccessToken.count }
+      end
     end
   end
 end


### PR DESCRIPTION
It allows the Implicit grant flow to reuse access tokens. This fixes issue #421.
Feedback or improvements are welcome.
However the only flow that does not support token reuse is client credential flow. Should this flow also be supported to reuse its token?
