### PR TITLE
Rescue ActiveRecord::StatementInvalid on migration

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -27,6 +27,8 @@ If you are using ActiveRecord run `rails generate doorkeeper:application_scopes
 && rake db:migrate` to add it.
       MSG
     end
+  rescue ActiveRecord::StatementInvalid
+    # trap error when DB is not yet setup
   end
 
   def self.enable_orm


### PR DESCRIPTION
- configuration runs during initialization which causes generator to fail
- seems this rescue was removed during this commit c0e25987efda8ea38c9351f4cb12a120e15f1b48