### PR TITLE
Customize token flow OAuth expirations with a config lambda

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -172,27 +172,29 @@ and that your `initialize_models!` method doesn't raise any errors.\n
 
     option :resource_owner_authenticator,
            as: :authenticate_resource_owner,
-           default: (lambda do |routes|
+           default: (lambda do |_routes|
              logger.warn(I18n.translate('doorkeeper.errors.messages.resource_owner_authenticator_not_configured'))
              nil
            end)
     option :admin_authenticator,
            as: :authenticate_admin,
-           default: ->(routes) {}
+           default: ->(_routes) {}
     option :resource_owner_from_credentials,
-           default: (lambda do |routes|
+           default: (lambda do |_routes|
              warn(I18n.translate('doorkeeper.errors.messages.credential_flow_not_configured'))
              nil
            end)
-    option :skip_authorization,            default: ->(routes) {}
-    option :access_token_expires_in,       default: 7200
-    option :authorization_code_expires_in, default: 600
-    option :orm,                           default: :active_record
-    option :native_redirect_uri,           default: 'urn:ietf:wg:oauth:2.0:oob'
-    option :active_record_options,         default: {}
-    option :realm,                         default: 'Doorkeeper'
-    option :force_ssl_in_redirect_uri,     default: !Rails.env.development?
-    option :grant_flows,                   default: %w(authorization_code client_credentials)
+
+    option :skip_authorization,             default: ->(_routes) {}
+    option :access_token_expires_in,        default: 7200
+    option :custom_access_token_expires_in, default: lambda { |_app| nil }
+    option :authorization_code_expires_in,  default: 600
+    option :orm,                            default: :active_record
+    option :native_redirect_uri,            default: 'urn:ietf:wg:oauth:2.0:oob'
+    option :active_record_options,          default: {}
+    option :realm,                          default: 'Doorkeeper'
+    option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
+    option :grant_flows,                    default: %w(authorization_code client_credentials)
 
     attr_reader :reuse_access_token
 

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -11,11 +11,11 @@ module Doorkeeper
 
         def issue_token
           @token ||= AccessToken.find_or_create_for(
-              pre_auth.client,
-              resource_owner.id,
-              pre_auth.scopes,
-              configuration.access_token_expires_in,
-              false
+            pre_auth.client,
+            resource_owner.id,
+            pre_auth.scopes,
+            expiration,
+            false
           )
         end
 
@@ -29,6 +29,17 @@ module Doorkeeper
 
         def configuration
           Doorkeeper.configuration
+        end
+
+        def expiration
+          self.class.access_token_expires_in(configuration, pre_auth)
+        end
+
+        def self.access_token_expires_in(server, pre_auth)
+          custom_expiration = server.
+            custom_access_token_expires_in.call(pre_auth)
+          return custom_expiration if custom_expiration
+          server.access_token_expires_in
         end
       end
     end

--- a/lib/doorkeeper/oauth/request_concern.rb
+++ b/lib/doorkeeper/oauth/request_concern.rb
@@ -34,7 +34,7 @@ module Doorkeeper
           client,
           resource_owner_id,
           scopes,
-          server.access_token_expires_in,
+          Authorization::Token.access_token_expires_in(server, client),
           server.refresh_token_enabled?)
       end
 

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -26,6 +26,11 @@ Doorkeeper.configure do
   # If you want to disable expiration, set this to nil.
   # access_token_expires_in 2.hours
 
+  # Assign a custom TTL for implicit grants.
+  # custom_access_token_expires_in do |oauth_client|
+  #   oauth_client.application.additional_settings.implicit_oauth_expiration
+  # end
+
   # Reuse access token for the same resource owner within an application (disabled by default)
   # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
   # reuse_access_token

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -2,7 +2,12 @@ require 'spec_helper_integration'
 
 module Doorkeeper::OAuth
   describe AuthorizationCodeRequest do
-    let(:server) { double :server, access_token_expires_in: 2.days, refresh_token_enabled?: false }
+    let(:server) do
+      double :server,
+             access_token_expires_in: 2.days,
+             refresh_token_enabled?: false,
+             custom_access_token_expires_in: ->(_app) { nil }
+    end
     let(:grant)  { FactoryGirl.create :access_grant }
     let(:client) { grant.application }
 

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -7,7 +7,8 @@ module Doorkeeper::OAuth
         :server,
         default_scopes: Doorkeeper::OAuth::Scopes.new,
         access_token_expires_in: 2.hours,
-        refresh_token_enabled?: false
+        refresh_token_enabled?: false,
+        custom_access_token_expires_in: ->(_app) { nil }
       )
     end
     let(:credentials) { Client::Credentials.new(client.uid, client.secret) }

--- a/spec/lib/oauth/token_request_spec.rb
+++ b/spec/lib/oauth/token_request_spec.rb
@@ -48,6 +48,26 @@ module Doorkeeper::OAuth
       expect(subject.authorize).to be_a(ErrorResponse)
     end
 
+    context 'with custom expirations' do
+      let(:custom_ttl) { 1233 }
+
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          custom_access_token_expires_in do |_oauth_client|
+            # The RSpec scope isn't available in here
+            1233
+          end
+        end
+      end
+
+      it 'should use the custom ttl' do
+        subject.authorize
+        token = Doorkeeper::AccessToken.first
+        expect(token.expires_in).to eq(custom_ttl)
+      end
+    end
+
     context 'token reuse' do
       it 'creates a new token if there are no matching tokens' do
         Doorkeeper.configuration.stub(:reuse_access_token).and_return(true)


### PR DESCRIPTION
At NationBuilder, we assign a custom expiration to access tokens derived from token-based OAuth. We do this because our authorization code tokens tend to have very high expirations, while our token-based access tokens have very short ones. This pull request solves this problem for us by enabling the user to define an expiration on each app. Since we placed this configuration option inside of a lambda, it could also dynamically customized to vary in different ways.

-David