### PR TITLE
Use Time instead of DateTime

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@ User-visible changes worth mentioning.
 
 ---
 
+## 3.0.0 (rc2)
+
+- [#671] Fixes NoMethodError - undefined method 'getlocal' when calling
+  the /oauth/token path. Switch from using a DateTime object to update
+  AR to using a Time object. (Issue #668)
+
 ## 3.0.0 (rc1)
 
 ### Backward incompatible changes

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -1,12 +1,12 @@
 module Doorkeeper
   module Models
     module Revocable
-      def revoke(clock = DateTime)
+      def revoke(clock = Time)
         update_attribute :revoked_at, clock.now
       end
 
       def revoked?
-        !!(revoked_at && revoked_at <= DateTime.now)
+        !!(revoked_at && revoked_at <= Time.now)
       end
     end
   end

--- a/spec/lib/models/revocable_spec.rb
+++ b/spec/lib/models/revocable_spec.rb
@@ -19,12 +19,12 @@ describe 'Revocable' do
 
   describe :revoked? do
     it 'is revoked if :revoked_at has passed' do
-      allow(subject).to receive(:revoked_at).and_return(DateTime.now - 1000)
+      allow(subject).to receive(:revoked_at).and_return(Time.now - 1000)
       expect(subject).to be_revoked
     end
 
     it 'is not revoked if :revoked_at has not passed' do
-      allow(subject).to receive(:revoked_at).and_return(DateTime.now + 1000)
+      allow(subject).to receive(:revoked_at).and_return(Time.now + 1000)
       expect(subject).not_to be_revoked
     end
 


### PR DESCRIPTION
- Active record works better with Time, as opposed to DateTime objects,
  see issue #668 for more details.

Note: I updated the code, but the test cases kept working despite the change.  I updated the revokable test cases anyway, to match the change above, and the test cases are still passing.