### PR TITLE
Extra Details to Custom Token Generator

### DIFF
--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -129,7 +129,9 @@ module Doorkeeper
 
     def generate_token
       generator = Doorkeeper.configuration.access_token_generator.constantize
-      self.token = generator.generate(resource_owner_id: resource_owner_id)
+      self.token = generator.generate(resource_owner_id: resource_owner_id,
+                                      scopes: scopes, application: application,
+                                      expires_in: expires_in)
     rescue NoMethodError
       raise Errors::UnableToGenerateToken, "#{generator} does not respond to `.generate`."
     rescue NameError


### PR DESCRIPTION
Added scopes, application and expires_in to the arguments passed to custom token generators.

Scopes and application are needed for use with client credentials grants as in such cases the resource_owner_id is nil and so the scope and application can be used to identify the authorization context of the request.

Expires in is passed so that JWT tokens created with Doorkeeper::JWT gem can set JWT "exp" attribute and allow other systems looking at the JWT token to check the expiry.