### PR TITLE
Spike on configurable index settings for access token

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -94,6 +94,10 @@ and that your `initialize_models!` method doesn't raise any errors.\n
         @config.instance_variable_set('@refresh_token_enabled', true)
       end
 
+      def use_unique_refresh_token_index
+        @config.instance_variable_set('@use_unique_refresh_token_index', true)
+      end
+
       def realm(realm)
         @config.instance_variable_set('@realm', realm)
       end

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -16,7 +16,7 @@ module Doorkeeper
       validates :token, presence: true, uniqueness: true
       validates :refresh_token, uniqueness: true, if: :use_refresh_token?
 
-      attr_writer :use_refresh_token
+      attr_writer :use_refresh_token, :use_unique_refresh_token_index?
 
       if ::Rails.version.to_i < 4 || defined?(::ProtectedAttributes)
         attr_accessible :application_id, :resource_owner_id, :expires_in,
@@ -99,6 +99,10 @@ module Doorkeeper
 
     def use_refresh_token?
       !!@use_refresh_token
+    end
+
+    def use_unique_refresh_token_index?
+      !!@use_unique_refresh_token_index
     end
 
     def as_json(_options = {})


### PR DESCRIPTION
If you run mongo and the collection oauth_access_tokens is sharded the following index creation in access_token fails:

```ruby
index({ refresh_token: 1 }, { unique: true, sparse: true })
```

My idea here is to make this configurable exposing an initializer config like:

```ruby
#config 
use_unique_refresh_token_index #default to true 

##access_token_mixin
index({ refresh_token: 1 }, { unique: :use_unique_refresh_token_index? , sparse: true })
``` 

Btw I am having some hard time to understand how to push the config into the mixin. Any suggestion?





