### PR TITLE
Add fix to Request::AuthorizationCode to use client from uid

### DIFF
--- a/lib/doorkeeper/request/authorization_code.rb
+++ b/lib/doorkeeper/request/authorization_code.rb
@@ -2,7 +2,17 @@ module Doorkeeper
   module Request
     class AuthorizationCode
       def self.build(server)
-        new(server.grant, server.client, server)
+        new(server.grant, client(server), server)
+      end
+
+      # If the credentials are present, use it to authenticate the client.
+      # if not, use only the uid to fetch the client.
+      def self.client(server)
+        if server.credentials.present?
+          server.client
+        else
+          server.client_via_uid
+        end
       end
 
       attr_accessor :grant, :client, :server


### PR DESCRIPTION
According to http://tools.ietf.org/html/rfc6749#section-4.1.3 the `client_secret` attribute is not required when using the authorization_code grant. Only the uid and the redirect_uri are validated on AccessToken creation.

I opened an issue regarding this code changes: #482
