### PR TITLE
JWT Support

### DIFF
--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "railties", ">= 3.2"
+  s.add_dependency "jwt", "~> 1.3.0"
 
   s.add_development_dependency "sqlite3", "~> 1.3.5"
   s.add_development_dependency "rspec-rails", "~> 2.99.0"

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -52,6 +52,8 @@ require 'doorkeeper/orm/mongoid2'
 require 'doorkeeper/orm/mongoid3'
 require 'doorkeeper/orm/mongoid4'
 
+require 'jwt'
+
 module Doorkeeper
   def self.configured?
     @config.present?

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -108,6 +108,18 @@ and that your `initialize_models!` method doesn't raise any errors.\n
       def force_ssl_in_redirect_uri(boolean)
         @config.instance_variable_set("@force_ssl_in_redirect_uri", boolean)
       end
+
+      def use_jwt_token
+        @config.instance_variable_set('@jwt_token_enabled', true)
+      end
+
+      def jwt_secret_key(jwt_secret_key)
+        @config.instance_variable_set('@jwt_secret_key', jwt_secret_key)
+      end
+
+      def jwt_encryption_method(jwt_encryption_method)
+        @config.instance_variable_set('@jwt_encryption_method', jwt_encryption_method)
+      end
     end
 
     module Option
@@ -199,6 +211,10 @@ and that your `initialize_models!` method doesn't raise any errors.\n
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
 
+    option :jwt_token_payload, default: nil
+    option :jwt_secret_key, default: nil.to_s
+    option :jwt_encryption_method, default: nil
+
     attr_reader :reuse_access_token
 
     def refresh_token_enabled?
@@ -243,6 +259,18 @@ and that your `initialize_models!` method doesn't raise any errors.\n
 
     def token_grant_types
       @token_grant_types ||= calculate_token_grant_types
+    end
+
+    def jwt_token_enabled?
+      !!@jwt_token_enabled
+    end
+
+    def jwt_secret_key
+      @jwt_secret_key ||= nil
+    end
+
+    def jwt_encryption_method
+      @jwt_encryption_method ||= nil
     end
 
     private

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -118,7 +118,8 @@ and that your `initialize_models!` method doesn't raise any errors.\n
       end
 
       def jwt_encryption_method(jwt_encryption_method)
-        @config.instance_variable_set('@jwt_encryption_method', jwt_encryption_method)
+        @config.instance_variable_set(
+          '@jwt_encryption_method', jwt_encryption_method)
       end
     end
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -79,7 +79,7 @@ module Doorkeeper
           scopes:            scopes.to_s,
           expires_in:        expires_in,
           use_refresh_token: use_refresh_token,
-          use_jwt_token: use_jwt_token
+          use_jwt_token:     use_jwt_token
         )
       end
 
@@ -133,7 +133,7 @@ module Doorkeeper
     end
 
     def generate_token
-      if use_jwt_token? && jwt_token_payload.present?
+      if use_jwt_token?
         self.token = JWT.encode(jwt_token_payload, jwt_secret_key, jwt_encryption_method)
       else
         self.token = UniqueToken.generate
@@ -149,7 +149,6 @@ module Doorkeeper
     end
 
     def jwt_secret_key
-      return nil if Doorkeeper.configuration.jwt_secret_key.blank?
       Doorkeeper.configuration.jwt_secret_key
     end
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -66,7 +66,10 @@ module Doorkeeper
           )
       end
 
-      def find_or_create_for(application, resource_owner_id, scopes, expires_in, use_refresh_token, use_jwt_token)
+      def find_or_create_for(
+        application, resource_owner_id, scopes, expires_in,
+        use_refresh_token, use_jwt_token
+      )
         if Doorkeeper.configuration.reuse_access_token
           access_token = matching_token_for(application, resource_owner_id, scopes)
           if access_token && !access_token.expired?
@@ -79,7 +82,7 @@ module Doorkeeper
           scopes:            scopes.to_s,
           expires_in:        expires_in,
           use_refresh_token: use_refresh_token,
-          use_jwt_token:     use_jwt_token
+          use_jwt_token: use_jwt_token
         )
       end
 
@@ -134,7 +137,8 @@ module Doorkeeper
 
     def generate_token
       if use_jwt_token?
-        self.token = JWT.encode(jwt_token_payload, jwt_secret_key, jwt_encryption_method)
+        self.token = JWT.encode(
+          jwt_token_payload, jwt_secret_key, jwt_encryption_method)
       else
         self.token = UniqueToken.generate
       end

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -16,11 +16,11 @@ module Doorkeeper
       validates :token, presence: true, uniqueness: true
       validates :refresh_token, uniqueness: true, if: :use_refresh_token?
 
