### PR TITLE
Make the Authorization header case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#568] TokensController: Memoize strategy.authorize_response result to enable
     subclasses to use the response object.
 - [#571] Fix database initialization issues in some configurations.
+- [#582] The Authorization header fields are now case insensitive.
 
 
 ## 2.1.0

--- a/lib/doorkeeper/oauth/token.rb
+++ b/lib/doorkeeper/oauth/token.rb
@@ -11,13 +11,13 @@ module Doorkeeper
         end
 
         def from_bearer_authorization(request)
-          pattern = /^Bearer /
+          pattern = /^Bearer /i
           header  = request.authorization
           token_from_header(header, pattern) if match?(header, pattern)
         end
 
         def from_basic_authorization(request)
-          pattern = /^Basic /
+          pattern = /^Basic /i
           header  = request.authorization
           token_from_basic_header(header, pattern) if match?(header, pattern)
         end

--- a/spec/lib/oauth/token_spec.rb
+++ b/spec/lib/oauth/token_spec.rb
@@ -56,8 +56,14 @@ module Doorkeeper
       end
 
       describe :from_bearer_authorization do
-        it 'returns token from authorization bearer' do
+        it 'returns token from capitalized authorization bearer' do
           request = double authorization: 'Bearer SomeToken'
+          token   = Token.from_bearer_authorization(request)
+          expect(token).to eq('SomeToken')
+        end
+
+        it 'returns token from lowercased authorization bearer' do
+          request = double authorization: 'bearer SomeToken'
           token   = Token.from_bearer_authorization(request)
           expect(token).to eq('SomeToken')
         end
@@ -70,8 +76,14 @@ module Doorkeeper
       end
 
       describe :from_basic_authorization do
-        it 'returns token from authorization basic' do
+        it 'returns token from capitalized authorization basic' do
           request = double authorization: "Basic #{Base64.encode64 'SomeToken:'}"
+          token   = Token.from_basic_authorization(request)
+          expect(token).to eq('SomeToken')
+        end
+
+        it 'returns token from lowercased authorization basic' do
+          request = double authorization: "basic #{Base64.encode64 'SomeToken:'}"
           token   = Token.from_basic_authorization(request)
           expect(token).to eq('SomeToken')
         end


### PR DESCRIPTION
Some oauth2 libraries are writing Authorization headers field names in lowercase and thus can't be used with applications using doorkeeper.

For instance, the token won't be extracted:
```
Authorization: bearer 4f7781e23a7695865bce77232fed0a0e5b3b20d9cd9c700a6b48a5ee05b4fa94
```

Moreover, HTTP header field names should be case-insensitive according to the [specs](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).