### PR TITLE
Ensure applications scopes

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -89,6 +89,10 @@ doorkeeper.
         @config.instance_variable_set("@reuse_access_token", true)
       end
 
+      def ensure_application_scopes
+        @config.instance_variable_set("@ensure_application_scopes", true)
+      end
+
       def force_ssl_in_redirect_uri(boolean)
         @config.instance_variable_set("@force_ssl_in_redirect_uri", boolean)
       end
@@ -190,7 +194,7 @@ doorkeeper.
     option :grant_flows,                    default: %w(authorization_code client_credentials)
     option :access_token_generator,         default: "Doorkeeper::OAuth::Helpers::UniqueToken"
 
-    attr_reader :reuse_access_token
+    attr_reader :reuse_access_token, :ensure_application_scopes
 
     def refresh_token_enabled?
       !!@refresh_token_enabled

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -24,6 +24,7 @@ module Doorkeeper
           private
 
           def valid_scopes(server_scopes, application_scopes)
+            return application_scopes if Doorkeeper.configuration.ensure_application_scopes
             if application_scopes.present?
               server_scopes & application_scopes
             else

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -24,7 +24,7 @@ module Doorkeeper
           private
 
           def valid_scopes(server_scopes, application_scopes)
-            return application_scopes if Doorkeeper.configuration.ensure_application_scopes
+            return Doorkeeper.configuration.default_scopes + application_scopes if Doorkeeper.configuration.ensure_application_scopes
             if application_scopes.present?
               server_scopes & application_scopes
             else


### PR DESCRIPTION
This is yet another way to add a constraint to the grant flow for limiting the scopes that can be authorized. The scenario is:

* doorkeeper has defined scopes a,b,c,d
* client A select as available scopes a,b,c
* the authorize process for A fails if scope d is required

This is a security concern especially when an implicit authorization flow is in place.
The behaviour is enabled adding a conf called **ensure_application_scopes**. Without this conf doorkeeper fallback to the normal behaviour.

Is this something can be discussed?

 