-      attr_writer :use_refresh_token
+      attr_writer :use_refresh_token, :use_jwt_token
 
       if ::Rails.version.to_i < 4 || defined?(::ProtectedAttributes)
         attr_accessible :application_id, :resource_owner_id, :expires_in,
-                        :scopes, :use_refresh_token
+                        :scopes, :use_refresh_token, :use_jwt_token
       end
 
       before_validation :generate_token, on: :create
@@ -66,7 +66,7 @@ module Doorkeeper
           )
       end
 
-      def find_or_create_for(application, resource_owner_id, scopes, expires_in, use_refresh_token)
+      def find_or_create_for(application, resource_owner_id, scopes, expires_in, use_refresh_token, use_jwt_token)
         if Doorkeeper.configuration.reuse_access_token
           access_token = matching_token_for(application, resource_owner_id, scopes)
           if access_token && !access_token.expired?
@@ -78,7 +78,8 @@ module Doorkeeper
           resource_owner_id: resource_owner_id,
           scopes:            scopes.to_s,
           expires_in:        expires_in,
-          use_refresh_token: use_refresh_token
+          use_refresh_token: use_refresh_token,
+          use_jwt_token: use_jwt_token
         )
       end
 
@@ -99,6 +100,10 @@ module Doorkeeper
 
     def use_refresh_token?
       !!@use_refresh_token
+    end
+
+    def use_jwt_token?
+      !!@use_jwt_token
     end
 
     def as_json(_options = {})
@@ -128,7 +133,29 @@ module Doorkeeper
     end
 
     def generate_token
-      self.token = UniqueToken.generate
+      if use_jwt_token? && jwt_token_payload.present?
+        self.token = JWT.encode(jwt_token_payload, jwt_secret_key, jwt_encryption_method)
+      else
+        self.token = UniqueToken.generate
+      end
+    end
+
+    def jwt_token_payload
+      if Doorkeeper.configuration.jwt_token_payload.is_a?(Proc)
+        instance_eval(&Doorkeeper.configuration.jwt_token_payload)
+      else
+        { token: UniqueToken.generate }
+      end
+    end
+
+    def jwt_secret_key
+      return nil if Doorkeeper.configuration.jwt_secret_key.blank?
+      Doorkeeper.configuration.jwt_secret_key
+    end
+
+    def jwt_encryption_method
+      return nil if Doorkeeper.configuration.jwt_encryption_method.blank?
+      Doorkeeper.configuration.jwt_encryption_method.to_s.upcase
     end
   end
 end

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -26,6 +26,7 @@ module Doorkeeper
             resource_owner.id,
             pre_auth.scopes,
             self.class.access_token_expires_in(configuration, pre_auth),
+            false,
             false
           )
         end

--- a/lib/doorkeeper/oauth/request_concern.rb
+++ b/lib/doorkeeper/oauth/request_concern.rb
@@ -35,7 +35,8 @@ module Doorkeeper
           resource_owner_id,
           scopes,
           Authorization::Token.access_token_expires_in(server, client),
-          server.refresh_token_enabled?)
+          server.refresh_token_enabled?,
+          server.jwt_token_enabled?)
       end
 
       def before_successful_response

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -102,4 +102,26 @@ Doorkeeper.configure do
 
   # WWW-Authenticate Realm (default "Doorkeeper").
   # realm "Doorkeeper"
+
+  # JWT Settings
+  # Use a JWT token
+  # use_jwt_token
+  #
+  # Set the payload for the JWT token. This should contain unique information
+  # about the user.
+  # jwt_token_payload do
+  #   user = User.find_by_id(session[:user_id])
+  #   {
+  #     id: user.id,
+  #     name: user.name
+  #   }
+  # end
+  #
+  # Set the encryption secret. This would be shared with any other applications
+  # that should be able to read the payload of the token
+  # jwt_secret_key "secret"
+  #
+  # Specify encryption type. Supports any algorithim in
+  # https://github.com/progrium/ruby-jwt
+  # jwt_encryption_method :rs512
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -163,6 +163,52 @@ describe Doorkeeper, 'configuration' do
     end
   end
 
+  describe 'use_jwt_token' do
+    it 'is false by default' do
+      expect(subject.jwt_token_enabled?).to be_falsey
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        use_jwt_token
+      end
+      expect(subject.jwt_token_enabled?).to be_truthy
+    end
+  end
+
+  describe 'jwt_token_payload' do
+    it 'is nil by default' do
+      expect(subject.jwt_token_payload).to be_nil
+    end
+
+    it 'sets the block that is accessible via authenticate_admin' do
+      block = proc {}
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        jwt_token_payload &block
+      end
+      expect(subject.jwt_token_payload).to eq(block)
+    end
+  end
+
+  describe 'jwt_encryption_method' do
+    it 'defaults to nil' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+      end
+      expect(subject.jwt_encryption_method).to be_nil
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        jwt_encryption_method :rs512
+      end
+      expect(subject.jwt_encryption_method).to eq :rs512
+    end
+  end
+
   describe 'enable_application_owner' do
     it 'is disabled by default' do
       expect(Doorkeeper.configuration.enable_application_owner?).not_to be_truthy

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -6,7 +6,8 @@ module Doorkeeper::OAuth
       double :server,
              access_token_expires_in: 2.days,
              refresh_token_enabled?: false,
