### PR TITLE
Adds support for mobile app redirect uri's

### DIFF
--- a/app/validators/redirect_uri_validator.rb
+++ b/app/validators/redirect_uri_validator.rb
@@ -29,6 +29,6 @@ class RedirectUriValidator < ActiveModel::EachValidator
 
   def invalid_ssl_uri?(uri)
     forces_ssl = Doorkeeper.configuration.force_ssl_in_redirect_uri
-    forces_ssl && uri.try(:scheme) != 'https'
+    forces_ssl && uri.try(:scheme) == 'http'
   end
 end

--- a/spec/validators/redirect_uri_validator_spec.rb
+++ b/spec/validators/redirect_uri_validator_spec.rb
@@ -55,6 +55,11 @@ describe RedirectUriValidator do
       expect(subject).to be_valid
     end
 
+    it 'accepts app redirect uri' do
+      subject.redirect_uri = 'some-awesome-app://oauth/callback'
+      expect(subject).to be_valid
+    end
+
     it 'accepts a non secured protocol when disabled' do
       subject.redirect_uri = 'http://example.com/callback'
       allow(Doorkeeper.configuration).to receive(


### PR DESCRIPTION
Doorkeeper didn't accept native/mobile redirect URI's for (for example) iOS applications. With this simple adjustment you can keep forcing ssl and add an iOS application URI.

See also: https://github.com/doorkeeper-gem/doorkeeper/issues/552 