### PR TITLE
add support for using only application-level scopes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@ User-visible changes worth mentioning.
 
 ### Backward incompatible changes
 
+- [#678] Change application-specific scopes to take precedence over server-wide
+  scopes. This removes the previous behavior where the intersection between
+  application and server scopes was used.
 - [#648] Extracts mongodb ORMs to
   https://github.com/doorkeeper-gem/doorkeeper-mongodb. If you use ActiveRecord
   you don’t need to do any change, otherwise you will need to install the new

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -25,7 +25,7 @@ module Doorkeeper
 
           def valid_scopes(server_scopes, application_scopes)
             if application_scopes.present?
-              server_scopes & application_scopes
+              application_scopes
             else
               server_scopes
             end

--- a/spec/lib/oauth/helpers/scope_checker_spec.rb
+++ b/spec/lib/oauth/helpers/scope_checker_spec.rb
@@ -41,12 +41,12 @@ module Doorkeeper::OAuth::Helpers
         Doorkeeper::OAuth::Scopes.from_string 'common svr'
       end
       let(:application_scopes) do
-        Doorkeeper::OAuth::Scopes.from_string 'common'
+        Doorkeeper::OAuth::Scopes.from_string 'app123'
       end
 
-      it 'is valid if scope is included in the server and the application' do
+      it 'is valid if scope is included in the application scope list' do
         expect(ScopeChecker.valid?(
-          'common',
+          'app123',
           server_scopes,
           application_scopes
         )).to be_truthy

--- a/spec/lib/oauth/token_request_spec.rb
+++ b/spec/lib/oauth/token_request_spec.rb
@@ -84,8 +84,11 @@ module Doorkeeper::OAuth
 
       it 'skips token creation if there is a matching one' do
         allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
+        allow(application.scopes).to receive(:has_scopes?).and_return(true)
+        allow(application.scopes).to receive(:all?).and_return(true)
         FactoryGirl.create(:access_token, application_id: pre_auth.client.id,
                            resource_owner_id: owner.id, scopes: 'public')
+
         expect do
           subject.authorize
         end.to_not change { Doorkeeper::AccessToken.count }


### PR DESCRIPTION
This adds a config option to allow application scopes to fully override server-level scopes instead of the current behavior where the valid set is based on the intersection of the two sets.  It defaults to false.

If this is mostly in order I am happy to expand the generated config and add documentation.