### PR TITLE
limit token scopes inside app scopes for client credential request

### DIFF
--- a/lib/doorkeeper/oauth/client_credentials/validation.rb
+++ b/lib/doorkeeper/oauth/client_credentials/validation.rb
@@ -25,7 +25,7 @@ module Doorkeeper
         end
 
         def validate_scopes
-          return true unless @request.original_scopes.present?
+          return true unless @request.scopes.present?
 
           application_scopes = if @client.present?
                                  @client.application.scopes
@@ -34,7 +34,7 @@ module Doorkeeper
                                end
 
           ScopeChecker.valid?(
-            @request.original_scopes,
+            @request.scopes.to_s,
             @server.scopes,
             application_scopes
           )

--- a/spec/lib/oauth/client_credentials/validation_spec.rb
+++ b/spec/lib/oauth/client_credentials/validation_spec.rb
@@ -7,7 +7,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
     let(:server)      { double :server, scopes: nil }
     let(:application) { double scopes: nil }
     let(:client)      { double application: application }
-    let(:request)     { double :request, client: client, original_scopes: nil }
+    let(:request) { double :request, client: client, scopes: nil }
 
     subject { Validation.new(server, request) }
 
@@ -24,7 +24,8 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
       it 'is invalid when scopes are not included in the server' do
         server_scopes = Doorkeeper::OAuth::Scopes.from_string 'email'
         allow(server).to receive(:scopes).and_return(server_scopes)
-        allow(request).to receive(:original_scopes).and_return('invalid')
+        allow(request).to receive(:scopes).and_return(
+          Doorkeeper::OAuth::Scopes.from_string 'invalid')
         expect(subject).not_to be_valid
       end
 
@@ -34,7 +35,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
           server_scopes = Doorkeeper::OAuth::Scopes.from_string 'email app'
           allow(application).to receive(:scopes).and_return(application_scopes)
           allow(server).to receive(:scopes).and_return(server_scopes)
-          allow(request).to receive(:original_scopes).and_return('app')
+          allow(request).to receive(:scopes).and_return(application_scopes)
           expect(subject).to be_valid
         end
 
@@ -43,7 +44,8 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
           server_scopes = Doorkeeper::OAuth::Scopes.from_string 'email app'
           allow(application).to receive(:scopes).and_return(application_scopes)
           allow(server).to receive(:scopes).and_return(server_scopes)
-          allow(request).to receive(:original_scopes).and_return('email')
+          allow(request).to receive(:scopes).and_return(
+            Doorkeeper::OAuth::Scopes.from_string 'email')
           expect(subject).not_to be_valid
         end
       end

--- a/spec/lib/oauth/client_credentials_request_spec.rb
+++ b/spec/lib/oauth/client_credentials_request_spec.rb
@@ -6,7 +6,8 @@ require 'doorkeeper/oauth/client_credentials_request'
 module Doorkeeper::OAuth
   describe ClientCredentialsRequest do
     let(:server) { double default_scopes: nil }
-    let(:client) { double }
+    let(:application) { double :application, scopes: Scopes.from_string('') }
+    let(:client) { double :client, application: application }
     let(:token_creator) { double :issuer, create: true, token: double }
 
     subject { ClientCredentialsRequest.new(server, client) }
@@ -58,6 +59,40 @@ module Doorkeeper::OAuth
         subject.issuer = token_creator
         expect(token_creator).to receive(:create).with(client, Doorkeeper::OAuth::Scopes.from_string('email'))
         subject.authorize
+      end
+    end
+
+    context 'with restricted client' do
+      let(:default_scopes) do
+        Doorkeeper::OAuth::Scopes.from_string('public email')
+      end
+      let(:server_scopes) do
+        Doorkeeper::OAuth::Scopes.from_string('public email phone')
+      end
+      let(:client_scopes) do
+        Doorkeeper::OAuth::Scopes.from_string('public phone')
+      end
+
+      before do
+        allow(server).to receive(:default_scopes).and_return(default_scopes)
+        allow(server).to receive(:scopes).and_return(server_scopes)
+        allow(server).to receive(:access_token_expires_in).and_return(100)
+        allow(application).to receive(:scopes).and_return(client_scopes)
+        allow(client).to receive(:id).and_return(nil)
+      end
+
+      it 'delegates the error to issuer if no scope was requested' do
+        subject = ClientCredentialsRequest.new(server, client)
+        subject.authorize
+        expect(subject.response).to be_a(Doorkeeper::OAuth::ErrorResponse)
+        expect(subject.error).to eq(:invalid_scope)
+      end
+
+      it 'issues an access token with requested scopes' do
+        subject = ClientCredentialsRequest.new(server, client, scope: 'phone')
+        subject.authorize
+        expect(subject.response).to be_a(Doorkeeper::OAuth::TokenResponse)
+        expect(subject.response.token.scopes_string).to eq('phone')
       end
     end
   end


### PR DESCRIPTION
Using latest master version of doorkeeper with:

* `doorkeeper.configuration.default_scopes` is set to `public`.
* `doorkeeper.configuration.optional_scopes` is set to `x, y, z`.
* There is a registered application - app1, `app1.scopes` is set to `x, y`.

When app1 requesting an access token using client credential flow, the results are:

* if `params[:scope]` is not present, result token will have scopes `public`
* if `params[:scope]` is set to `public`, server will deny the request - because `public` is not in `app1.scopes`

This is very strange, since when i requesting `public` scope, it saids the scope is invalid. But when i'm not requesting any specific scope, it grants me a `public` scope.

In my opinion, when `params[:scope]` is not present, server should either deny the request or grant all scopes belonging to the client (in this case should be `x, y`), or grant it the default scope only if default scope belongs to the client.

[fixes #593]