### PR TITLE
added grape helper

### DIFF
--- a/lib/doorkeeper/grape/authorization_decorator.rb
+++ b/lib/doorkeeper/grape/authorization_decorator.rb
@@ -1,0 +1,17 @@
+module Doorkeeper
+  module Grape
+    class AuthorizationDecorator < SimpleDelegator
+      def parameters
+        params
+      end
+
+      def authorization
+        env = __getobj__.env
+        env['HTTP_AUTHORIZATION'] ||
+          env['X-HTTP_AUTHORIZATION'] ||
+          env['X_HTTP_AUTHORIZATION'] ||
+          env['REDIRECT_X_HTTP_AUTHORIZATION']
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/grape/helpers.rb
+++ b/lib/doorkeeper/grape/helpers.rb
@@ -1,0 +1,46 @@
+require 'doorkeeper/grape/authorization_decorator'
+
+module Doorkeeper
+  module Grape
+    module Helpers
+      extend ::Grape::API::Helpers
+      include Doorkeeper::Rails::Helpers
+
+      # endpoint specific scopes > parameter scopes > default scopes
+      def doorkeeper_authorize!(*scopes)
+        endpoint_scopes = env['api.endpoint'].options[:route_options][:scopes]
+        scopes = if endpoint_scopes
+                   Doorkeeper::OAuth::Scopes.from_array(endpoint_scopes)
+                 elsif scopes && !scopes.empty?
+                   Doorkeeper::OAuth::Scopes.from_array(scopes)
+                 end
+
+        super(*scopes)
+      end
+
+      def doorkeeper_render_error_with(error)
+        status_code = case error.status
+                      when :unauthorized
+                        401
+                      when :forbidden
+                        403
+                      end
+
+        error!({ error: error.description }, status_code)
+      end
+
+      private
+
+      def doorkeeper_token
+        @_doorkeeper_token ||= OAuth::Token.authenticate(
+          decorated_request,
+          *Doorkeeper.configuration.access_token_methods
+        )
+      end
+
+      def decorated_request
+        AuthorizationDecorator.new(request)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Proof of concept for #563.

Should not be merged yet, since it still has a few rough edges:
- I couldn't figure out how to get a array of scopes `[:private, :private_write]` into a comparable format for `valid_doorkeeper_token?(*scopes)`. The current implementation probably doesn't work well with multiple scopes.
- specs are missing
- currently only the `from_access_token_param` and `from_bearer_token_param` access_token methods work, sind `Grape::Request` doesn't provide a similiar method to `ActionDispatch::Request#authorization`

small code sample on how to use it:

```
require 'doorkeeper/grape/helpers'

module API
    class Base < Grape::API
       before do
          doorkeeper_authorize!
       end

       get '/', scopes: [:users] do
           @users = Users.all
       end
   end
end
```

