### PR TITLE
Development-URIs

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -194,6 +194,7 @@ and that your `initialize_models!` method doesn't raise any errors.\n
     option :authorization_code_expires_in,  default: 600
     option :orm,                            default: :active_record
     option :native_redirect_uri,            default: 'urn:ietf:wg:oauth:2.0:oob'
+    option :development_uris,               default: :disabled
     option :active_record_options,          default: {}
     option :realm,                          default: 'Doorkeeper'
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -15,8 +15,25 @@ module Doorkeeper
           url == client_url
         end
 
+        def self.matches_development_urls?(url)
+          return false if Doorkeeper.configuration.development_uris == :disabled
+
+          Doorkeeper.configuration.development_uris.split.any? do |dev_url|
+            host_match?(url, dev_url)
+          end
+        end
+
         def self.valid_for_authorization?(url, client_url)
           valid?(url) && client_url.split.any? { |other_url| matches?(url, other_url) }
+        end
+
+        def self.host_match?(url1, url2)
+          host1 = as_uri(url1).host
+          host2 = as_uri(url2).host
+
+          # check domains, ignore subdomains
+          check_length = [host1.length, host2.length].min
+          host1[-check_length..-1] == host2[-check_length..-1]
         end
 
         def self.as_uri(url)

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -58,8 +58,11 @@ module Doorkeeper
       # TODO: test uri should be matched against the client's one
       def validate_redirect_uri
         return false unless redirect_uri.present?
-        Helpers::URIChecker.native_uri?(redirect_uri) ||
-          Helpers::URIChecker.valid_for_authorization?(redirect_uri, client.redirect_uri)
+        result = Helpers::URIChecker.native_uri?(redirect_uri)
+        result |= Helpers::URIChecker.valid_for_authorization?(redirect_uri, client.redirect_uri)
+        result |= Helpers::URIChecker.matches_development_urls?(redirect_uri)
+
+        result
       end
     end
   end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -102,4 +102,14 @@ Doorkeeper.configure do
 
   # WWW-Authenticate Realm (default "Doorkeeper").
   # realm "Doorkeeper"
+
+  # URIs for development environment
+  # These won't get validated against redirect_uris of a client and will always
+  # be redirect after an successful authorization.
+  # Also, only host will be matched, and subdomains will be ignored
+  # Example: set to 'https://devs.your-company.com:3000'
+  # Redirect from 'http://this-dev.devs.your-company.com:3001/whatever?and=so_on'
+  # will be redirect to the given URL
+  # If this setting is set to :disabled, behavior won't change
+  # development_uris :disabled
 end

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -95,4 +95,14 @@ Doorkeeper.configure do
 
   # WWW-Authenticate Realm (default "Doorkeeper").
   realm "Doorkeeper"
+
+  # URIs for development environment
+  # These won't get validated against redirect_uris of a client and will always
+  # be redirect after an successful authorization.
+  # Also, only host will be matched, and subdomains will be ignored
+  # Example: set to 'https://devs.your-company.com:3000'
+  # Redirect from 'http://this-dev.devs.your-company.com:3001/whatever?and=so_on'
+  # will be redirect to the given URL
+  # If this setting is set to :disabled, behavior won't change
+  development_uris :disabled
 end

--- a/spec/lib/oauth/helpers/uri_checker_spec.rb
+++ b/spec/lib/oauth/helpers/uri_checker_spec.rb
@@ -41,6 +41,79 @@ module Doorkeeper::OAuth::Helpers
       end
     end
 
