### PR TITLE
Fixes scopes_match? bug that skipped authorization form in some cases

### DIFF
--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -59,7 +59,7 @@ module Doorkeeper
 
       def scopes_match?(token_scopes, param_scopes, app_scopes)
         (!token_scopes.present? && !param_scopes.present?) ||
-          Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
+          Doorkeeper::OAuth::Helpers::ScopeChecker.match?(
             token_scopes.to_s,
             param_scopes,
             app_scopes

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -2,24 +2,41 @@ module Doorkeeper
   module OAuth
     module Helpers
       module ScopeChecker
-        def self.valid?(scope_str, server_scopes, application_scopes = nil)
-          @valid_scopes = if application_scopes.present?
-                            server_scopes & application_scopes
-                          else
-                            server_scopes
-                          end
+        class Validator
+          def initialize(scope_str, server_scopes, application_scopes)
+            @scope_str = scope_str
+            @valid_scopes = valid_scopes(server_scopes, application_scopes)
+            @parsed_scopes = OAuth::Scopes.from_string(scope_str)
+          end
 
-          @parsed_scopes = OAuth::Scopes.from_string(scope_str)
-          scope_str.present? &&
-            scope_str !~ /[\n|\r|\t]/ &&
-            @valid_scopes.has_scopes?(@parsed_scopes)
+          def valid?
+            @scope_str.present? &&
+              @scope_str !~ /[\n|\r|\t]/ &&
+              @valid_scopes.has_scopes?(@parsed_scopes)
+          end
+
+          def match?
+            valid? && @parsed_scopes.has_scopes?(@valid_scopes)
+          end
+
+          private
+
+          def valid_scopes(server_scopes, application_scopes)
+            if application_scopes.present?
+              server_scopes & application_scopes
+            else
+              server_scopes
+            end
+          end
+        end
+
+        def self.valid?(scope_str, server_scopes, application_scopes = nil)
+          Validator.new(scope_str, server_scopes, application_scopes).valid?
         end
 
         def self.match?(scope_str, server_scopes, application_scopes = nil)
-          valid?(scope_str, server_scopes, application_scopes) &&
-            @parsed_scopes.has_scopes?(@valid_scopes)
+          Validator.new(scope_str, server_scopes, application_scopes).match?
         end
-
       end
     end
   end

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -3,16 +3,23 @@ module Doorkeeper
     module Helpers
       module ScopeChecker
         def self.valid?(scope_str, server_scopes, application_scopes = nil)
-          valid_scopes = if application_scopes.present?
-                           server_scopes & application_scopes
-                         else
-                           server_scopes
-                         end
+          @valid_scopes = if application_scopes.present?
+                            server_scopes & application_scopes
+                          else
+                            server_scopes
+                          end
 
+          @parsed_scopes = OAuth::Scopes.from_string(scope_str)
           scope_str.present? &&
             scope_str !~ /[\n|\r|\t]/ &&
-            valid_scopes.has_scopes?(OAuth::Scopes.from_string(scope_str))
+            @valid_scopes.has_scopes?(@parsed_scopes)
         end
+
+        def self.match?(scope_str, server_scopes, application_scopes = nil)
+          valid?(scope_str, server_scopes, application_scopes) &&
+            @parsed_scopes.has_scopes?(@valid_scopes)
+        end
+
       end
     end
   end

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -220,7 +220,6 @@ module Doorkeeper
         expect(last_token).to be_nil
       end
 
-
       it 'matches application scopes' do
         application = FactoryGirl.create :application, scopes: "private read"
         FactoryGirl.create :access_token, default_attributes.merge(

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -202,11 +202,24 @@ module Doorkeeper
         expect(last_token).to be_nil
       end
 
-      it 'matches the scopes' do
+      it 'matches token with fewer scopes' do
+        FactoryGirl.create :access_token, default_attributes.merge(scopes: 'public')
+        last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
+        expect(last_token).to be_nil
+      end
+
+      it 'matches token with different scopes' do
         FactoryGirl.create :access_token, default_attributes.merge(scopes: 'public email')
         last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
         expect(last_token).to be_nil
       end
+
+      it 'matches token with more scopes' do
+        FactoryGirl.create :access_token, default_attributes.merge(scopes: 'public write email')
+        last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
+        expect(last_token).to be_nil
+      end
+
 
       it 'matches application scopes' do
         application = FactoryGirl.create :application, scopes: "private read"

--- a/spec/requests/flows/skip_authorization_spec.rb
+++ b/spec/requests/flows/skip_authorization_spec.rb
@@ -24,11 +24,18 @@ feature 'Skip authorization form' do
       url_should_have_param 'code', Doorkeeper::AccessGrant.first.token
     end
 
-    scenario 'does not skip authorization when scopes differ' do
+    scenario 'does not skip authorization when scopes differ (new request has fewer scopes)' do
       client_is_authorized(@client, @resource_owner, scopes: 'public write')
       visit authorization_endpoint_url(client: @client, scope: 'public')
       i_should_see 'Authorize'
     end
+
+    scenario 'does not skip authorization when scopes differ (new request has more scopes)' do
+      client_is_authorized(@client, @resource_owner, scopes: 'public write')
+      visit authorization_endpoint_url(client: @client, scopes: 'public write email')
+      i_should_see 'Authorize'
+    end
+
 
     scenario 'creates grant with new scope when scopes differ' do
       client_is_authorized(@client, @resource_owner, scopes: 'public write')

--- a/spec/requests/flows/skip_authorization_spec.rb
+++ b/spec/requests/flows/skip_authorization_spec.rb
@@ -36,7 +36,6 @@ feature 'Skip authorization form' do
       i_should_see 'Authorize'
     end
 
-
     scenario 'creates grant with new scope when scopes differ' do
       client_is_authorized(@client, @resource_owner, scopes: 'public write')
       visit authorization_endpoint_url(client: @client, scope: 'public')


### PR DESCRIPTION
There are cases when `AccessToken.find_or_create_for` doesn't work properly and authorization form is not shown to the user, even though scopes have been changed.

If a user has already been authorized once with say `public write` scopes and another authorization request was sent with `public` or `public email` scopes, then `scopes_match?` correctly determines that these scopes do not match and authorization form appears.

However, if new authorization request has say `public write email` scopes, then `scopes_match?` returns `true` because new scopes array contains previous one and in this case authorization form is skipped.