### PR TITLE
Remove Metal integration link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ https://github.com/doorkeeper-gem/doorkeeper/releases.
     - [Routes](#routes)
     - [Authenticating](#authenticating)
 - [Protecting resources with OAuth (a.k.a your API endpoint)](#protecting-resources-with-oauth-aka-your-api-endpoint)
-    - [ActionController::Metal integration](#actioncontrollermetal-integration)
     - [Route Constraints and other integrations](#route-constraints-and-other-integrations)
     - [Access Token Scopes](#access-token-scopes)
     - [Authenticated resource owner](#authenticated-resource-owner)


### PR DESCRIPTION
Removes unused link in README since the Metal integration information was modified and mostly removed in 977057fa40c3ca125.