+    describe '.host_match?' do
+      it 'is true for equal hosts' do
+        uri = client_uri = 'http://app.co'
+        expect(URIChecker.host_match?(uri, client_uri)).to be_truthy
+      end
+
+      it 'is true for subdomain hosts' do
+        uri = 'http://whatever.app.co'
+        client_uri = 'http://app.co'
+        expect(URIChecker.host_match?(uri, client_uri)).to be_truthy
+
+        uri = 'http://app.co'
+        client_uri = 'http://whatever.app.co'
+        expect(URIChecker.host_match?(uri, client_uri)).to be_truthy
+      end
+
+      it 'ignores path on comparsion' do
+        uri = 'http://app.co/hello_world'
+        client_uri = 'http://app.co'
+        expect(URIChecker.host_match?(uri, client_uri)).to be_truthy
+      end
+
+      it 'ignores query parameter on comparsion' do
+        uri = 'http://app.co/?query=testing'
+        client_uri = 'http://app.co'
+        expect(URIChecker.host_match?(uri, client_uri)).to be_truthy
+      end
+
+      it 'ignores path that look like domains on comparsion' do
+        uri = 'http://app.com/app.co'
+        client_uri = 'http://app.co'
+        expect(URIChecker.host_match?(uri, client_uri)).to be_falsey
+      end
+
+      it 'fails for not matching domains' do
+        uri = 'http://app.com/'
+        client_uri = 'http://app.co'
+        expect(URIChecker.host_match?(uri, client_uri)).to be_falsey
+      end
+    end
+
+    describe '.matches_development_urls?' do
+      it 'is true if url matches a client url' do
+        Doorkeeper.configuration.instance_variable_set '@development_uris', 'http://example.co http://example.com'
+
+        uri = 'http://example.com'
+        expect(URIChecker.matches_development_urls?(uri)).to be_truthy
+      end
+
+      it 'is true even with subdomains' do
+        Doorkeeper.configuration.instance_variable_set '@development_uris', 'http://example.co http://example.com'
+        uri = 'http://subdomain.example.com'
+        expect(URIChecker.matches_development_urls?(uri)).to be_true
+      end
+
+      it 'ignores query params' do
+        Doorkeeper.configuration.instance_variable_set '@development_uris', 'http://example.co http://example.com'
+        uri = 'http://example.com?foo=bar'
+        expect(URIChecker.matches_development_urls?(uri)).to be_truthy
+      end
+
+      it 'fails if it does not match' do
+        Doorkeeper.configuration.instance_variable_set '@development_uris', 'http://example.co http://example.com'
+        uri = 'http://example.de'
+        expect(URIChecker.matches_development_urls?(uri)).to be_falsey
+      end
+
+      it 'fails if config is disabled' do
+        uri = 'http://example.de'
+        expect(URIChecker.matches_development_urls?(uri)).to be_falsey
+      end
+    end
+
     describe '.matches?' do
       it 'is true if both url matches' do
         uri = client_uri = 'http://app.co/aaa'
@@ -98,6 +171,25 @@ module Doorkeeper::OAuth::Helpers
       it 'is false if invalid' do
         uri = client_uri = 'http://app.co/aaa?waffles=abc'
         expect(URIChecker.valid_for_authorization?(uri, client_uri)).to be false
+      end
+    end
+
+    describe '.matches_development_urls?' do
+      it 'is true for valid development uri' do
+        Doorkeeper.configuration.instance_variable_set '@development_uris', 'http://localhost:3000 http://example.com'
+        uri = 'http://localhost:3000'
+        expect(URIChecker.matches_development_urls?(uri)).to be_truthy
+      end
+
+      it 'is true for valid development uri regardless of port' do
+        Doorkeeper.configuration.instance_variable_set '@development_uris', 'http://localhost:3000 http://example.com'
+        uri = 'http://localhost:1337'
+        expect(URIChecker.matches_development_urls?(uri)).to be_truthy
+      end
+
+      it 'is false for default development_uris-setting' do
+        uri = 'http://localhost:1337'
+        expect(URIChecker.matches_development_urls?(uri)).to be_falsey
       end
     end
   end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -133,6 +133,14 @@ module Doorkeeper::OAuth
       expect(subject).not_to be_authorizable
     end
 
+    it 'matches the redirect uri against development_uris' do
+      subject.redirect_uri = 'http://nothesame.com'
+
+      Doorkeeper.configuration.instance_variable_set '@development_uris', 'http://nothesame.com/'
+      expect(subject).to be_authorizable
+    end
+
+
     it 'stores the state' do
       expect(subject.state).to eq('save-this')
     end


### PR DESCRIPTION
This adds a feature to define static Development-URIs. When requesting access from one of those (or subdomains), the request will be considered valid even when the redirect_uri does not match a Client-URI. 

This helps testing the OAuth-Integeration while developing apps without the need to define specific Development-URIs per Application. 

Since the default setting disables this feature, there is no need to update the configuration of existing apps.  

Matching is based on the host only. Ports, Protocol, Params, etc. will be ignored. So keep in mind, that you could create security issues when using it irresponsible. (e.g. don't add http://com as a Dev-URI :see_no_evil:)