### PR TITLE
Make scopes model attribute accessible on application create/editing, to avoid mass assignment errors.

### DIFF
--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -17,7 +17,7 @@ module Doorkeeper
       before_validation :generate_uid, :generate_secret, on: :create
 
       if respond_to?(:attr_accessible)
-        attr_accessible :name, :redirect_uri
+        attr_accessible :name, :redirect_uri, :scopes
       end
     end
 


### PR DESCRIPTION
Tests pass.

Fixes:
[2015-08-11 14:41:16] WARN  ActiveRecord::Base : WARNING: Can't mass-assign protected attributes for Doorkeeper::Application: scopes