### PR TITLE
use `scope` instead of `scopes` for refresh token scope param

### DIFF
--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -18,7 +18,12 @@ module Doorkeeper
         @server          = server
         @refresh_token   = refresh_token
         @credentials     = credentials
-        @original_scopes = parameters[:scope]
+        # Prefer :scope, can fall back to :scopes for backwards compatible.
+        if parameters[:scope].present?
+          @original_scopes = parameters[:scope]
+        else
+          @original_scopes = parameters[:scopes]
+        end
         @refresh_token_parameter = parameters[:refresh_token]
 
         if credentials

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -18,7 +18,7 @@ module Doorkeeper
         @server          = server
         @refresh_token   = refresh_token
         @credentials     = credentials
-        @original_scopes = parameters[:scopes]
+        @original_scopes = parameters[:scope]
         @refresh_token_parameter = parameters[:refresh_token]
 
         if credentials

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -71,12 +71,25 @@ module Doorkeeper::OAuth
       end
 
       it 'reduces scopes to the provided scopes' do
-        parameters[:scope] = 'public'
+        parameters[:scopes] = 'public'
         subject.authorize
         expect(Doorkeeper::AccessToken.last.scopes).to eq([:public])
       end
 
       it 'validates that scopes are included in the original access token' do
+        parameters[:scopes] = 'public update'
+
+        subject.validate
+        expect(subject.error).to eq(:invalid_scope)
+      end
+
+      it 'reduces params[:scope] to the provided scopes' do
+        parameters[:scope] = 'public'
+        subject.authorize
+        expect(Doorkeeper::AccessToken.last.scopes).to eq([:public])
+      end
+
+      it 'validates params[:scope] are included in the original token' do
         parameters[:scope] = 'public update'
 
         subject.validate

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -71,13 +71,13 @@ module Doorkeeper::OAuth
       end
 
       it 'reduces scopes to the provided scopes' do
-        parameters[:scopes] = 'public'
+        parameters[:scope] = 'public'
         subject.authorize
         expect(Doorkeeper::AccessToken.last.scopes).to eq([:public])
       end
 
       it 'validates that scopes are included in the original access token' do
-        parameters[:scopes] = 'public update'
+        parameters[:scope] = 'public update'
 
         subject.validate
         expect(subject.error).to eq(:invalid_scope)


### PR DESCRIPTION
in [Doorkeeper::OAuth::RefreshTokenRequest](https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib%2Fdoorkeeper%2Foauth%2Frefresh_token_request.rb#L21), it initializes `@original_scopes` with `parameters[:scopes]`, but according to rfc 6749 [Refreshing an Access Token](https://tools.ietf.org/html/rfc6749#section-6), the parameter name should be `scope`.

fix #594