### PR TITLE
make authrization code show action no need resource owner authenticated.

### DIFF
--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   class AuthorizationsController < Doorkeeper::ApplicationController
-    before_filter :authenticate_resource_owner!
+    before_filter :authenticate_resource_owner!, except: [:show]
 
     def new
       if pre_auth.authorizable?


### PR DESCRIPTION
I'd like to sign out resource owner after authorization granted or denied. In case if granted, and if the redirect URI is the native one, it will request user sign in again to show the code already in URL. I think it should be fine to skip `authenticate_resource_owner` for auth code show action, since it just pop the code into html content.
