### PR TITLE
Revoke Refresh Token on access token use

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,7 @@ User-visible changes worth mentioning.
 - [#665] `doorkeeper_unauthorized_render_options(error:)` and
   `doorkeeper_forbidden_render_options(error:)` now accept `error` keyword
   argument.
+- [#691] Revoke Refresh Token on access token use
 
 ### Removed deprecations
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -189,6 +189,7 @@ doorkeeper.
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
     option :access_token_generator,         default: "Doorkeeper::OAuth::Helpers::UniqueToken"
+    option :refresh_token_revoked_in,       default: 0
 
     attr_reader :reuse_access_token
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -21,7 +21,7 @@ module Doorkeeper
 
       if respond_to?(:attr_accessible)
         attr_accessible :application_id, :resource_owner_id, :expires_in,
-                        :scopes, :use_refresh_token
+                        :scopes, :use_refresh_token, :previous_refresh_token
       end
 
       before_validation :generate_token, on: :create

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -17,7 +17,9 @@ module Doorkeeper
         if old_refresh_token && !old_refresh_token.revoked?
           old_refresh_token.revoke_in(refresh_token_revoked_in)
         end
-        update_attribute :previous_refresh_token, "" if previous_refresh_token != ""
+        if previous_refresh_token.present?
+          update_attribute :previous_refresh_token, ""
+        end
       end
 
       def old_refresh_token
@@ -26,10 +28,6 @@ module Doorkeeper
 
       def refresh_token_revoked_in
         Doorkeeper.configuration.refresh_token_revoked_in
-      end
-
-      def configuration
-        Doorkeeper.configuration
       end
     end
   end

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -8,6 +8,29 @@ module Doorkeeper
       def revoked?
         !!(revoked_at && revoked_at <= Time.now)
       end
+
+      def revoke_in(time)
+        update_attribute :revoked_at, Time.now + time
+      end
+
+      def revoke_previous_refresh_token!
+        if old_refresh_token && !old_refresh_token.revoked?
+          old_refresh_token.revoke_in(refresh_token_revoked_in)
+        end
+        update_attribute :previous_refresh_token, "" if previous_refresh_token != ""
+      end
+
+      def old_refresh_token
+        @old_refresh_token ||= AccessToken.by_refresh_token(previous_refresh_token)
+      end
+
+      def refresh_token_revoked_in
+        Doorkeeper.configuration.refresh_token_revoked_in
+      end
+
+      def configuration
+        Doorkeeper.configuration
+      end
     end
   end
 end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -35,7 +35,7 @@ module Doorkeeper
         refresh_token.transaction do
           refresh_token.lock!
           raise Errors::InvalidTokenReuse if refresh_token.revoked?
-          unless refresh_token.revoked_at
+          if !refresh_token.revoked_at
             refresh_token.revoke_in(server.refresh_token_revoked_in)
           end
 
@@ -56,14 +56,11 @@ module Doorkeeper
         create_params = {
           application_id: refresh_token.application_id,
           expires_in: expires_in,
+          previous_refresh_token: refresh_token.refresh_token,
           resource_owner_id: refresh_token.resource_owner_id,
           scopes: scopes.to_s,
           use_refresh_token: true
         }
-
-        unless server.refresh_token_revoked_in.zero?
-          create_params[:previous_refresh_token] = refresh_token.refresh_token
-        end
 
         @access_token = AccessToken.create!(create_params)
       end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -35,7 +35,7 @@ module Doorkeeper
         refresh_token.transaction do
           refresh_token.lock!
           raise Errors::InvalidTokenReuse if refresh_token.revoked?
-          if !refresh_token.revoked_at
+          if refresh_token.revoked_at.nil?
             refresh_token.revoke_in(server.refresh_token_revoked_in)
           end
 
@@ -56,7 +56,7 @@ module Doorkeeper
         create_params = {
           application_id: refresh_token.application_id,
           expires_in: expires_in,
-          previous_refresh_token: refresh_token.refresh_token,
+          previous_refresh_token: refresh_token.refresh_token.to_s,
           resource_owner_id: refresh_token.resource_owner_id,
           scopes: scopes.to_s,
           use_refresh_token: true

--- a/lib/doorkeeper/oauth/token.rb
+++ b/lib/doorkeeper/oauth/token.rb
@@ -55,7 +55,9 @@ module Doorkeeper
 
       def self.authenticate(request, *methods)
         if token = from_request(request, *methods)
-          AccessToken.by_token(token)
+          access_token = AccessToken.by_token(token)
+          access_token.revoke_previous_refresh_token! if access_token
+          access_token
         end
       end
     end

--- a/lib/generators/doorkeeper/previous_refresh_token_generator.rb
+++ b/lib/generators/doorkeeper/previous_refresh_token_generator.rb
@@ -1,0 +1,33 @@
+require 'rails/generators/active_record'
+
+class Doorkeeper::PreviousRefreshTokenGenerator < Rails::Generators::Base
+  include Rails::Generators::Migration
+  source_root File.expand_path('../templates', __FILE__)
+  desc 'Support revoke refresh token on access token use'
+
+  def self.next_migration_number(path)
+    ActiveRecord::Generators::Base.next_migration_number(path)
+  end
+
+  def previous_refresh_token
+    if oauth_applications_exists? && !previous_refresh_token_column_exists?
+      migration_template(
+        'add_previous_refresh_token_to_access_tokens.rb',
+        'db/migrate/add_previous_refresh_token_to_access_tokens.rb'
+      )
+    end
+  end
+
+  private
+
+  def previous_refresh_token_column_exists?
+    ActiveRecord::Base.connection.column_exists?(
+      :oauth_access_tokens,
+      :previous_refresh_token
+    )
+  end
+
+  def oauth_applications_exists?
+    ActiveRecord::Base.connection.table_exists? :oauth_applications
+  end
+end

--- a/lib/generators/doorkeeper/previous_refresh_token_generator.rb
+++ b/lib/generators/doorkeeper/previous_refresh_token_generator.rb
@@ -1,33 +1,31 @@
 require 'rails/generators/active_record'
 
-class Doorkeeper::PreviousRefreshTokenGenerator < Rails::Generators::Base
-  include Rails::Generators::Migration
-  source_root File.expand_path('../templates', __FILE__)
-  desc 'Support revoke refresh token on access token use'
+module Doorkeeper
+  class PreviousRefreshTokenGenerator < Rails::Generators::Base
+    include Rails::Generators::Migration
+    source_root File.expand_path('../templates', __FILE__)
+    desc 'Support revoke refresh token on access token use'
 
-  def self.next_migration_number(path)
-    ActiveRecord::Generators::Base.next_migration_number(path)
-  end
+    def self.next_migration_number(path)
+      ActiveRecord::Generators::Base.next_migration_number(path)
+    end
 
-  def previous_refresh_token
-    if oauth_applications_exists? && !previous_refresh_token_column_exists?
-      migration_template(
-        'add_previous_refresh_token_to_access_tokens.rb',
-        'db/migrate/add_previous_refresh_token_to_access_tokens.rb'
+    def previous_refresh_token
+      if !previous_refresh_token_column_exists?
+        migration_template(
+          'add_previous_refresh_token_to_access_tokens.rb',
+          'db/migrate/add_previous_refresh_token_to_access_tokens.rb'
+        )
+      end
+    end
+
+    private
+
+    def previous_refresh_token_column_exists?
+      ActiveRecord::Base.connection.column_exists?(
+        :oauth_access_tokens,
+        :previous_refresh_token
       )
     end
-  end
-
-  private
-
-  def previous_refresh_token_column_exists?
-    ActiveRecord::Base.connection.column_exists?(
-      :oauth_access_tokens,
-      :previous_refresh_token
-    )
-  end
-
-  def oauth_applications_exists?
-    ActiveRecord::Base.connection.table_exists? :oauth_applications
   end
 end

--- a/lib/generators/doorkeeper/templates/add_previous_refresh_token_to_access_tokens.rb
+++ b/lib/generators/doorkeeper/templates/add_previous_refresh_token_to_access_tokens.rb
@@ -1,0 +1,5 @@
+class AddPreviousRefreshTokenToAccessTokens < ActiveRecord::Migration
+  def change
+    add_column :oauth_access_tokens, :previous_refresh_token, :string, default: "", null: false
+  end
+end

--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -41,6 +41,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       t.datetime :revoked_at
       t.datetime :created_at,        null: false
       t.string   :scopes
+      t.string   :previous_refresh_token
     end
 
     add_index :oauth_access_tokens, :token, unique: true

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -22,7 +22,7 @@ describe 'doorkeeper authorize filter' do
 
     let(:token_string) { '1A2BC3' }
     let(:token) do
-      double(Doorkeeper::AccessToken, acceptable?: true)
+      double(Doorkeeper::AccessToken, acceptable?: true, previous_refresh_token: "", revoke_previous_refresh_token!: true)
     end
 
     it 'access_token param' do
@@ -100,7 +100,7 @@ describe 'doorkeeper authorize filter' do
     let(:token_string) { '1A2DUWE' }
 
     it 'allows if the token has particular scopes' do
-      token = double(Doorkeeper::AccessToken, accessible?: true, scopes: %w(write public))
+      token = double(Doorkeeper::AccessToken, accessible?: true, scopes: %w(write public), previous_refresh_token: "", revoke_previous_refresh_token!: true)
       expect(token).to receive(:acceptable?).with([:write]).and_return(true)
       expect(Doorkeeper::AccessToken).to receive(:by_token).with(token_string).and_return(token)
       get :index, access_token: token_string
@@ -108,7 +108,7 @@ describe 'doorkeeper authorize filter' do
     end
 
     it 'does not allow if the token does not include given scope' do
-      token = double(Doorkeeper::AccessToken, accessible?: true, scopes: ['public'], revoked?: false, expired?: false)
+      token = double(Doorkeeper::AccessToken, accessible?: true, scopes: ['public'], revoked?: false, expired?: false, previous_refresh_token: "", revoke_previous_refresh_token!: true)
       expect(Doorkeeper::AccessToken).to receive(:by_token).with(token_string).and_return(token)
       expect(token).to receive(:acceptable?).with([:write]).and_return(false)
       get :index, access_token: token_string

--- a/spec/dummy/db/migrate/20150909133655_add_previous_refresh_token_to_access_tokens.rb
+++ b/spec/dummy/db/migrate/20150909133655_add_previous_refresh_token_to_access_tokens.rb
@@ -1,0 +1,5 @@
+class AddPreviousRefreshTokenToAccessTokens < ActiveRecord::Migration
+  def change
+    add_column :oauth_access_tokens, :previous_refresh_token, :string, default: "", null: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141209001746) do
+ActiveRecord::Schema.define(version: 20150909133655) do
 
   create_table "oauth_access_grants", force: true do |t|
     t.integer  "resource_owner_id",              null: false
@@ -29,12 +29,13 @@ ActiveRecord::Schema.define(version: 20141209001746) do
   create_table "oauth_access_tokens", force: true do |t|
     t.integer  "resource_owner_id"
     t.integer  "application_id"
-    t.string   "token",             null: false
+    t.string   "token",                               null: false
     t.string   "refresh_token"
     t.integer  "expires_in"
     t.datetime "revoked_at"
-    t.datetime "created_at",        null: false
+    t.datetime "created_at",                          null: false
     t.string   "scopes"
+    t.string   "previous_refresh_token", default: "", null: false
   end
 
   add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,6 +11,7 @@ FactoryGirl.define do
     sequence(:resource_owner_id) { |n| n }
     application
     expires_in 2.hours
+    previous_refresh_token "token"
 
     factory :clientless_access_token do
       application nil

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,7 +11,6 @@ FactoryGirl.define do
     sequence(:resource_owner_id) { |n| n }
     application
     expires_in 2.hours
-    previous_refresh_token "token"
 
     factory :clientless_access_token do
       application nil

--- a/spec/lib/models/revocable_spec.rb
+++ b/spec/lib/models/revocable_spec.rb
@@ -33,4 +33,26 @@ describe 'Revocable' do
       expect(subject).not_to be_revoked
     end
   end
+
+  describe :revoke_previous_refresh_token! do
+    subject { FactoryGirl.build(:access_token, previous_refresh_token: 'old_refresh_token') }
+    previous_token = FactoryGirl.build(:access_token, token: "previous_token")
+    after { subject.revoke_previous_refresh_token! }
+
+    it 'revokes the previous token if present and sets the attribute :previous_refresh_token to ""' do
+      expect(Doorkeeper::AccessToken).to receive(:by_refresh_token).with(subject.previous_refresh_token).and_return(previous_token)
+      expect(previous_token).to receive(:revoke_in)
+      expect(subject).to receive(:update_attribute).with(:previous_refresh_token, "")
+    end
+
+    it 'does nothing if the previous refresh token is eq to ""' do
+      subject.previous_refresh_token = ""
+      expect(subject).to_not receive(:update_attribute).with(:previous_refresh_token, "")
+    end
+
+    it 'sets the attribute :previous_refresh_token to nil if the previous refresh token does not exist' do
+      expect(Doorkeeper::AccessToken).to receive(:by_refresh_token).with(subject.previous_refresh_token).and_return(nil)
+      expect(subject).to receive(:update_attribute).with(:previous_refresh_token, "")
+    end
+  end
 end

--- a/spec/support/shared/controllers_shared_context.rb
+++ b/spec/support/shared/controllers_shared_context.rb
@@ -4,7 +4,7 @@ shared_context 'valid token', token: :valid do
   end
 
   let :token do
-    double(Doorkeeper::AccessToken, accessible?: true, includes_scope?: true, acceptable?: true)
+    double(Doorkeeper::AccessToken, accessible?: true, includes_scope?: true, acceptable?: true, revoke_previous_refresh_token!: true, previous_refresh_token: "")
   end
 
   before :each do
@@ -18,7 +18,7 @@ shared_context 'invalid token', token: :invalid do
   end
 
   let :token do
-    double(Doorkeeper::AccessToken, accessible?: false, revoked?: false, expired?: false, includes_scope?: false, acceptable?: false)
+    double(Doorkeeper::AccessToken, accessible?: false, revoked?: false, expired?: false, includes_scope?: false, acceptable?: false, previous_refresh_token: "", revoke_previous_refresh_token!: true)
   end
 
   before :each do


### PR DESCRIPTION
Creating another PR based on this https://github.com/doorkeeper-gem/doorkeeper/pull/578. Copying description:

> This PR allows refresh tokens to not either revoke at some point in the future (if you want to allow some wiggle room for network failures, etc) set refresh_token_revoked_in to some number of seconds in the future.
>
> Also allows for refresh tokens to not be revoked until an access token created with that refresh token is successfully used once. Set refresh_token_revoked_on_use to true.
>
> Both are off by default.