### PR TITLE
Revoke Refresh Token on access token use

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -187,9 +187,10 @@ and that your `initialize_models!` method doesn't raise any errors.\n
              warn(I18n.translate('doorkeeper.errors.messages.credential_flow_not_configured'))
              nil
            end)
-
     option :skip_authorization,             default: ->(_routes) {}
     option :access_token_expires_in,        default: 7200
+    option :refresh_token_revoked_in,       default: 0
+    option :refresh_token_revoked_on_use,   default: false
     option :custom_access_token_expires_in, default: lambda { |_app| nil }
     option :authorization_code_expires_in,  default: 600
     option :orm,                            default: :active_record

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -20,7 +20,7 @@ module Doorkeeper
 
       if ::Rails.version.to_i < 4 || defined?(::ProtectedAttributes)
         attr_accessible :application_id, :resource_owner_id, :expires_in,
-                        :scopes, :use_refresh_token
+                        :scopes, :use_refresh_token, :previous_refresh_token
       end
 
       before_validation :generate_token, on: :create

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -3,10 +3,29 @@ module Doorkeeper
     module Revocable
       def revoke(clock = DateTime)
         update_attribute :revoked_at, clock.now
+        Doorkeeper.configuration.refresh_token_revoked_on_use
+      end
+
+      def revoke_in(time)
+        update_attribute :revoked_at, (DateTime.now + time)
       end
 
       def revoked?
         !!(revoked_at && revoked_at <= DateTime.now)
+      end
+
+      def revoke_previous_refresh_token!
+        return if previous_refresh_token.nil?
+        old_refresh_token = AccessToken.by_refresh_token(previous_refresh_token)
+        old_refresh_token = nil if old_refresh_token.nil? or old_refresh_token.revoked?
+        if old_refresh_token
+          if Doorkeeper.configuration.refresh_token_revoked_in
+            old_refresh_token.revoke
+          else
+            old_refresh_token.revoke_in(Doorkeeper.configuration.refresh_token_revoked_in)
+          end
+        end
+        update_attribute :previous_refresh_token, nil
       end
     end
   end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -32,7 +32,7 @@ module Doorkeeper
       attr_reader :refresh_token_parameter
 
       def before_successful_response
-        refresh_token.revoke
+        refresh_token.revoke_in(server.refresh_token_revoked_in) unless refresh_token.revoked_at || server.refresh_token_revoked_on_use
         create_access_token
       end
 
@@ -41,12 +41,15 @@ module Doorkeeper
       end
 
       def create_access_token
-        @access_token = AccessToken.create!(
+        create_params = {
           application_id:    refresh_token.application_id,
           resource_owner_id: refresh_token.resource_owner_id,
           scopes:            scopes.to_s,
           expires_in:        server.access_token_expires_in,
-          use_refresh_token: true)
+          use_refresh_token: true
+        }
+        create_params[:previous_refresh_token] = refresh_token.refresh_token if server.refresh_token_revoked_on_use
+        @access_token = AccessToken.create! create_params
       end
 
       def validate_token_presence

--- a/lib/doorkeeper/oauth/scopes.rb
+++ b/lib/doorkeeper/oauth/scopes.rb
@@ -5,6 +5,7 @@ module Doorkeeper
       include Comparable
 
       def self.from_string(string)
+        return from_array(string) if string.is_a?(Array)
         string ||= ''
         new.tap do |scope|
           scope.add(*string.split)

--- a/lib/doorkeeper/oauth/token.rb
+++ b/lib/doorkeeper/oauth/token.rb
@@ -55,7 +55,9 @@ module Doorkeeper
 
       def self.authenticate(request, *methods)
         if token = from_request(request, *methods)
-          AccessToken.by_token(token)
+          access_token = AccessToken.by_token(token)
+          access_token.revoke_previous_refresh_token! if access_token && Doorkeeper.configuration.refresh_token_revoked_on_use
+          access_token
         end
       end
     end

--- a/lib/doorkeeper/orm/mongo_mapper/access_token.rb
+++ b/lib/doorkeeper/orm/mongo_mapper/access_token.rb
@@ -16,6 +16,7 @@ module Doorkeeper
     key :expires_in,        Integer
     key :revoked_at,        DateTime
     key :scopes,            String
+    key :previous_refresh_token, String
 
     def self.last
       self.sort(:created_at).last

--- a/lib/doorkeeper/orm/mongoid2/access_token.rb
+++ b/lib/doorkeeper/orm/mongoid2/access_token.rb
@@ -16,6 +16,7 @@ module Doorkeeper
     field :refresh_token, type: String
     field :expires_in, type: Integer
     field :revoked_at, type: DateTime
