### PR TITLE
Feature: Allow regex expressions of what constitutes a valid redirect uri

### DIFF
--- a/app/validators/redirect_uri_validator.rb
+++ b/app/validators/redirect_uri_validator.rb
@@ -24,7 +24,7 @@ class RedirectUriValidator < ActiveModel::EachValidator
   private
 
   def native_redirect_uri?(uri)
-    self.class.native_redirect_uri.present? && uri.to_s == self.class.native_redirect_uri.to_s
+    self.class.native_redirect_uri.present? && uri.to_s.match(self.class.native_redirect_uri)
   end
 
   def invalid_ssl_uri?(uri)


### PR DESCRIPTION
Different Applications are unable to use both urn:ietf:wg:oauth:2.0:oob:auto and urn:ietf:wg:oauth:2.0:oob. I thought the best way to solve this was to allow for the `native_redirect_uri` to be a regular expression, such as /urn:ietf:wg:oauth:2.0:oob:auto|urn:ietf:wg:oauth:2.0:oob/

Further, applications may have their own schema requirements that aren't either of the those.