### PR TITLE
Updates the size of the `token` column

### DIFF
--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -27,7 +27,15 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
     create_table :oauth_access_tokens do |t|
       t.integer  :resource_owner_id
       t.integer  :application_id
+
+      # If you use a custom token generator you may need to change this column
+      # from string to text, so that it accepts tokens larger than 255
+      # characters. More info on custom token generators in:
+      # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
+      #
+      # t.text     :token,             null: false
       t.string   :token,             null: false
+
       t.string   :refresh_token
       t.integer  :expires_in
       t.datetime :revoked_at


### PR DESCRIPTION
This commit updates the size of the `token` column inside the default migration template from a `string` column type to `text`.

The rationale of this proposal is to accomdate users who may use an alternative token generator (accomplished in #611), which uses tokens larger than 255 characters.