+    field :previous_refresh_token, String
 
     index :token, unique: true
     index :refresh_token, unique: true, sparse: true

--- a/lib/doorkeeper/orm/mongoid3/access_token.rb
+++ b/lib/doorkeeper/orm/mongoid3/access_token.rb
@@ -16,6 +16,7 @@ module Doorkeeper
     field :refresh_token, type: String
     field :expires_in, type: Integer
     field :revoked_at, type: DateTime
+    field :previous_refresh_token, String
 
     index({ token: 1 }, { unique: true })
     index({ refresh_token: 1 }, { unique: true, sparse: true })

--- a/lib/doorkeeper/orm/mongoid4/access_token.rb
+++ b/lib/doorkeeper/orm/mongoid4/access_token.rb
@@ -16,6 +16,7 @@ module Doorkeeper
     field :refresh_token, type: String
     field :expires_in, type: Integer
     field :revoked_at, type: DateTime
+    field :previous_refresh_token, String
 
     index({ token: 1 }, { unique: true })
     index({ refresh_token: 1 }, { unique: true, sparse: true })

--- a/lib/generators/doorkeeper/access_token_previous_token_generator.rb
+++ b/lib/generators/doorkeeper/access_token_previous_token_generator.rb
@@ -1,0 +1,34 @@
+require 'rails/generators/active_record'
+
+class Doorkeeper::AccessTokenPreviousTokenGenerator < Rails::Generators::Base
+  include Rails::Generators::Migration
+  source_root File.expand_path('../templates', __FILE__)
+  desc 'Provide support for revoking previous refresh token on new access token first use.'
+
+  def access_token_previous_token
+    if oauth_access_tokens_exists? && !previous_token_column_exists?
+      migration_template(
+        'add_previous_refresh_token_to_access_tokens.rb',
+        'db/migrate/add_previous_refresh_token_to_access_tokens.rb'
+      )
+    end
+  end
+
+  def self.next_migration_number(dirname)
+    ActiveRecord::Generators::Base.next_migration_number(dirname)
+  end
+
+  private
+
+  def previous_token_column_exists?
+    ActiveRecord::Base.connection.column_exists?(
+      :oauth_access_tokens,
+      :previous_refresh_token
+    )
+  end
+
+  # Might be running this before install
+  def oauth_access_tokens_exists?
+    ActiveRecord::Base.connection.table_exists? :oauth_access_tokens
+  end
+end

--- a/lib/generators/doorkeeper/templates/add_previous_refresh_token_to_access_tokens.rb
+++ b/lib/generators/doorkeeper/templates/add_previous_refresh_token_to_access_tokens.rb
@@ -1,0 +1,5 @@
+class AddPreviousRefreshTokenToAccessTokens < ActiveRecord::Migration
+  def change
+    add_column :oauth_access_tokens, :previous_refresh_token, :string
+  end
+end

--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -33,6 +33,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       t.datetime :revoked_at
       t.datetime :created_at,        null: false
       t.string   :scopes
+      t.string   :previous_refresh_token
     end
 
     add_index :oauth_access_tokens, :token, unique: true

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -31,6 +31,12 @@ Doorkeeper.configure do
   # Issue access tokens with refresh token (disabled by default)
   use_refresh_token
 
+  # Revoke the refresh token in a set time. Defaults to now
+  # refresh_token_revoked_in 0.seconds
+
+  # Do not revoke the refresh token until the new access token is used once. Defaults to false
+  # refresh_token_revoked_on_use false
+
   # Provide support for an owner to be assigned to each registered application (disabled by default)
   # Optional parameter :confirmation => true (default false) if you want to enforce ownership of
   # a registered application

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20141209001746) do
     t.datetime "revoked_at"
     t.datetime "created_at",        null: false
     t.string   "scopes"
+    t.string   "previous_refresh_token"
   end
 
   add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true

--- a/spec/lib/models/revocable_spec.rb
+++ b/spec/lib/models/revocable_spec.rb
@@ -33,4 +33,28 @@ describe 'Revocable' do
       expect(subject).not_to be_revoked
     end
   end
