### PR TITLE
Fix relation "oauth_applications" does not exist

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -19,7 +19,9 @@ module Doorkeeper
   def self.check_for_missing_columns
     if Doorkeeper.configuration.orm == :active_record &&
         ActiveRecord::Base.connected? &&
-        ActiveRecord::Base.connection.table_exists?(Doorkeeper::Application.table_name) &&
+        ActiveRecord::Base.connection.table_exists?(
+          Doorkeeper::Application.table_name
+        ) &&
         !Doorkeeper::Application.new.attributes.include?("scopes")
 
       puts <<-MSG.squish

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -19,6 +19,7 @@ module Doorkeeper
   def self.check_for_missing_columns
     if Doorkeeper.configuration.orm == :active_record &&
         ActiveRecord::Base.connected? &&
+        ActiveRecord::Base.connection.table_exists?(Doorkeeper::Application.table_name) &&
         !Doorkeeper::Application.new.attributes.include?("scopes")
 
       puts <<-MSG.squish


### PR DESCRIPTION
This issue typically occurs on a CI when `bundle exec rake db:schema:load` is executed. To reproduce it locally run:

```
bundle exec rake db:drop && bundle exec rake db:create && bundle exec rake db:schema:load
```

The error happens because the initializer `doorkeeper.rb` is run before the table has been created.