### PR TITLE
Application has to be doorkeepers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enable by default `authorization_code` and `client_credentials` grant flows.
   Disables implicit and password grant flows by default.
 - [#510, #544, 722113f] Revoked refresh token response bugfix.
+- [#546] Doorkeeper::Application, fixes possible Application model conflict.
 
 ## 2.0.1
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -22,7 +22,7 @@ module Doorkeeper
         !Doorkeeper::Application.new.attributes.include?("scopes")
 
       puts <<-MSG.squish
-[doorkeeper] Missing column: `applications.scopes`.
+[doorkeeper] Missing column: `oauth_applications.scopes`.
 If you are using ActiveRecord run `rails generate doorkeeper:application_scopes
 && rake db:migrate` to add it.
       MSG

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -19,7 +19,7 @@ module Doorkeeper
   def self.check_for_missing_columns
     if Doorkeeper.configuration.orm == :active_record &&
         ActiveRecord::Base.connected? &&
-        !Application.new.attributes.include?("scopes")
+        !Doorkeeper::Application.new.attributes.include?("scopes")
 
       puts <<-MSG.squish
 [doorkeeper] Missing column: `applications.scopes`.


### PR DESCRIPTION
Is now referenced as Doorkeeper::Application, fixes possible Application model conflict. Also makes the error message if there actually is an error more descriptive and actionable.

Discussed in issue #546 