+
+  describe :revoke_previous_refresh_token! do
+    subject { FactoryGirl.build(:access_token, :previous_refresh_token => 'old_refresh_token') }
+    previous_token = FactoryGirl.build(:access_token)
+
+    it 'revokes the previous token if present and sets the attribute :previous_refresh_token to nil' do
+      expect(Doorkeeper::AccessToken).to receive(:by_refresh_token).with(subject.previous_refresh_token).and_return(previous_token)
+      expect(previous_token).to receive(:revoke)
+      expect(subject).to receive(:update_attribute).with(:previous_refresh_token, nil)
+      subject.revoke_previous_refresh_token!
+    end
+
+    it 'does nothing if the previous refresh token is nil' do
+      subject.previous_refresh_token = nil
+      expect(subject).to_not receive(:update_attribute).with(:previous_refresh_token, nil)
+      subject.revoke_previous_refresh_token!
+    end
+
+    it 'sets the attribute :previous_refresh_token to nil if the previous refresh token does not exist' do
+      expect(Doorkeeper::AccessToken).to receive(:by_refresh_token).with(subject.previous_refresh_token).and_return(nil)
+      expect(subject).to receive(:update_attribute).with(:previous_refresh_token, nil)
+      subject.revoke_previous_refresh_token!
+    end
+  end
 end

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_integration'
 
 module Doorkeeper::OAuth
   describe RefreshTokenRequest do
-    let(:server)         { double :server, access_token_expires_in: 2.minutes }
+    let(:server)         { double :server, access_token_expires_in: 2.minutes, refresh_token_revoked_in: 0.seconds, refresh_token_revoked_on_use: false }
     let!(:refresh_token) { FactoryGirl.create(:access_token, use_refresh_token: true) }
     let(:client)         { refresh_token.application }
     let(:credentials)    { Client::Credentials.new(client.uid, client.secret) }
@@ -48,6 +48,43 @@ module Doorkeeper::OAuth
       refresh_token.save
       subject.validate
       expect(subject).to be_valid
+    end
+
+    context 'refresh tokens expire on access token use' do
+      let(:server) { double :server, access_token_expires_in: 2.minutes, refresh_token_revoked_in: 0.seconds, refresh_token_revoked_on_use: true, refresh_token_enabled?: true }
+
+      it 'issues a new token for the client' do
+        expect do
+          subject.authorize
+        end.to change { client.access_tokens.count }.by(1)
+      end
+
+      it 'does not revoke the previous token' do
+        subject.authorize
+        refresh_token.revoked?.should eq(false)
+      end
+
+      it 'sets the previous refresh token in the new access token' do
+        subject.authorize
+        expect(client.access_tokens.last.previous_refresh_token).to eq(refresh_token.refresh_token)
+      end
+    end
+
+    context 'longer lived refresh tokens' do
+      let(:server) { double :server, access_token_expires_in: 2.minutes, refresh_token_revoked_in: 1.day, refresh_token_revoked_on_use: false }
+
+      it 'revokes the previous token' do
+        expect { subject.authorize } .to change { refresh_token.revoked_at }.from(nil).to(be_within(1).of(DateTime.now + 1.day))
+      end
+
+      context 'revoked token' do
+        time = DateTime.now + 3.hours
+        let!(:refresh_token) { FactoryGirl.create(:access_token, use_refresh_token: true, revoked_at: time) }
+        it 'does not change the revoke time of a future revoked token' do
+          subject.authorize
+          refresh_token.revoked_at.should eq(time)
+        end
+      end
     end
 
     context 'clientless access tokens' do

--- a/spec/lib/oauth/token_spec.rb
+++ b/spec/lib/oauth/token_spec.rb
@@ -91,6 +91,16 @@ module Doorkeeper
           expect(AccessToken).to receive(:by_token).with('token')
           Token.authenticate double, token
         end
+
+        context 'revoke old token on first access token use' do
+          it 'calls revoke previous refresh token if token was found' do
+            Doorkeeper.configuration.stub(:refresh_token_revoked_on_use).and_return(true)
+            token = ->(r) { 'token' }
+            expect(AccessToken).to receive(:by_token).with('token').and_return(token)
+            expect(token).to receive(:revoke_previous_refresh_token!)
+            Token.authenticate double, token
+          end
+        end
       end
     end
   end

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -23,6 +23,11 @@ module Doorkeeper
         expect(token.refresh_token).not_to be_nil
       end
 
+      it 'stores a previous refresh token if it was provided' do
+        token = FactoryGirl.create :access_token, use_refresh_token: true, previous_refresh_token: 'some_token'
+        expect(token.previous_refresh_token).not_to be_nil
+      end
+
       it 'is not valid if token exists' do
         token1 = FactoryGirl.create :access_token, use_refresh_token: true
         token2 = FactoryGirl.create :access_token, use_refresh_token: true


### PR DESCRIPTION
This PR allows refresh tokens to not either revoke at some point in the future (if you want to allow some wiggle room for network failures, etc) set refresh_token_revoked_in to some number of seconds in the future.

Also allows for refresh tokens to not be revoked until an access token created with that refresh token is successfully used once. Set refresh_token_revoked_on_use to true.

Both are off by default.

I made this work with ActiveRecord and it is passing test but no work was done for Mongoid.