### PR TITLE
Array#join for multiple URI errors

### DIFF
--- a/app/helpers/doorkeeper/dashboard_helper.rb
+++ b/app/helpers/doorkeeper/dashboard_helper.rb
@@ -5,7 +5,7 @@ module Doorkeeper::DashboardHelper
         content_tag(:span, class: 'help-block') do
           msg.capitalize
         end
-      end.reduce(&:join).html_safe
+      end.join.html_safe
     end
   end
 

--- a/spec/helpers/doorkeeper/dashboard_helper_spec.rb
+++ b/spec/helpers/doorkeeper/dashboard_helper_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper_integration'
+
+describe Doorkeeper::DashboardHelper do
+  describe '.doorkeeper_errors_for' do
+    let(:object) { double errors: { method: messages } }
+    let(:messages) { ['first message', 'second message'] }
+
+    context 'when object has errors' do
+      it 'returns error messages' do
+        messages.each do |message|
+          expect(helper.doorkeeper_errors_for(object, :method)).to include(
+            message.capitalize
+          )
+        end
+      end
+    end
+
+    context 'when object has no errors' do
+      it 'returns nil' do
+        expect(helper.doorkeeper_errors_for(object, :amonter_method)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
If there are more than one errors `reduce(&:join)` will fail, because of trying to call `String#join`. When there is single error - reduce will return first element of the list without evaluating block (and without exception). I guess there is should be just Array#join.