### PR TITLE
Remove unused update authorization route from the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ This will mount following routes:
     GET       /oauth/authorize/:code
     GET       /oauth/authorize
     POST      /oauth/authorize
-    PUT       /oauth/authorize
     DELETE    /oauth/authorize
     POST      /oauth/token
     POST      /oauth/revoke


### PR DESCRIPTION
This should have been in #574. Ooops.