### PR TITLE
Rails before 4 with strong_parameters gem

### DIFF
--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -11,7 +11,7 @@ module Doorkeeper
     included do
       belongs_to :application, class_name: 'Doorkeeper::Application', inverse_of: :access_grants
 
-      if ::Rails.version.to_i < 4 || defined?(::ProtectedAttributes)
+      if (::Rails.version.to_i < 4 && !defined?(::StrongParameters)) || defined?(::ProtectedAttributes)
         attr_accessible :resource_owner_id, :application_id, :expires_in, :redirect_uri, :scopes
       end
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -18,7 +18,7 @@ module Doorkeeper
 
       attr_writer :use_refresh_token
 
-      if ::Rails.version.to_i < 4 || defined?(::ProtectedAttributes)
+      if (::Rails.version.to_i < 4 && !defined?(::StrongParameters)) || defined?(::ProtectedAttributes)
         attr_accessible :application_id, :resource_owner_id, :expires_in,
                         :scopes, :use_refresh_token
       end

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -15,7 +15,7 @@ module Doorkeeper
 
       before_validation :generate_uid, :generate_secret, on: :create
 
-      if ::Rails.version.to_i < 4 || defined?(::ProtectedAttributes)
+      if (::Rails.version.to_i < 4 && !defined?(::StrongParameters)) || defined?(::ProtectedAttributes)
         attr_accessible :name, :redirect_uri
       end
     end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -21,7 +21,7 @@ when "mongo_mapper"
 end
 
 class User
-  if ::Rails.version.to_i < 4 || defined?(::ProtectedAttributes)
+  if (::Rails.version.to_i < 4 && !defined?(::StrongParameters)) || defined?(::ProtectedAttributes)
     attr_accessible :name, :password
   end
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -27,7 +27,7 @@ module Dummy
     # Activate observers that should always be running.
     # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
 
-    if defined?(ActiveRecord) && Rails.version.to_i < 4
+    if defined?(ActiveRecord) && Rails.version.to_i < 4 && !defined?(::StrongParameters)
       config.active_record.whitelist_attributes = true
     end
 


### PR DESCRIPTION
That check can be handy in situation if someone for example got Rails 3.2 app with strong_parameters gem to not generate attr_accessible in models. What you think?
