### PR TITLE
follow maintaining versions of Ruby and Rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.0
   - 2.1
 env:
-  - rails=3.1.12
   - rails=3.2.18
   - rails=4.0.5
   - rails=4.1.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # Defaults. For supported versions check .travis.yml
-ENV['rails'] ||= ENV['orm'] == "mongoid4" ? '4.1.0' : '3.2.0'
-ENV['orm']   ||= 'active_record'
+ENV['orm'] ||= 'active_record'
+ENV['rails'] ||= %w(active_record mongoid4).include?(ENV['orm']) ? '4.1' : '3.2'
 
 source 'https://rubygems.org'
 
@@ -27,6 +27,9 @@ when 'mongoid4'
 when 'mongo_mapper'
   gem 'mongo_mapper', '~> 0.12'
   gem 'bson_ext', '~> 1.7'
+
+else
+  fail "Invalid ENV['orm']: #{ENV['orm']}."
 
 end
 


### PR DESCRIPTION
Rails 3.1 is outdated and no longer supported and Rails 4.2 will release soon.
Also Ruby 1.9.3 will end on February 23, 2015 and Ruby 2.2 will release in few months.

I suggest Doorkeeper focusing testing and supporting maintaining versions of Ruby and Rails, that will make our Travis-CI faster.
This PR upgrade default development environment to Rails 4.1, and Travis-CI no longer test Rails 3.1(although Doorkeeper works well with it).