-             custom_access_token_expires_in: ->(_app) { nil }
+             custom_access_token_expires_in: ->(_app) { nil },
+             jwt_token_enabled?: false
     end
     let(:grant)  { FactoryGirl.create :access_grant }
     let(:client) { grant.application }

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -8,7 +8,8 @@ module Doorkeeper::OAuth
         default_scopes: Doorkeeper::OAuth::Scopes.new,
         access_token_expires_in: 2.hours,
         refresh_token_enabled?: false,
-        custom_access_token_expires_in: ->(_app) { nil }
+        custom_access_token_expires_in: ->(_app) { nil },
+        jwt_token_enabled?: false
       )
     end
     let(:credentials) { Client::Credentials.new(client.uid, client.secret) }

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -19,7 +19,10 @@ module Doorkeeper
         end
 
         token = FactoryGirl.create :access_token, use_jwt_token: true
-        expect(JWT.decode(token.token, nil, nil)[0]).to be_a(Hash)
+        decoded_token = JWT.decode(token.token, nil, nil)
+        expect(decoded_token[0]).to be_a(Hash)
+        expect(decoded_token[1]["typ"]).to eq "JWT"
+        expect(decoded_token[1]["alg"]).to eq "none"
       end
 
       it "encodes the payload in to the token" do
@@ -32,7 +35,8 @@ module Doorkeeper
         end
 
         token = FactoryGirl.create :access_token, use_jwt_token: true
-        expect(JWT.decode(token.token, nil, nil)[0]).to eq({ "foo" => "bar" })
+        decoded_token = JWT.decode(token.token, nil, nil)
+        expect(decoded_token[0]).to eq({ "foo" => "bar" })
       end
 
       it "encodes the signed payload in to the token" do
@@ -47,7 +51,8 @@ module Doorkeeper
         end
 
         token = FactoryGirl.create :access_token, use_jwt_token: true
-        expect(JWT.decode(token.token, "secret", nil)[0]).to eq({ "foo" => "bar" })
+        decoded_token = JWT.decode(token.token, "secret", nil)
+        expect(decoded_token[0]).to eq({ "foo" => "bar" })
       end
 
       it "encodes the encrypted payload in to the token" do
@@ -63,7 +68,10 @@ module Doorkeeper
         end
 
         token = FactoryGirl.create :access_token, use_jwt_token: true
-        expect(JWT.decode(token.token, "secret", "HS512")[0]).to eq({ "foo" => "bar" })
+        decoded_token = JWT.decode(token.token, "secret", "HS512")
+        expect(decoded_token[0]).to eq({ "foo" => "bar" })
+        expect(decoded_token[1]["typ"]).to eq "JWT"
+        expect(decoded_token[1]["alg"]).to eq "HS512"
       end
 
       it "does not use JWT without use_jwt_token set" do
@@ -74,7 +82,8 @@ module Doorkeeper
         end
 
         token = FactoryGirl.create :access_token
-        expect{ JWT.decode(token.token, nil, nil) }.to raise_error(JWT::DecodeError)
+        expect{ JWT.decode(token.token, nil, nil) }
+          .to raise_error(JWT::DecodeError)
       end
     end
 

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -12,6 +12,72 @@ module Doorkeeper
       let(:factory_name) { :access_token }
     end
 
