### PR TITLE
Adds CSRF protection to ApplicationMetalController

### DIFF
--- a/app/controllers/doorkeeper/application_metal_controller.rb
+++ b/app/controllers/doorkeeper/application_metal_controller.rb
@@ -6,11 +6,18 @@ module Doorkeeper
       AbstractController::Rendering,
       ActionController::Rendering,
       ActionController::Renderers::All,
+      ActionController::RequestForgeryProtection,
       Helpers::Controller
     ]
 
     MODULES.each do |mod|
       include mod
+    end
+
+    if ::Rails.version.to_i < 4
+      protect_from_forgery
+    else
+      protect_from_forgery with: :exception
     end
   end
 end

--- a/spec/requests/endpoints/token_spec.rb
+++ b/spec/requests/endpoints/token_spec.rb
@@ -61,4 +61,20 @@ feature 'Token endpoint' do
     should_have_json 'error', 'invalid_request'
     should_have_json 'error_description', translated_error_message('invalid_request')
   end
+
+  context 'forgery protection enabled' do
+    before do
+      Doorkeeper::ApplicationMetalController.allow_forgery_protection = true
+    end
+
+    after do
+      Doorkeeper::ApplicationMetalController.allow_forgery_protection = false
+    end
+
+    scenario 'raises exception on forged requests' do
+      expect do
+        post token_endpoint_url(code: @authorization.token, client: @client)
+      end.to raise_error(ActionController::InvalidAuthenticityToken)
+    end
+  end
 end

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -50,4 +50,12 @@ RSpec.configure do |config|
   end
 
   config.order = 'random'
+
+  config.before do
+    Doorkeeper::ApplicationMetalController.allow_forgery_protection = false
+  end
+
+  config.after do
+    Doorkeeper::ApplicationMetalController.allow_forgery_protection = true
+  end
 end


### PR DESCRIPTION
Per c1b5c45e2c42c0191ca9f12a2836e31ee1a8de57, this adds forgery protection to
ApplicationMetalController - which is used by TokensController#create. As a result, it is possible
to phish access tokens through the password grant flow on a third party site.
