### PR TITLE
bump version to 2.0.0.alpha

### DIFF
--- a/lib/doorkeeper/version.rb
+++ b/lib/doorkeeper/version.rb
@@ -1,3 +1,3 @@
 module Doorkeeper
-  VERSION = '1.4.0'
+  VERSION = '2.0.0.alpha1'
 end


### PR DESCRIPTION
Bump version to `2.0.0.alpha`

`gem 'doorkeeper', '~> 1', github: 'doorkeeper-gem/doorkeeper'` will prevent upgrade to the edge version which would broken API.
