### PR TITLE
AccessToken should establish proper connection

### DIFF
--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -7,7 +7,7 @@ module Doorkeeper
         require 'doorkeeper/orm/active_record/application'
 
         if Doorkeeper.configuration.active_record_options[:establish_connection]
-          [Doorkeeper::AccessGrant, Doorkeeper::Application, Doorkeeper::AccessGrant].each do |c|
+          [Doorkeeper::AccessGrant, Doorkeeper::AccessToken, Doorkeeper::Application].each do |c|
             c.send :establish_connection, Doorkeeper.configuration.active_record_options[:establish_connection]
           end
         end


### PR DESCRIPTION
With configuring Doorkeeper gem to use ActiveRecord ORM and with providing option to connect other database:

```ruby
Doorkeeper.configure do
  orm :active_record
  active_record_options establish_connection: 'some_freaky_database'
end
```
And using later:

```ruby
Doorkeeper::AccessToken.by_token(token_string)
```

I got error:

```sql
PG::UndefinedTable: ERROR:  relation "oauth_access_tokens" does not exist
LINE 5:                WHERE a.attrelid = '"oauth_access_tokens"'::r...
                                          ^
:               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
                FROM pg_attribute a LEFT JOIN pg_attrdef d
                  ON a.attrelid = d.adrelid AND a.attnum = d.adnum
               WHERE a.attrelid = '"oauth_access_tokens"'::regclass
                 AND a.attnum > 0 AND NOT a.attisdropped
               ORDER BY a.attnum
```