### PR TITLE
Guarantee consistent state when changing config.

### DIFF
--- a/spec/requests/endpoints/authorization_spec.rb
+++ b/spec/requests/endpoints/authorization_spec.rb
@@ -53,14 +53,6 @@ feature 'Authorization endpoint' do
   end
 
   context 'forgery protection enabled' do
-    before do
-      ActionController::Base.allow_forgery_protection = true
-    end
-
-    after do
-      ActionController::Base.allow_forgery_protection = false
-    end
-
     background do
       create_resource_owner
       sign_in
@@ -68,10 +60,12 @@ feature 'Authorization endpoint' do
 
     scenario 'raises exception on forged requests' do
       ActionController::Base.any_instance.should_receive(:handle_unverified_request)
-      post "/oauth/authorize",
-        client_id:      @client.uid,
-        redirect_uri:   @client.redirect_uri,
-        response_type:  'code'
+      allowing_forgery_protection do
+        post "/oauth/authorize",
+          client_id:      @client.uid,
+          redirect_uri:   @client.redirect_uri,
+          response_type:  'code'
+      end
     end
   end
 end

--- a/spec/support/helpers/authorization_request_helper.rb
+++ b/spec/support/helpers/authorization_request_helper.rb
@@ -27,6 +27,15 @@ module AuthorizationRequestHelper
   def i_should_be_on_client_callback(client)
     expect(client.redirect_uri).to eq("#{current_uri.scheme}://#{current_uri.host}#{current_uri.path}")
   end
+
+  def allowing_forgery_protection(&block)
+    _original_value = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+
+    block.call
+  ensure
+    ActionController::Base.allow_forgery_protection = _original_value
+  end
 end
 
 RSpec.configuration.send :include, AuthorizationRequestHelper, type: :request


### PR DESCRIPTION
When changing application configuration options for test runs, I've found it's best to do it in a way that ensures the original state is rolled back to no matter what.

This refactoring guarantees the application is not left in an inconsistent state in case an error is raised during the test run - more specifically as part of the call to `post "/oauth/authorize..."`.
