### PR TITLE
Application UID/Secret generation should happen for blank fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ User-visible changes worth mentioning.
   the /oauth/token path. Switch from using a DateTime object to update
   AR to using a Time object. (Issue #668)
 - [#677] Support editing application-specific scopes via the standard forms.
+- [#682] Pass error hash to Grape `error!`
 
 ## 3.0.0 (rc1)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ User-visible changes worth mentioning.
   AR to using a Time object. (Issue #668)
 - [#677] Support editing application-specific scopes via the standard forms.
 - [#682] Pass error hash to Grape `error!`
+- [#683] Also generate application secret/UID if fields are blank strings
 
 ## 3.0.0 (rc1)
 

--- a/lib/doorkeeper/grape/helpers.rb
+++ b/lib/doorkeeper/grape/helpers.rb
@@ -26,7 +26,7 @@ module Doorkeeper
                         403
                       end
 
-        error!({ error: error.description }, status_code)
+        error!({ error: error.description }, status_code, error.headers)
       end
 
       private

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -39,13 +39,13 @@ module Doorkeeper
     end
 
     def generate_uid
-      if self.uid.blank?
+      if uid.blank?
         self.uid = UniqueToken.generate
       end
     end
 
     def generate_secret
-      if self.secret.blank?
+      if secret.blank?
         self.secret = UniqueToken.generate
       end
     end

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -39,11 +39,15 @@ module Doorkeeper
     end
 
     def generate_uid
-      self.uid ||= UniqueToken.generate
+      if self.uid.blank?
+        self.uid = UniqueToken.generate
+      end
     end
 
     def generate_secret
-      self.secret ||= UniqueToken.generate
+      if self.secret.blank?
+        self.secret = UniqueToken.generate
+      end
     end
   end
 end

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -55,6 +55,12 @@ module Doorkeeper
       expect(new_application.uid).not_to be_nil
     end
 
+    it 'generates uid on create if an empty string' do
+      new_application.uid = ''
+      new_application.save
+      expect(new_application.uid).not_to be_blank
+    end
+
     it 'generates uid on create unless one is set' do
       new_application.uid = uid
       new_application.save
@@ -91,6 +97,12 @@ module Doorkeeper
       expect(new_application.secret).to be_nil
       new_application.save
       expect(new_application.secret).not_to be_nil
+    end
+
+    it 'generate secret on create if is blank string' do
+      new_application.secret = ''
+      new_application.save
+      expect(new_application.secret).not_to be_blank
     end
 
     it 'generate secret on create unless one is set' do


### PR DESCRIPTION
We are using Doorkeeper in a project, and there was a strange issue where the `oauth_applications` table's schema was somehow set to use the empty string as defaults for the `secret` and `uid` tables. (see [this pull request for MyUSA for details on the problem](https://github.com/18F/myusa/pull/684)). This would then make it impossible to create new applications because the blank string would not trigger the `generate_secret` and `generate_uid` before_create callbacks, but they would cause Rails to throw an exception for violating the `validates :presence` restriction on those fields.

While this ultimately turned out to be an issue with our DB schema and not with Doorkeeper, I feel like it would be good to modify this callback code for creates to also get triggered if the UID and Secret fields are blank strings, just because it turned out to be a difficult problem to find and resolve. So, I'm submitting a pull request back to you in case you agree. Thank you.