### PR TITLE
add support for specifying an alternative class for preauthorization

### DIFF
--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -41,9 +41,9 @@ module Doorkeeper
     end
 
     def pre_auth
-      @pre_auth ||= OAuth::PreAuthorization.new(Doorkeeper.configuration,
-                                                server.client_via_uid,
-                                                params)
+      @pre_auth ||= Doorkeeper.configuration.preauth_class.new(Doorkeeper.configuration,
+                                                               server.client_via_uid,
+                                                               params.merge(current_resource_owner: current_resource_owner))
     end
 
     def authorization

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -98,6 +98,12 @@ doorkeeper.
           '@access_token_generator', access_token_generator
         )
       end
+
+      def preauth_class(klass)
+        @config.instance_variable_set(
+          '@preauth_class', klass
+        )
+      end
     end
 
     module Option
@@ -189,6 +195,7 @@ doorkeeper.
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
     option :access_token_generator,         default: "Doorkeeper::OAuth::Helpers::UniqueToken"
+    option :preauth_class,                  default: "DoorKeeper::OAuth::PreAuthorization"
 
     attr_reader :reuse_access_token
 


### PR DESCRIPTION
I'm submitting this PR mostly to follow up on #667 with what I'm using in my project right now.  I was hoping we could resume discussion and find a way to add a supported hook of some kind for users to control preauthorization behavior.

What do you think?  The crux of my argument is that doorkeeper lacks a few key control loci (this PR addresses just one) that are required to implement various policies beyond the current one where all users can access all scopes.  Monkey patching is one way to go, but it seems cleaner to provide a way that users can rely on.  With the current implementation in this PR, I can build a class that takes the user, application, and scopes in the auth request and apply whatever logic is appropriate to my company to decide if it should be approved.