### PR TITLE
Change scopes for absent application/client to restrict to empty set

### DIFF
--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -62,7 +62,7 @@ module Doorkeeper
         return false unless token.present?
         return true if token.scopes.blank? && param_scopes.blank?
 
-        Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
+        Doorkeeper::OAuth::Helpers::ScopeChecker.match?(
           param_scopes.to_s,
           token,
           application

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -60,16 +60,13 @@ module Doorkeeper
 
       def scopes_match?(token, param_scopes, application)
         return false unless token.present?
+        return true if token.scopes.blank? && param_scopes.blank?
 
-        if token.scopes.blank? && param_scopes.blank?
-          true
-        else
-          Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
-            param_scopes.to_s,
-            token,
-            application
-          )
-        end
+        Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
+          param_scopes.to_s,
+          token,
+          application
+        )
       end
 
       def find_or_create_for(application, resource_owner_id, scopes, expires_in, use_refresh_token)

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -53,18 +53,23 @@ module Doorkeeper
                               resource_owner_or_id
                             end
         token = last_authorized_token_for(application.try(:id), resource_owner_id)
-        if token && scopes_match?(token.scopes, scopes, application.try(:scopes))
+        if token && scopes_match?(token, scopes, application)
           token
         end
       end
 
-      def scopes_match?(token_scopes, param_scopes, app_scopes)
-        (!token_scopes.present? && !param_scopes.present?) ||
-          Doorkeeper::OAuth::Helpers::ScopeChecker.match?(
-            token_scopes.to_s,
-            param_scopes,
-            app_scopes
+      def scopes_match?(token, param_scopes, application)
+        return false unless token.present?
+
+        if token.scopes.blank? && param_scopes.blank?
+          true
+        else
+          Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
+            param_scopes.to_s,
+            token,
+            application
           )
+        end
       end
 
       def find_or_create_for(application, resource_owner_id, scopes, expires_in, use_refresh_token)

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -33,11 +33,6 @@ module Doorkeeper
 
     private
 
-    def has_scopes?
-      Doorkeeper.configuration.orm != :active_record ||
-        Application.new.attributes.include?("scopes")
-    end
-
     def generate_uid
       self.uid ||= UniqueToken.generate
     end

--- a/lib/doorkeeper/oauth/client_credentials/validation.rb
+++ b/lib/doorkeeper/oauth/client_credentials/validation.rb
@@ -27,16 +27,10 @@ module Doorkeeper
         def validate_scopes
           return true unless @request.scopes.present?
 
-          application_scopes = if @client.present?
-                                 @client.application.scopes
-                               else
-                                 ''
-                               end
-
           ScopeChecker.valid?(
-            @request.scopes.to_s,
-            @server.scopes,
-            application_scopes
+            @request.original_scopes,
+            @server,
+            @client.application
           )
         end
       end

--- a/lib/doorkeeper/oauth/client_credentials/validation.rb
+++ b/lib/doorkeeper/oauth/client_credentials/validation.rb
@@ -28,7 +28,7 @@ module Doorkeeper
           return true unless @request.original_scopes.present?
 
           ScopeChecker.valid?(
-            @request.original_scopes,
+            @request.original_scopes.to_s,
             @server,
             @client.application
           )

--- a/lib/doorkeeper/oauth/client_credentials/validation.rb
+++ b/lib/doorkeeper/oauth/client_credentials/validation.rb
@@ -25,7 +25,7 @@ module Doorkeeper
         end
 
         def validate_scopes
