### PR TITLE
Add custom access token expiration support for Client Credentials flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#595] HTTP spec: Add `scope` for refresh token scope param
 - [#596] Limit scopes in app scopes for client credentials
 - [#567] Add Grape helpers for easier integration with Grape framework
+- [#606] Add custom access token expiration support for Client Credentials flow
 
 
 ## 2.1.3

--- a/lib/doorkeeper/oauth/client_credentials/issuer.rb
+++ b/lib/doorkeeper/oauth/client_credentials/issuer.rb
@@ -24,11 +24,13 @@ module Doorkeeper
         private
 
         def create_token(client, scopes, creator)
+          ttl = Authorization::Token.access_token_expires_in(@server, client)
+
           creator.call(
             client,
             scopes,
             use_refresh_token: false,
-            expires_in: @server.access_token_expires_in
+            expires_in: ttl
           )
         end
       end

--- a/spec/lib/oauth/client_credentials_request_spec.rb
+++ b/spec/lib/oauth/client_credentials_request_spec.rb
@@ -5,7 +5,12 @@ require 'doorkeeper/oauth/client_credentials_request'
 
 module Doorkeeper::OAuth
   describe ClientCredentialsRequest do
-    let(:server) { double default_scopes: nil }
+    let(:server) do
+      double(
+        default_scopes: nil,
+        custom_access_token_expires_in: ->(_app) { nil }
+      )
+    end
     let(:application)   { double :application, scopes: Scopes.from_string('') }
     let(:client)        { double :client, application: application }
     let(:token_creator) { double :issuer, create: true, token: double }


### PR DESCRIPTION
8d17a7a introduced a configuration option for a custom application-specific
access token expiration, however this option did not work with the Client
Credentials flow.

Modify Doorkeeper::OAuth::ClientCredentials::Issuer class so that it utilizes
the Doorkeeper.configuration.custom_access_token_expires_in option when
present.