### PR TITLE
only fallback i18n when it's not set

### DIFF
--- a/lib/doorkeeper/engine.rb
+++ b/lib/doorkeeper/engine.rb
@@ -5,7 +5,9 @@ module Doorkeeper
     end
 
     initializer "doorkeeper.locales" do |app|
-      app.config.i18n.fallbacks = [:en]
+      if app.config.i18n.fallbacks.blank?
+        app.config.i18n.fallbacks = [:en]
+      end
     end
 
     initializer "doorkeeper.routes" do


### PR DESCRIPTION
PR for #649

The option fallback can be set as many types, such as `ActiveSupport::OrderedOption`, `Array`, `Hash`, `true`, `false` and `nil`.

I also found the `lib/doorkeeper/engine.rb` is run after `config/appliction.rb`

To conservative, let only set i18n fallback when the application not set it.