-          return true unless @request.scopes.present?
+          return true unless @request.original_scopes.present?
 
           ScopeChecker.valid?(
             @request.original_scopes,

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -18,12 +18,13 @@ module Doorkeeper
           end
 
           def match?
-            valid? && parsed_scopes.has_scopes?(@valid_scopes)
+            valid? && parsed_scopes.equal?(@valid_scopes)
           end
 
           private
 
           def valid_scopes(scopes_source, application)
+            # TODO: Refactor this
             if application
               if application.scopes.present?
                 scopes_source.scopes & application.scopes

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -27,7 +27,7 @@ module Doorkeeper
             if application_scopes.present?
               server_scopes & application_scopes
             else
-              server_scopes
+              OAuth::Scopes.new # Empty set
             end
           end
         end

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -32,7 +32,7 @@ module Doorkeeper
 
       def validate_scopes
         return true unless @original_scopes.present?
-        ScopeChecker.valid? @original_scopes, server.scopes, client.try(:scopes)
+        ScopeChecker.valid? @original_scopes, server, client
       end
 
       def validate_resource_owner

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -50,8 +50,8 @@ module Doorkeeper
         return true unless scope.present?
         Helpers::ScopeChecker.valid?(
           scope,
-          server.scopes,
-          client.application.scopes
+          server,
+          client.application
         )
       end
 

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -72,7 +72,7 @@ module Doorkeeper
 
       def validate_scope
         if @original_scopes.present?
-          ScopeChecker.valid?(@original_scopes, refresh_token.scopes)
+          ScopeChecker.valid?(@original_scopes, refresh_token.scopes, @client.try(:scopes))
         else
           true
         end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -74,8 +74,8 @@ module Doorkeeper
         if @original_scopes.present?
           ScopeChecker.valid?(
               @original_scopes,
-              refresh_token.scopes,
-              @client.try(:scopes)
+              refresh_token,
+              client
           )
         else
           true

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -73,9 +73,9 @@ module Doorkeeper
       def validate_scope
         if @original_scopes.present?
           ScopeChecker.valid?(
-              @original_scopes,
-              refresh_token,
-              client
+            @original_scopes,
+            refresh_token,
+            client
           )
         else
           true

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -72,7 +72,11 @@ module Doorkeeper
 
       def validate_scope
         if @original_scopes.present?
-          ScopeChecker.valid?(@original_scopes, refresh_token.scopes, @client.try(:scopes))
+          ScopeChecker.valid?(
+              @original_scopes,
+              refresh_token.scopes,
+              @client.try(:scopes)
+          )
         else
           true
         end

--- a/lib/doorkeeper/oauth/scopes.rb
+++ b/lib/doorkeeper/oauth/scopes.rb
@@ -60,6 +60,12 @@ module Doorkeeper
         other_array = other.present? ? other.all : []
         self.class.from_array(all & other_array)
       end
+
+      def equal?(other)
+        self_scopes = self.map(&:to_s).sort
+        other_scopes = other.map(&:to_s).sort
+        (self_scopes.size == other_scopes.size) && ((self_scopes & other_scopes) == self_scopes)
+      end
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,6 +20,7 @@ FactoryGirl.define do
   factory :application, class: Doorkeeper::Application do
     sequence(:name) { |n| "Application #{n}" }
     redirect_uri 'https://app.com/callback'
+    scopes 'public write'
   end
 
   factory :user

--- a/spec/lib/oauth/client_credentials/validation_spec.rb
+++ b/spec/lib/oauth/client_credentials/validation_spec.rb
@@ -7,7 +7,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
     let(:server)      { double :server, scopes: nil }
     let(:application) { double scopes: nil }
     let(:client)      { double application: application }
-    let(:request)     { double :request, client: client, scopes: nil }
+    let(:request)     { double :request, client: client, original_scopes: nil }
 
     subject { Validation.new(server, request) }
 
@@ -24,7 +24,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
       it 'is invalid when scopes are not included in the server' do
         server_scopes = Doorkeeper::OAuth::Scopes.from_string 'email'
         allow(server).to receive(:scopes).and_return(server_scopes)
-        allow(request).to receive(:scopes).and_return(
+        allow(request).to receive(:original_scopes).and_return(
           Doorkeeper::OAuth::Scopes.from_string 'invalid')
         expect(subject).not_to be_valid
       end
@@ -35,7 +35,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
           server_scopes = Doorkeeper::OAuth::Scopes.from_string 'email app'
           allow(application).to receive(:scopes).and_return(application_scopes)
           allow(server).to receive(:scopes).and_return(server_scopes)
-          allow(request).to receive(:scopes).and_return(application_scopes)
+          allow(request).to receive(:original_scopes).and_return(application_scopes)
           expect(subject).to be_valid
         end
 
@@ -44,7 +44,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
           server_scopes = Doorkeeper::OAuth::Scopes.from_string 'email app'
           allow(application).to receive(:scopes).and_return(application_scopes)
           allow(server).to receive(:scopes).and_return(server_scopes)
-          allow(request).to receive(:scopes).and_return(
+          allow(request).to receive(:original_scopes).and_return(
             Doorkeeper::OAuth::Scopes.from_string 'email')
           expect(subject).not_to be_valid
         end

--- a/spec/lib/oauth/helpers/scope_checker_spec.rb
+++ b/spec/lib/oauth/helpers/scope_checker_spec.rb
@@ -7,8 +7,12 @@ module Doorkeeper::OAuth::Helpers
   describe ScopeChecker, '.valid?' do
     let(:server) do
       server = Object.new
-      server.stub(:default_scopes) { ::Doorkeeper::OAuth::Scopes.from_string 'common basic' }
-      server.stub(:scopes) { ::Doorkeeper::OAuth::Scopes.from_string 'common basic extra user' }
+      server.stub(:default_scopes) do
+        ::Doorkeeper::OAuth::Scopes.from_string 'common basic'
+      end
+      server.stub(:scopes) do
+        ::Doorkeeper::OAuth::Scopes.from_string 'common basic extra user'
+      end
       server
     end
 
@@ -63,67 +67,100 @@ module Doorkeeper::OAuth::Helpers
         end
 
         it 'is invalid if scope is not present' do
-          expect(ScopeChecker.valid?(nil, server, application)).to be_falsey
+          expect(
+            ScopeChecker.valid?(nil, server, application)
+          ).to be_falsey
         end
 
         it 'is invalid if unknown scope is present' do
-          expect(ScopeChecker.valid?('scope', server, application)).to be_falsey
+          expect(
+            ScopeChecker.valid?('scope', server, application)
+          ).to be_falsey
         end
 
         it 'is invalid if scope is blank' do
-          expect(ScopeChecker.valid?(' ', server, application)).to be_falsey
+          expect(
+            ScopeChecker.valid?(' ', server, application)
+          ).to be_falsey
         end
 
         it 'is invalid if includes tabs space' do
-          expect(ScopeChecker.valid?("common\tuser", server, application)).to be_falsey
+          expect(
+            ScopeChecker.valid?("common\tuser", server, application)
+          ).to be_falsey
         end
 
         it 'is invalid if includes return space' do
-          expect(ScopeChecker.valid?("common\ruser", server, application)).to be_falsey
+          expect(
+            ScopeChecker.valid?("common\ruser", server, application)
+          ).to be_falsey
         end
 
         it 'is invalid if includes new lines' do
-          expect(ScopeChecker.valid?("common\nuser", server, application)).to be_falsey
+          expect(
+            ScopeChecker.valid?("common\nuser", server, application)
+          ).to be_falsey
         end
 
         it 'is valid if the scope is in the full set of server scopes' do
-          expect(ScopeChecker.valid?('common extra user', server, application)).to be_truthy
+          expect(
+            ScopeChecker.valid?('common extra user', server, application)
+          ).to be_truthy
         end
 
         it 'is invalid if any scope is not in the full set of server scopes' do
-          expect(ScopeChecker.valid?('common extra user invalid', server, application)).to be_falsey
+          expect(
+            ScopeChecker.valid?(
+              'common extra user invalid',
+              server,
+              application)
+          ).to be_falsey
         end
       end
 
       context 'with scopes' do
         let(:application) do
           application = Object.new
-          application.stub(:scopes) { Doorkeeper::OAuth::Scopes.from_string 'common user extra' }
+          application.stub(:scopes) do
+            Doorkeeper::OAuth::Scopes.from_string 'common user extra'
+          end
           application
         end
 
-        it 'is valid if the scope is in the server & application intersection' do
-          expect(ScopeChecker.valid?('common', server, application)).to be_truthy
+        it 'is valid if the scope is in the server/app intersection' do
+          expect(
+            ScopeChecker.valid?('common', server, application)
+          ).to be_truthy
         end
 
-        it 'is valid with multiple scopes in the server & application intersection' do
-          expect(ScopeChecker.valid?('common extra user', server, application)).to be_truthy
+        it 'is valid with multiple scopes in the server/app intersection' do
+          expect(
+            ScopeChecker.valid?('common extra user', server, application)
+          ).to be_truthy
         end
 
         it 'is invalid if the scope is not in the application set' do
-          expect(ScopeChecker.valid?('basic', server, application)).to be_falsey
+          expect(
+            ScopeChecker.valid?('basic', server, application)
+          ).to be_falsey
         end
 
         it 'is invalid if any scope not in the application set' do
-          expect(ScopeChecker.valid?('extra common user basic', server, application)).to be_falsey
+          expect(
+            ScopeChecker.valid?('extra common user basic', server, application)
+          ).to be_falsey
         end
 
         it 'is invalid if the scope is not in the server set' do
-          expect(ScopeChecker.valid?('invalid', server, application)).to be_falsey
+          expect(
+            ScopeChecker.valid?('invalid', server, application)
+          ).to be_falsey
         end
 
         it 'is invalid if any scope is not included in server scopes' do
-          expect(ScopeChecker.valid?('extra common invalid', server, application)).to be_falsey
+          expect(
+            ScopeChecker.valid?('extra common invalid', server, application)
+          ).to be_falsey
         end
       end
     end

--- a/spec/lib/oauth/helpers/scope_checker_spec.rb
+++ b/spec/lib/oauth/helpers/scope_checker_spec.rb
@@ -7,12 +7,8 @@ module Doorkeeper::OAuth::Helpers
   describe ScopeChecker, '.valid?' do
     let(:server) do
       server = Object.new
-      server.stub(:default_scopes) do
-        ::Doorkeeper::OAuth::Scopes.from_string 'common basic'
-      end
-      server.stub(:scopes) do
-        ::Doorkeeper::OAuth::Scopes.from_string 'common basic extra user'
-      end
+      allow(server).to receive(:default_scopes).and_return(::Doorkeeper::OAuth::Scopes.from_string('common basic'))
+      allow(server).to receive(:scopes).and_return(::Doorkeeper::OAuth::Scopes.from_string('common basic extra user'))
       server
     end
 
@@ -62,7 +58,7 @@ module Doorkeeper::OAuth::Helpers
       context 'without scopes' do
         let(:application) do
           application = Object.new
-          application.stub(:scopes) { nil }
+          allow(application).to receive(:scopes).and_return(nil)
           application
         end
 
@@ -121,9 +117,7 @@ module Doorkeeper::OAuth::Helpers
       context 'with scopes' do
         let(:application) do
           application = Object.new
-          application.stub(:scopes) do
-            Doorkeeper::OAuth::Scopes.from_string 'common user extra'
-          end
+          allow(application).to receive(:scopes).and_return(Doorkeeper::OAuth::Scopes.from_string('common user extra'))
           application
         end
 

--- a/spec/lib/oauth/helpers/scope_checker_spec.rb
+++ b/spec/lib/oauth/helpers/scope_checker_spec.rb
@@ -7,46 +7,75 @@ module Doorkeeper::OAuth::Helpers
   describe ScopeChecker, '.valid?' do
     let(:server_scopes) { Doorkeeper::OAuth::Scopes.new }
 
-    it 'is valid if scope is present' do
-      server_scopes.add :scope
-      expect(ScopeChecker.valid?('scope', server_scopes)).to be_truthy
-    end
+    context 'without application scopes' do
+      it 'is invalid if scope is present' do
+        server_scopes.add :scope
+        expect(ScopeChecker.valid?('scope', server_scopes)).to be_falsey
+      end
 
-    it 'is invalid if includes tabs space' do
-      expect(ScopeChecker.valid?("\tsomething", server_scopes)).to be_falsey
-    end
-
-    it 'is invalid if scope is not present' do
-      expect(ScopeChecker.valid?(nil, server_scopes)).to be_falsey
-    end
-
-    it 'is invalid if scope is blank' do
-      expect(ScopeChecker.valid?(' ', server_scopes)).to be_falsey
-    end
-
-    it 'is invalid if includes return space' do
-      expect(ScopeChecker.valid?("scope\r", server_scopes)).to be_falsey
-    end
-
-    it 'is invalid if includes new lines' do
-      expect(ScopeChecker.valid?("scope\nanother", server_scopes)).to be_falsey
-    end
-
-    it 'is invalid if any scope is not included in server scopes' do
-      expect(ScopeChecker.valid?('scope another', server_scopes)).to be_falsey
-    end
+      it 'is invalid if scope is not present' do
+        expect(ScopeChecker.valid?(nil, server_scopes)).to be_falsey
+      end
+    end 
 
     context 'with application_scopes' do
       let(:server_scopes) do
-        Doorkeeper::OAuth::Scopes.from_string 'common svr'
+        Doorkeeper::OAuth::Scopes.from_string 'common svr user'
       end
       let(:application_scopes) do
-        Doorkeeper::OAuth::Scopes.from_string 'common'
+        Doorkeeper::OAuth::Scopes.from_string 'common user extra'
       end
 
-      it 'is valid if scope is included in the server and the application' do
+      it 'is invalid if scope is not present' do
         expect(ScopeChecker.valid?(
-          'common',
+          nil,
+          server_scopes,
+          application_scopes
+        )).to be_falsey
+      end
+
+      it 'is invalid if scope is blank' do
+        expect(ScopeChecker.valid?(
+          ' ',
+          server_scopes,
+          application_scopes
+        )).to be_falsey
+      end
+
+      it 'is invalid if includes tabs space' do
+        expect(ScopeChecker.valid?(
+          "common\tuser",
+          server_scopes,
+          application_scopes
+        )).to be_falsey
+      end
+
+      it 'is invalid if includes return space' do
+        expect(ScopeChecker.valid?(
+          "common\ruser",
+          server_scopes,
+          application_scopes
+        )).to be_falsey
+      end
+
+      it 'is invalid if includes new lines' do
+        expect(ScopeChecker.valid?(
+          "common\nuser",
+          server_scopes
+        )).to be_falsey
+      end
+
+      it 'is invalid if any scope is not included in server scopes' do
+        expect(ScopeChecker.valid?(
+          'common extra',
+          server_scopes,
+          application_scopes
+        )).to be_falsey
+      end
+
+      it 'is valid if scopes included in the server and the application' do
+        expect(ScopeChecker.valid?(
+          'common user',
           server_scopes,
           application_scopes
         )).to be_truthy

--- a/spec/lib/oauth/helpers/scope_checker_spec.rb
+++ b/spec/lib/oauth/helpers/scope_checker_spec.rb
@@ -16,7 +16,7 @@ module Doorkeeper::OAuth::Helpers
       it 'is invalid if scope is not present' do
         expect(ScopeChecker.valid?(nil, server_scopes)).to be_falsey
       end
-    end 
+    end
 
     context 'with application_scopes' do
       let(:server_scopes) do

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -11,7 +11,7 @@ module Doorkeeper::OAuth
 
     let(:application) do
       application = double :application
-      allow(application).to receive(:scopes).and_return(Scopes.from_string(''))
+      allow(application).to receive(:scopes).and_return(Scopes.from_string('public'))
       application
     end
 

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -93,7 +93,7 @@ module Doorkeeper::OAuth
 
       it 'reduces scopes to the provided scopes' do
         parameters[:scopes] = 'public'
-        subject.authorize
+        expect { subject.authorize }.to change { Doorkeeper::AccessToken.count }.by(1)
         expect(Doorkeeper::AccessToken.last.scopes).to eq([:public])
       end
 

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -93,6 +93,7 @@ module Doorkeeper::OAuth
 
       it 'reduces scopes to the provided scopes' do
         parameters[:scopes] = 'public'
+        
         expect { subject.authorize }.to change { Doorkeeper::AccessToken.count }.by(1)
         expect(Doorkeeper::AccessToken.last.scopes).to eq([:public])
       end

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -97,10 +97,9 @@ feature 'Authorization Code Flow' do
     end
 
     scenario 'returns new token if scopes have changed' do
-      skip 'TODO: need to add request helpers to this feature spec'
+      client_is_authorized(@client, @resource_owner, scopes: 'public')
+      visit authorization_endpoint_url(client: @client, scope: 'public write')
 
-      client_is_authorized(@client, @resource_owner, scopes: 'public write')
-      visit authorization_endpoint_url(client: @client, scope: 'public')
       click_on 'Authorize'
 
       authorization_code = Doorkeeper::AccessGrant.first.token

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -99,7 +99,6 @@ feature 'Authorization Code Flow' do
     scenario 'returns new token if scopes have changed' do
       client_is_authorized(@client, @resource_owner, scopes: 'public')
       visit authorization_endpoint_url(client: @client, scope: 'public write')
-
       click_on 'Authorize'
 
       authorization_code = Doorkeeper::AccessGrant.first.token

--- a/spec/requests/flows/skip_authorization_spec.rb
+++ b/spec/requests/flows/skip_authorization_spec.rb
@@ -27,31 +27,14 @@ feature 'Skip authorization form' do
     scenario 'does not skip authorization when scopes differ' do
       client_is_authorized(@client, @resource_owner, scopes: 'public')
       visit authorization_endpoint_url(client: @client, scope: 'public write')
-      i_should_see 'Authorize'
-    end
 
-    scenario 'does not skip authorization when scopes differ (new request has more scopes)' do
-      client_is_authorized(@client, @resource_owner, scopes: 'public write')
-      visit authorization_endpoint_url(client: @client, scopes: 'public write email')
       i_should_see 'Authorize'
     end
 
     scenario 'creates grant with new scope when scopes differ' do
       client_is_authorized(@client, @resource_owner, scopes: 'public')
       visit authorization_endpoint_url(client: @client, scope: 'public write')
-      click_on 'Authorize'
-      access_grant_should_have_scopes :public, :write
-    end
 
-    scenario 'doesn not skip authorization when scopes are greater' do
-      client_is_authorized(@client, @resource_owner, scopes: 'public')
-      visit authorization_endpoint_url(client: @client, scope: 'public write')
-      i_should_see 'Authorize'
-    end
-
-    scenario 'creates grant with new scope when scopes are greater' do
-      client_is_authorized(@client, @resource_owner, scopes: 'public')
-      visit authorization_endpoint_url(client: @client, scope: 'public write')
       click_on 'Authorize'
       access_grant_should_have_scopes :public, :write
     end

--- a/spec/requests/flows/skip_authorization_spec.rb
+++ b/spec/requests/flows/skip_authorization_spec.rb
@@ -24,9 +24,9 @@ feature 'Skip authorization form' do
       url_should_have_param 'code', Doorkeeper::AccessGrant.first.token
     end
 
-    scenario 'does not skip authorization when scopes differ (new request has fewer scopes)' do
-      client_is_authorized(@client, @resource_owner, scopes: 'public write')
-      visit authorization_endpoint_url(client: @client, scope: 'public')
+    scenario 'does not skip authorization when scopes differ' do
+      client_is_authorized(@client, @resource_owner, scopes: 'public')
+      visit authorization_endpoint_url(client: @client, scope: 'public write')
       i_should_see 'Authorize'
     end
 
@@ -37,10 +37,10 @@ feature 'Skip authorization form' do
     end
 
     scenario 'creates grant with new scope when scopes differ' do
-      client_is_authorized(@client, @resource_owner, scopes: 'public write')
-      visit authorization_endpoint_url(client: @client, scope: 'public')
+      client_is_authorized(@client, @resource_owner, scopes: 'public')
+      visit authorization_endpoint_url(client: @client, scope: 'public write')
       click_on 'Authorize'
-      access_grant_should_have_scopes :public
+      access_grant_should_have_scopes :public, :write
     end
 
     scenario 'doesn not skip authorization when scopes are greater' do

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -34,7 +34,7 @@ RSpec.configure do |config|
 
   config.infer_base_class_for_anonymous_controllers = false
 
-  config.include RSpec::Rails::RequestExampleGroup, type: :request
+  config.include RSpec::Rails::RequestExampleGroup, type: :feature
 
   config.before do
     DatabaseCleaner.start


### PR DESCRIPTION
refer PR #577 

The work is not finish, the problem is `valid_scopes` in `/lib/doorkeeper/oauth/helpers/scope_checker.rb` change old behaviour and break 3 cases.

some testing code
```ruby
application = Doorkeeper::Application.first
access_token = Doorkeeper::AccessToken.first
user = User.first

application.scopes # => ['public', 'write']
access_token.scopes # => ['public', 'write', 'yooo']

v = Validator.new('public write', access_token, application)
v.send :@valid_scopes # => ['public', 'write'] MAY NOT MAKE SENSE HERE
v.parsed_scopes # => ['public', 'write']

Doorkeeper::AccessToken.matching_token_for(application, user.id, 'public write yooo') == access_token # => true
```