### PR TITLE
Add option to specific access token's complexity

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -198,6 +198,7 @@ and that your `initialize_models!` method doesn't raise any errors.\n
     option :realm,                          default: 'Doorkeeper'
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
+    option :access_token_complexity,        default: {}
 
     attr_reader :reuse_access_token
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -128,7 +128,7 @@ module Doorkeeper
     end
 
     def generate_token
-      self.token = UniqueToken.generate
+      self.token = UniqueToken.generate(Doorkeeper.configuration.access_token_complexity)
     end
   end
 end

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -31,6 +31,9 @@ Doorkeeper.configure do
   # Issue access tokens with refresh token (disabled by default)
   use_refresh_token
 
+  # Access token's configured complexity (defaults to 32 bit hex token)
+  # access_token_complexity size: 64, generator: SecureRandom.urlsafe_base64
+
   # Provide support for an owner to be assigned to each registered application (disabled by default)
   # Optional parameter :confirmation => true (default false) if you want to enforce ownership of
   # a registered application

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -284,6 +284,20 @@ describe Doorkeeper, 'configuration' do
     end
   end
 
+  describe 'access_token_complexity' do
+    it 'it uses hex and a size of 32 by default' do
+      expect(Doorkeeper.configuration.access_token_complexity).to eq({})
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        access_token_complexity size: 54
+      end
+      expect(subject.access_token_complexity).to eq(size: 54)
+    end
+  end
+
   it 'raises an exception when configuration is not set' do
     old_config = Doorkeeper.configuration
     Doorkeeper.module_eval do


### PR DESCRIPTION
I may be daft, however, while I did notice that UniqueToken#generate's method signature includes options to change a token's complexity I couldn't find a nice way to configure it.

For your consideration, I've added a configuration option to change the token's complexity.