### PR TITLE
Failing specs for refresh tokens

### DIFF
--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -40,7 +40,7 @@ module Doorkeeper::OAuth
     it 'rejects revoked tokens' do
       refresh_token.revoke
       subject.validate
-      expect(subject.error).to eq(:invalid_request)
+      expect(subject.error).to eq(:invalid_grant)
     end
 
     it 'accepts expired tokens' do

--- a/spec/requests/flows/refresh_token_spec.rb
+++ b/spec/requests/flows/refresh_token_spec.rb
@@ -53,19 +53,17 @@ feature 'Refresh Token Flow' do
       expect(@token.reload).to be_revoked
     end
 
-    # TODO: verify proper error code for this (previously was invalid_grant)
     scenario 'client gets an error for invalid refresh token' do
       post refresh_token_endpoint_url(client: @client, refresh_token: 'invalid')
       should_not_have_json 'refresh_token'
-      should_have_json 'error', 'invalid_request'
+      should_have_json 'error', 'invalid_grant'
     end
 
-    # TODO: verify proper error code for this (previously was invalid_grant)
     scenario 'client gets an error for revoked acccess token' do
       @token.revoke
       post refresh_token_endpoint_url(client: @client, refresh_token: @token.refresh_token)
       should_not_have_json 'refresh_token'
-      should_have_json 'error', 'invalid_request'
+      should_have_json 'error', 'invalid_grant'
     end
   end
 


### PR DESCRIPTION
I tried to get these specs to pass but hit a wall. Here's a rough idea of my code

```ruby
module Doorkeeper
  module OAuth
    class RefreshTokenRequest
      include Validations
      include OAuth::RequestConcern
      include OAuth::Helpers

      validate :token_present, error: :invalid_request
      validate :token,        error: :invalid_grant
      validate :client,       error: :invalid_client
      validate :client_match, error: :invalid_grant
      validate :scope,        error: :invalid_scope
...
      def validate_token_present
        refresh_token.present?
      end
      
      def validate_token
        validate_token_present && !refresh_token.revoked?
      end
...
     end
  end
end

```

Depending on the order of the validate specs, a different test would fail. Any idea what the issue is?

Related PR: https://github.com/doorkeeper-gem/doorkeeper/issues/510.