+    describe :token do
+      it "creates a JWT token" do
+        Doorkeeper.configure do
+          use_jwt_token
+        end
+
+        token = FactoryGirl.create :access_token, use_jwt_token: true
+        expect(JWT.decode(token.token, nil, nil)[0]).to be_a(Hash)
+      end
+
+      it "encodes the payload in to the token" do
+        Doorkeeper.configure do
+          use_jwt_token
+
+          jwt_token_payload do
+            { foo: "bar" }
+          end
+        end
+
+        token = FactoryGirl.create :access_token, use_jwt_token: true
+        expect(JWT.decode(token.token, nil, nil)[0]).to eq({ "foo" => "bar" })
+      end
+
+      it "encodes the signed payload in to the token" do
+        Doorkeeper.configure do
+          use_jwt_token
+
+          jwt_token_payload do
+            { foo: "bar" }
+          end
+
+          jwt_secret_key "secret"
+        end
+
+        token = FactoryGirl.create :access_token, use_jwt_token: true
+        expect(JWT.decode(token.token, "secret", nil)[0]).to eq({ "foo" => "bar" })
+      end
+
+      it "encodes the encrypted payload in to the token" do
+        Doorkeeper.configure do
+          use_jwt_token
+
+          jwt_token_payload do
+            { foo: "bar" }
+          end
+
+          jwt_secret_key "secret"
+          jwt_encryption_method :hs512
+        end
+
+        token = FactoryGirl.create :access_token, use_jwt_token: true
+        expect(JWT.decode(token.token, "secret", "HS512")[0]).to eq({ "foo" => "bar" })
+      end
+
+      it "does not use JWT without use_jwt_token set" do
+        Doorkeeper.configure do
+          jwt_token_payload do
+            { foo: "bar" }
+          end
+        end
+
+        token = FactoryGirl.create :access_token
+        expect{ JWT.decode(token.token, nil, nil) }.to raise_error(JWT::DecodeError)
+      end
+    end
+
     describe :refresh_token do
       it 'has empty refresh token if it was not required' do
         token = FactoryGirl.create :access_token

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -36,7 +36,7 @@ module Doorkeeper
 
         token = FactoryGirl.create :access_token, use_jwt_token: true
         decoded_token = JWT.decode(token.token, nil, nil)
-        expect(decoded_token[0]).to eq({ "foo" => "bar" })
+        expect(decoded_token[0]).to eq("foo" => "bar")
       end
 
       it "encodes the signed payload in to the token" do
@@ -52,7 +52,7 @@ module Doorkeeper
 
         token = FactoryGirl.create :access_token, use_jwt_token: true
         decoded_token = JWT.decode(token.token, "secret", nil)
-        expect(decoded_token[0]).to eq({ "foo" => "bar" })
+        expect(decoded_token[0]).to eq("foo" => "bar")
       end
 
       it "encodes the encrypted payload in to the token" do
@@ -69,7 +69,7 @@ module Doorkeeper
 
         token = FactoryGirl.create :access_token, use_jwt_token: true
         decoded_token = JWT.decode(token.token, "secret", "HS512")
-        expect(decoded_token[0]).to eq({ "foo" => "bar" })
+        expect(decoded_token[0]).to eq("foo" => "bar")
         expect(decoded_token[1]["typ"]).to eq "JWT"
         expect(decoded_token[1]["alg"]).to eq "HS512"
       end
@@ -82,8 +82,8 @@ module Doorkeeper
         end
 
         token = FactoryGirl.create :access_token
-        expect{ JWT.decode(token.token, nil, nil) }
-          .to raise_error(JWT::DecodeError)
+        expect { JWT.decode(token.token, nil, nil) }.to(
+          raise_error(JWT::DecodeError))
       end
     end
 

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -15,6 +15,7 @@ module Doorkeeper
     describe :token do
       it "creates a JWT token" do
         Doorkeeper.configure do
+          orm DOORKEEPER_ORM
           use_jwt_token
         end
 
@@ -27,6 +28,7 @@ module Doorkeeper
 
       it "encodes the payload in to the token" do
         Doorkeeper.configure do
+          orm DOORKEEPER_ORM
           use_jwt_token
 
           jwt_token_payload do
@@ -41,6 +43,7 @@ module Doorkeeper
 
       it "encodes the signed payload in to the token" do
         Doorkeeper.configure do
+          orm DOORKEEPER_ORM
           use_jwt_token
 
           jwt_token_payload do
@@ -57,6 +60,7 @@ module Doorkeeper
 
       it "encodes the encrypted payload in to the token" do
         Doorkeeper.configure do
+          orm DOORKEEPER_ORM
           use_jwt_token
 
           jwt_token_payload do
@@ -76,6 +80,7 @@ module Doorkeeper
 
       it "does not use JWT without use_jwt_token set" do
         Doorkeeper.configure do
+          orm DOORKEEPER_ORM
           jwt_token_payload do
             { foo: "bar" }
           end


### PR DESCRIPTION
We talked about making this an extension in #598 but I wanted to submit it as a PR and get your thoughts before attempting to extract it, both to check that I'm not missing anything and in case seeing it written out changes your perspective on having it in the gem directly.

Adds support for JWT tokens, set up through the regular Doorkeeper config process. Supports custom payloads and secrets and multiple encryption types, all disabled by default.

Use case for JWT tokens is allowing applications to identify tokens provided by the Doorkeeper app and communicate amongst themselves without having to check in with the central application. If you know the secret used to encode the token you can decode it and access identifying information for the user.