### PR TITLE
Fix parameter for custom_access_token_expires_in

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ User-visible changes worth mentioning.
 
 ---
 
+## 2.2.1 - unreleased
+
+- [#636] `custom_access_token_expires_in` bugfixes
+
+
 ## 2.2.0 - 2015-04-19
 
 - [#611] Allow custom access token generators to be used

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -9,12 +9,9 @@ module Doorkeeper
           @resource_owner = resource_owner
         end
 
-        def self.access_token_expires_in(server, pre_auth)
-          custom_expiration = server.
-            custom_access_token_expires_in.call(pre_auth)
-
-          if custom_expiration
-            custom_expiration
+        def self.access_token_expires_in(server, pre_auth_or_oauth_client)
+          if expiration = custom_expiration(server, pre_auth_or_oauth_client)
+            expiration
           else
             server.access_token_expires_in
           end
@@ -36,6 +33,18 @@ module Doorkeeper
             action: :show,
             access_token: token.token
           }
+        end
+
+        private
+
+        def self.custom_expiration(server, pre_auth_or_oauth_client)
+          oauth_client = if pre_auth_or_oauth_client.respond_to?(:client)
+                           pre_auth_or_oauth_client.client
+                         else
+                           pre_auth_or_oauth_client
+                         end
+
+          server.custom_access_token_expires_in.call(oauth_client)
         end
 
         def configuration

--- a/lib/doorkeeper/oauth/client.rb
+++ b/lib/doorkeeper/oauth/client.rb
@@ -4,6 +4,14 @@ require 'doorkeeper/oauth/client/credentials'
 module Doorkeeper
   module OAuth
     class Client
+      attr_accessor :application
+
+      delegate :id, :name, :uid, :redirect_uri, :scopes, to: :@application
+
+      def initialize(application)
+        @application = application
+      end
+
       def self.find(uid, method = Application.method(:by_uid))
         if application = method.call(uid)
           new(application)
@@ -12,18 +20,11 @@ module Doorkeeper
 
       def self.authenticate(credentials, method = Application.method(:by_uid_and_secret))
         return false if credentials.blank?
+
         if application = method.call(credentials.uid, credentials.secret)
           new(application)
         end
       end
-
-      delegate :id, :name, :uid, :redirect_uri, :scopes, to: :@application
-
-      def initialize(application)
-        @application = application
-      end
-
-      attr_accessor :application
     end
   end
 end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -11,8 +11,8 @@ module Doorkeeper
       validate :client_match, error: :invalid_grant
       validate :scope,        error: :invalid_scope
 
-      attr_accessor :server, :refresh_token, :credentials, :access_token
-      attr_accessor :client
+      attr_accessor :access_token, :client, :credentials, :refresh_token,
+                    :server
 
       def initialize(server, refresh_token, credentials, parameters = {})
         @server          = server
@@ -41,11 +41,16 @@ module Doorkeeper
       end
 
       def create_access_token
+        expires_in = Authorization::Token.access_token_expires_in(
+          server,
+          client
+        )
+
         @access_token = AccessToken.create!(
-          application_id:    refresh_token.application_id,
+          application_id: refresh_token.application_id,
           resource_owner_id: refresh_token.resource_owner_id,
-          scopes:            scopes.to_s,
-          expires_in:        server.access_token_expires_in,
+          scopes: scopes.to_s,
+          expires_in: expires_in,
           use_refresh_token: true)
       end
 


### PR DESCRIPTION
`custom_access_token_expires_in` parameter could be an instance of:

* `Doorkeeper::OAuth::PreAuthorization`
* `Doorkeeper::OAuth::Client`
* `Doorkeeper::Application`

`Doorkeeper::OAuth::Client` is a small wrapper around
`Doorkeeper::Application`. `PreAuthorization` is an entirely different
object. This patch checks if we are about to send a `PreAuthorization`, and
if so we grab the associated client. This way, the method always receives
an Oauth Client as parameter.

Also, use `custom_access_token_expires_in` in `RefreshTokenRequest`.

[fixes #617]