### PR TITLE
Properly fall back to default_scopes when no scope is specified.

### DIFF
--- a/lib/doorkeeper/rails/helpers.rb
+++ b/lib/doorkeeper/rails/helpers.rb
@@ -4,7 +4,7 @@ module Doorkeeper
       extend ActiveSupport::Concern
 
       def doorkeeper_authorize!(*scopes)
-        @_doorkeeper_scopes = scopes || Doorkeeper.configuration.default_scopes
+        @_doorkeeper_scopes = scopes.presence || Doorkeeper.configuration.default_scopes
 
         if !valid_doorkeeper_token?
           doorkeeper_render_error

--- a/spec/requests/protected_resources/private_api_spec.rb
+++ b/spec/requests/protected_resources/private_api_spec.rb
@@ -40,6 +40,17 @@ feature 'Private API' do
     expect(page.body).to have_content('index')
   end
 
+  scenario 'access token with no default scopes' do
+    Doorkeeper.configuration.instance_eval {
+      @default_scopes = Doorkeeper::OAuth::Scopes.from_array([:public])
+      @scopes = default_scopes + optional_scopes
+    }
+    @token.update_attribute :scopes, 'dummy'
+    with_access_token_header @token.token
+    visit '/full_protected_resources'
+    response_status_should_be 403
+  end
+
   scenario 'access token with no allowed scopes' do
     @token.update_attribute :scopes, nil
     with_access_token_header @token.token


### PR DESCRIPTION
The parameter `scopes` is always an array which evaluates as truthy, so the intended fallback has never worked.

This bug caused Doorkeeper to allow clients to access to protected resources under the default scopes regardless of the scopes their token has.