### PR TITLE
allow for editing application-specific scopes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 - [#671] Fixes NoMethodError - undefined method 'getlocal' when calling
   the /oauth/token path. Switch from using a DateTime object to update
   AR to using a Time object. (Issue #668)
+- [#677] Support editing application-specific scopes via the standard forms.
 
 ## 3.0.0 (rc1)
 

--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -45,9 +45,9 @@ module Doorkeeper
 
     def application_params
       if params.respond_to?(:permit)
-        params.require(:doorkeeper_application).permit(:name, :redirect_uri)
+        params.require(:doorkeeper_application).permit(:name, :redirect_uri, :scopes)
       else
-        params[:doorkeeper_application].slice(:name, :redirect_uri) rescue nil
+        params[:doorkeeper_application].slice(:name, :redirect_uri, :scopes) rescue nil
       end
     end
   end

--- a/app/views/doorkeeper/applications/_form.html.erb
+++ b/app/views/doorkeeper/applications/_form.html.erb
@@ -17,13 +17,24 @@
       <%= f.text_area :redirect_uri, class: 'form-control' %>
       <%= doorkeeper_errors_for application, :redirect_uri %>
       <span class="help-block">
-         <%= t('doorkeeper.applications.help.redirect_uri') %>
-        </span>
+        <%= t('doorkeeper.applications.help.redirect_uri') %>
+      </span>
       <% if Doorkeeper.configuration.native_redirect_uri %>
           <span class="help-block">
             <%= raw t('doorkeeper.applications.help.native_redirect_uri', native_redirect_uri: "<code>#{ Doorkeeper.configuration.native_redirect_uri }</code>") %>
           </span>
       <% end %>
+    </div>
+  <% end %>
+
+  <%= content_tag :div, class: "form-group#{' has-error' if application.errors[:scopes].present?}" do %>
+    <%= f.label :scopes, class: 'col-sm-2 control-label' %>
+    <div class="col-sm-10">
+      <%= f.text_field :scopes, class: 'form-control' %>
+      <%= doorkeeper_errors_for application, :scopes %>
+      <span class="help-block">
+        <%= t('doorkeeper.applications.help.scopes') %>
+      </span>
     </div>
   <% end %>
 

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -5,12 +5,13 @@
 <div class="row">
   <div class="col-md-8">
     <h4><%= t('.application_id') %>:</h4>
-
     <p><code id="application_id"><%= @application.uid %></code></p>
 
     <h4><%= t('.secret') %>:</h4>
-
     <p><code id="secret"><%= @application.secret %></code></p>
+
+    <h4><%= t('.scopes') %>:</h4>
+    <p><code id="scopes"><%= @application.scopes %></code></p>
 
     <h4><%= t('.callback_urls') %>:</h4>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
       help:
         redirect_uri: 'Use one line per URI'
         native_redirect_uri: 'Use %{native_redirect_uri} for local tests'
+        scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
       edit:
         title: 'Edit application'
       index:
@@ -42,6 +43,7 @@ en:
         title: 'Application: %{name}'
         application_id: 'Application Id'
         secret: 'Secret'
+        scopes: 'Scopes'
         callback_urls: 'Callback urls'
         actions: 'Actions'
 


### PR DESCRIPTION
Tiny PR to add the `scopes` field to the application's show/edit forms.  Doesn't fundamentally change anything but removes the requirement for editing things directly in the DB.