### PR TITLE
TokensController: Memoize strategy.authorize_response result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove `wildcard_redirect_url` option
 - [#481] Customize token flow OAuth expirations with a config lambda
+- [#568] TokensController: Memoize strategy.authorize_response result.
 
 
 ## 2.1.0

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -1,7 +1,7 @@
 module Doorkeeper
   class TokensController < Doorkeeper::ApplicationMetalController
     def create
-      response = strategy.authorize
+      response = authorize_response
       self.headers.merge! response.headers
       self.response_body = response.body.to_json
       self.status        = response.status
@@ -36,6 +36,10 @@ module Doorkeeper
 
     def strategy
       @strategy ||= server.token_request params[:grant_type]
+    end
+
+    def authorize_response
+      @authorize_response ||= strategy.authorize
     end
   end
 end

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -40,4 +40,18 @@ describe Doorkeeper::TokensController do
       expect(response.status).to eq 200
     end
   end
+
+  describe 'authorize response memoization' do
+    it "memoizes the result of the authorization" do
+      strategy = double(:strategy, authorize: true)
+      expect(strategy).to receive(:authorize).once
+      allow(controller).to receive(:strategy) { strategy }
+
+      controller.stub(:create) do
+        controller.send :authorize_response
+        controller.send :authorize_response
+      end
+      post :create
+    end
+  end
 end


### PR DESCRIPTION
This allows easy access to the authorize response in a subclass of Doorkeeper::TokensController.
Without this change, I had to user the following code to access the authorize response:

```ruby
strategy.request.instance_variable_get('@response')
```

If you accept this PR, I'll update the commit to include the CHANGELOG entry, I simply didn't want to add that if you think this PR should never get merged.
I'm not 100% satisfied with the spec I added, but at least it gets the job done (It's red without the change, and green with the change), let me know if you want to improve it.

Another alternative I had in mind was to return `response` from `TokensController#create`, but I thought memoizing the result was a better solution.

Let me know if you have any questions.