### PR TITLE
Add `protect_from_forgery` to turn on Rails' built-in protection

### DIFF
--- a/app/controllers/doorkeeper/application_controller.rb
+++ b/app/controllers/doorkeeper/application_controller.rb
@@ -2,6 +2,12 @@ module Doorkeeper
   class ApplicationController < ActionController::Base
     include Helpers::Controller
 
+    if ::Rails.version.to_i < 4
+      protect_from_forgery
+    else
+      protect_from_forgery with: :exception
+    end
+
     helper 'doorkeeper/dashboard'
   end
 end

--- a/spec/requests/endpoints/authorization_spec.rb
+++ b/spec/requests/endpoints/authorization_spec.rb
@@ -51,4 +51,27 @@ feature 'Authorization endpoint' do
       i_should_see_translated_error_message :unsupported_response_type
     end
   end
+
+  context 'forgery protection enabled' do
+    before do
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = false
+    end
+
+    background do
+      create_resource_owner
+      sign_in
+    end
+
+    scenario 'raises exception on forged requests' do
+      ActionController::Base.any_instance.should_receive(:handle_unverified_request)
+      post "/oauth/authorize",
+        client_id:      @client.uid,
+        redirect_uri:   @client.redirect_uri,
+        response_type:  'code'
+    end
+  end
 end


### PR DESCRIPTION
Since the Doorkeeper controllers inherit from Doorkeeper::Application (which inherits directly from ActionController::Base) and not ApplicationController, they never call `protect_from_forgery`, which means that non-GET methods don’t validate CSRF tokens. Thus, it’s possible for an attacker to host a form on an arbitrary URL, and if a users is logged into a site that uses Doorkeeper visits the URL, the attacker can grant access to a application on that site.
