### PR TITLE
Allow custom access token generators to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,17 @@ class Api::V1::ProductsController < Api::V1::ApiController
 end
 ```
 
-For a more detailed explanation about scopes usage, check out the related
-[page in the
-wiki](https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes).
+### Custom Access Token Generator
+
+By default a 32 bit access token will be generated. If you require a custom token, such as [JWT](http://jwt.io), specify an object that responds to `.generate(resource_owner_id: resource_owner_id)` and returns a string to be used as the token.
+
+```ruby
+Doorkeeper.configure do
+  access_token_generator "Doorkeeper::JWT"
+end
+```
+
+JWT token support is available with [Doorkeeper-JWT](https://github.com/chriswarren/doorkeeper-jwt).
 
 ### Authenticated resource owner
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -204,7 +204,8 @@ and that your `initialize_models!` method doesn't raise any errors.\n
     option :realm,                          default: 'Doorkeeper'
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
-    option :access_token_generator, default: "UniqueToken"
+    option :access_token_generator,
+      default: "Doorkeeper::OAuth::Helpers::UniqueToken"
 
     attr_reader :reuse_access_token
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -204,8 +204,7 @@ and that your `initialize_models!` method doesn't raise any errors.\n
     option :realm,                          default: 'Doorkeeper'
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
-    option :access_token_generator,
-    default: "Doorkeeper::OAuth::Helpers::UniqueToken"
+    option :access_token_generator,         default: "Doorkeeper::OAuth::Helpers::UniqueToken"
 
     attr_reader :reuse_access_token
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -110,7 +110,9 @@ and that your `initialize_models!` method doesn't raise any errors.\n
       end
 
       def access_token_generator(access_token_generator)
-        @config.instance_variable_set('@access_token_generator', access_token_generator)
+        @config.instance_variable_set(
+          '@access_token_generator', access_token_generator
+        )
       end
     end
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -108,6 +108,10 @@ and that your `initialize_models!` method doesn't raise any errors.\n
       def force_ssl_in_redirect_uri(boolean)
         @config.instance_variable_set("@force_ssl_in_redirect_uri", boolean)
       end
+
+      def access_token_generator(access_token_generator)
+        @config.instance_variable_set('@access_token_generator', access_token_generator)
+      end
     end
 
     module Option
@@ -198,6 +202,7 @@ and that your `initialize_models!` method doesn't raise any errors.\n
     option :realm,                          default: 'Doorkeeper'
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
+    option :access_token_generator, default: "UniqueToken"
 
     attr_reader :reuse_access_token
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -205,7 +205,7 @@ and that your `initialize_models!` method doesn't raise any errors.\n
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
     option :access_token_generator,
-      default: "Doorkeeper::OAuth::Helpers::UniqueToken"
+    default: "Doorkeeper::OAuth::Helpers::UniqueToken"
 
     attr_reader :reuse_access_token
 

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -11,5 +11,8 @@ module Doorkeeper
 
     class MissingRequestStrategy < DoorkeeperError
     end
+
+    class UnableToGenerateToken < DoorkeeperError
+    end
   end
 end

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -14,5 +14,8 @@ module Doorkeeper
 
     class UnableToGenerateToken < DoorkeeperError
     end
+
+    class TokenGeneratorNotFound < DoorkeeperError
+    end
   end
 end

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -128,7 +128,7 @@ module Doorkeeper
     end
 
     def generate_token
-      generator = eval(Doorkeeper.configuration.access_token_generator)
+      generator = Doorkeeper.configuration.access_token_generator.constantize
       self.token = generator.generate
     rescue NoMethodError
       raise Errors::UnableToGenerateToken,

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -132,7 +132,7 @@ module Doorkeeper
       self.token = generator.generate
     rescue NoMethodError
       raise Errors::UnableToGenerateToken,
-        "#{generator} does not respond to `.generate`."
+      "#{generator} does not respond to `.generate`."
     end
   end
 end

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -129,15 +129,12 @@ module Doorkeeper
 
     def generate_token
       generator = Doorkeeper.configuration.access_token_generator.constantize
-
-      if generator.method(:generate).arity == 1
-        self.token = generator.generate(resource_owner_id)
-      else
-        self.token = generator.generate
-      end
-    rescue ArgumentError, TypeError, NoMethodError, NameError
+      self.token = generator.generate(resource_owner_id: resource_owner_id)
+    rescue NoMethodError
       raise Errors::UnableToGenerateToken,
       "#{generator} does not respond to `.generate`."
+    rescue NameError
+      raise Errors::TokenGeneratorNotFound, "#{generator} not found"
     end
   end
 end

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -129,8 +129,13 @@ module Doorkeeper
 
     def generate_token
       generator = Doorkeeper.configuration.access_token_generator.constantize
-      self.token = generator.generate
-    rescue NoMethodError
+
+      if generator.method(:generate).arity == 1
+        self.token = generator.generate(resource_owner_id)
+      else
+        self.token = generator.generate
+      end
+    rescue ArgumentError, TypeError, NoMethodError, NameError
       raise Errors::UnableToGenerateToken,
       "#{generator} does not respond to `.generate`."
     end

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -128,7 +128,11 @@ module Doorkeeper
     end
 
     def generate_token
-      self.token = UniqueToken.generate
+      generator = eval(Doorkeeper.configuration.access_token_generator)
+      self.token = generator.generate
+    rescue NoMethodError
+      raise Errors::UnableToGenerateToken,
+        "#{generator} does not respond to `.generate`."
     end
   end
 end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -31,6 +31,13 @@ Doorkeeper.configure do
   #   oauth_client.application.additional_settings.implicit_oauth_expiration
   # end
 
+  # Use a custom method for generating the access token. Provide a class that
+  # responds to `.generate` and returns a token string. If the method requires
+  # identifying information about the token owner it can accept one parameter,
+  # and `resource_owner_id` will be passed.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/pull/610
+  # access_token_generator "::Doorkeeper::JWT"
+
   # Reuse access token for the same resource owner within an application (disabled by default)
   # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
   # reuse_access_token

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -31,11 +31,8 @@ Doorkeeper.configure do
   #   oauth_client.application.additional_settings.implicit_oauth_expiration
   # end
 
-  # Use a custom method for generating the access token. Provide a class that
-  # responds to `.generate` and returns a token string. If the method requires
-  # identifying information about the token owner it can accept one parameter,
-  # and `resource_owner_id` will be passed.
-  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/pull/610
+  # Use a custom class for generating the access token.
+  # https://github.com/doorkeeper-gem/doorkeeper#custom-access-token-generator
   # access_token_generator "::Doorkeeper::JWT"
 
   # Reuse access token for the same resource owner within an application (disabled by default)

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -298,4 +298,20 @@ describe Doorkeeper, 'configuration' do
       @config = old_config
     end
   end
+
+  describe 'access_token_generator' do
+    it 'is \'UniqueToken\' by default' do
+      expect(Doorkeeper.configuration.access_token_generator).to(
+        eq('UniqueToken')
+      )
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        access_token_generator 'Example'
+      end
+      expect(subject.access_token_generator).to eq('Example')
+    end
+  end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -300,9 +300,9 @@ describe Doorkeeper, 'configuration' do
   end
 
   describe 'access_token_generator' do
-    it 'is \'UniqueToken\' by default' do
+    it 'is \'Doorkeeper::OAuth::Helpers::UniqueToken\' by default' do
       expect(Doorkeeper.configuration.access_token_generator).to(
-        eq('UniqueToken')
+        eq('Doorkeeper::OAuth::Helpers::UniqueToken')
       )
     end
 

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -14,9 +14,13 @@ module Doorkeeper
 
     describe :generate_token do
       it 'generates a token using the default method' do
-        allow(OAuth::Helpers::UniqueToken).to receive(:generate).and_call_original
-        token = FactoryGirl.create :access_token
-        expect(OAuth::Helpers::UniqueToken).to have_received(:generate).at_least(3).times
+        allow(OAuth::Helpers::UniqueToken).to(
+          receive(:generate).and_call_original)
+
+        FactoryGirl.create :access_token
+
+        expect(OAuth::Helpers::UniqueToken).to(
+          have_received(:generate).at_least(3).times)
       end
 
       it 'generates a token using a custom method' do
@@ -31,12 +35,14 @@ module Doorkeeper
           access_token_generator "CustomGenerator"
         end
 
-        allow(OAuth::Helpers::UniqueToken).to receive(:generate).and_call_original
+        allow(OAuth::Helpers::UniqueToken).to(
+          receive(:generate).and_call_original)
         allow(CustomGenerator).to receive(:generate).and_call_original
 
-        token = FactoryGirl.create :access_token
+        FactoryGirl.create :access_token
 
-        expect(OAuth::Helpers::UniqueToken).to have_received(:generate).at_least(2).times
+        expect(OAuth::Helpers::UniqueToken).to(
+          have_received(:generate).at_least(2).times)
         expect(CustomGenerator).to have_received(:generate)
       end
 
@@ -49,11 +55,11 @@ module Doorkeeper
           access_token_generator "NoGenerate"
         end
 
-        allow(OAuth::Helpers::UniqueToken).to receive(:generate).and_call_original
+        allow(OAuth::Helpers::UniqueToken).to(
+          receive(:generate).and_call_original)
 
         expect{ FactoryGirl.create :access_token }.to(
-          raise_error(Doorkeeper::Errors::UnableToGenerateToken)
-        )
+          raise_error(Doorkeeper::Errors::UnableToGenerateToken))
       end
     end
 

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -20,9 +20,9 @@ module Doorkeeper
         expect(token.token).to be_a(String)
       end
 
-      it 'generates a token using a custom method' do
+      it 'generates a token using a custome class' do
         module CustomGenerator
-          def self.generate
+          def self.generate(opts={})
             "custom_generator_token"
           end
         end
@@ -36,10 +36,10 @@ module Doorkeeper
         expect(token.token).to eq("custom_generator_token")
       end
 
-      it 'generates a token using a custom method that accepts an argument' do
+      it 'generates a token using a custome class that accepts an argument' do
         module CustomGeneratorArgs
-          def self.generate(resource_owner_id)
-            "custom_generator_token_#{resource_owner_id}"
+          def self.generate(opts={})
+            "custom_generator_token_#{opts[:resource_owner_id]}"
           end
         end
 
@@ -52,7 +52,7 @@ module Doorkeeper
         expect(token.token).to match(%r{custom_generator_token_\d})
       end
 
-      it 'raises an error if the custom method does not support generate' do
+      it 'raises an error if the custome class does not support generate' do
         module NoGenerate
         end
 
@@ -63,6 +63,16 @@ module Doorkeeper
 
         expect { FactoryGirl.create :access_token }.to(
           raise_error(Doorkeeper::Errors::UnableToGenerateToken))
+      end
+
+      it 'raises an error if the custome class does not exist' do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          access_token_generator "Doorkeeper::NotReal"
+        end
+
+        expect { FactoryGirl.create :access_token }.to(
+          raise_error(Doorkeeper::Errors::TokenGeneratorNotFound))
       end
     end
 

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -32,7 +32,7 @@ module Doorkeeper
 
         Doorkeeper.configure do
           orm DOORKEEPER_ORM
-          access_token_generator "CustomGenerator"
+          access_token_generator "Doorkeeper::CustomGenerator"
         end
 
         allow(OAuth::Helpers::UniqueToken).to(
@@ -52,13 +52,13 @@ module Doorkeeper
 
         Doorkeeper.configure do
           orm DOORKEEPER_ORM
-          access_token_generator "NoGenerate"
+          access_token_generator "Doorkeeper::NoGenerate"
         end
 
         allow(OAuth::Helpers::UniqueToken).to(
           receive(:generate).and_call_original)
 
-        expect{ FactoryGirl.create :access_token }.to(
+        expect { FactoryGirl.create :access_token }.to(
           raise_error(Doorkeeper::Errors::UnableToGenerateToken))
       end
     end

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -20,25 +20,9 @@ module Doorkeeper
         expect(token.token).to be_a(String)
       end
 
-      it 'generates a token using a custome class' do
-        module CustomGenerator
-          def self.generate(opts={})
-            "custom_generator_token"
-          end
-        end
-
-        Doorkeeper.configure do
-          orm DOORKEEPER_ORM
-          access_token_generator "Doorkeeper::CustomGenerator"
-        end
-
-        token = FactoryGirl.create :access_token
-        expect(token.token).to eq("custom_generator_token")
-      end
-
-      it 'generates a token using a custome class that accepts an argument' do
+      it 'generates a token using a custom object' do
         module CustomGeneratorArgs
-          def self.generate(opts={})
+          def self.generate(opts = {})
             "custom_generator_token_#{opts[:resource_owner_id]}"
           end
         end
@@ -52,7 +36,7 @@ module Doorkeeper
         expect(token.token).to match(%r{custom_generator_token_\d})
       end
 
-      it 'raises an error if the custome class does not support generate' do
+      it 'raises an error if the custom object does not support generate' do
         module NoGenerate
         end
 
@@ -65,7 +49,7 @@ module Doorkeeper
           raise_error(Doorkeeper::Errors::UnableToGenerateToken))
       end
 
-      it 'raises an error if the custome class does not exist' do
+      it 'raises an error if the custom object does not exist' do
         Doorkeeper.configure do
           orm DOORKEEPER_ORM
           access_token_generator "Doorkeeper::NotReal"

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -12,6 +12,51 @@ module Doorkeeper
       let(:factory_name) { :access_token }
     end
 
+    describe :generate_token do
+      it 'generates a token using the default method' do
+        allow(OAuth::Helpers::UniqueToken).to receive(:generate).and_call_original
+        token = FactoryGirl.create :access_token
+        expect(OAuth::Helpers::UniqueToken).to have_received(:generate).at_least(3).times
+      end
+
+      it 'generates a token using a custom method' do
+        module CustomGenerator
+          def self.generate
+            "asdf1234"
+          end
+        end
+
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          access_token_generator "CustomGenerator"
+        end
+
+        allow(OAuth::Helpers::UniqueToken).to receive(:generate).and_call_original
+        allow(CustomGenerator).to receive(:generate).and_call_original
+
+        token = FactoryGirl.create :access_token
+
+        expect(OAuth::Helpers::UniqueToken).to have_received(:generate).at_least(2).times
+        expect(CustomGenerator).to have_received(:generate)
+      end
+
+      it 'raises an error if the custom method does not support generate' do
+        module NoGenerate
+        end
+
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          access_token_generator "NoGenerate"
+        end
+
+        allow(OAuth::Helpers::UniqueToken).to receive(:generate).and_call_original
+
+        expect{ FactoryGirl.create :access_token }.to(
+          raise_error(Doorkeeper::Errors::UnableToGenerateToken)
+        )
+      end
+    end
+
     describe :refresh_token do
       it 'has empty refresh token if it was not required' do
         token = FactoryGirl.create :access_token

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -15,6 +15,7 @@ require 'rspec/autorun'
 require 'generator_spec/test_case'
 require 'timecop'
 require 'database_cleaner'
+require 'pry'
 
 Rails.logger.info "====> Doorkeeper.orm = #{Doorkeeper.configuration.orm.inspect}"
 if Doorkeeper.configuration.orm == :active_record


### PR DESCRIPTION
In response to #610, allows for custom access token generators to be used. Once this is in I'll move the functionality from the PR over to a separate gem. 