### PR TITLE
Add responders as a dependency

### DIFF
--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "railties", ">= 3.1"
+  s.add_dependency "responders", "~> 2.0"
 
   s.add_development_dependency "sqlite3", "~> 1.3.5"
   s.add_development_dependency "rspec-rails", "~> 2.99.0"


### PR DESCRIPTION
This is a fix for #494. In Rails 4.2 `respond_with` has been moved into the [responders gem](http://edgeguides.rubyonrails.org/4_2_release_notes.html#respond-with-class-level-respond-to) and this pull request adds the responders gem as a dependency.
