### PR TITLE
Ensure applications scopes

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -89,6 +89,10 @@ doorkeeper.
         @config.instance_variable_set("@reuse_access_token", true)
       end
 
+      def ensure_application_scopes
+        @config.instance_variable_set("@ensure_application_scopes", true)
+      end
+
       def force_ssl_in_redirect_uri(boolean)
         @config.instance_variable_set("@force_ssl_in_redirect_uri", boolean)
       end
@@ -190,7 +194,7 @@ doorkeeper.
     option :grant_flows,                    default: %w(authorization_code client_credentials)
     option :access_token_generator,         default: "Doorkeeper::OAuth::Helpers::UniqueToken"
 
-    attr_reader :reuse_access_token
+    attr_reader :reuse_access_token, :ensure_application_scopes
 
     def refresh_token_enabled?
       !!@refresh_token_enabled

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -24,7 +24,7 @@ module Doorkeeper
           private
 
           def valid_scopes(server_scopes, application_scopes)
-            return application_scopes if Doorkeeper.configuration.ensure_application_scopes
+            return Doorkeeper.configuration.default_scopes + application_scopes if Doorkeeper.configuration.ensure_application_scopes
             if application_scopes.present?
               application_scopes
             else

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -24,6 +24,7 @@ module Doorkeeper
           private
 
           def valid_scopes(server_scopes, application_scopes)
+            return application_scopes if Doorkeeper.configuration.ensure_application_scopes
             if application_scopes.present?
               application_scopes
             else

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -24,8 +24,7 @@ module Doorkeeper
           private
 
           def valid_scopes(server_scopes, application_scopes)
-            return Doorkeeper.configuration.default_scopes + application_scopes if Doorkeeper.configuration.ensure_application_scopes
-            if application_scopes.present?
+            if application_scopes.present? || Doorkeeper.configuration.ensure_application_scopes
               application_scopes
             else
               server_scopes

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -52,6 +52,10 @@ Doorkeeper.configure do
   # default_scopes  :public
   # optional_scopes :write, :update
 
+  # Authorize only application scopes. Uncomment to prevent that a scope is authorized without being
+  # requested by the application.
+  # ensure_application_scopes
+
   # Change the way client credentials are retrieved from the request object.
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
   # falls back to the `:client_id` and `:client_secret` params from the `params` object.


### PR DESCRIPTION
This PR adds a config that forces the Scope Checker to be runned only vs application scopes. No server scopes will be used and authorization will fail if the required scopes does not match an application scope.
Sometimes falling back on server scopes can be too weak because if an application does not define any scope == any server scope can be granted.
The **ensure_application_scope** add a strong rule that limit the authorizable scopes ONLY to the application scopes. 