### PR TITLE
Set table_name before including Mixin

### DIFF
--- a/lib/doorkeeper/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/access_grant.rb
@@ -1,7 +1,7 @@
 module Doorkeeper
   class AccessGrant < ActiveRecord::Base
-    include AccessGrantMixin
-
     self.table_name = "#{table_name_prefix}oauth_access_grants#{table_name_suffix}".to_sym
+
+    include AccessGrantMixin
   end
 end

--- a/lib/doorkeeper/orm/active_record/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/access_token.rb
@@ -1,8 +1,8 @@
 module Doorkeeper
   class AccessToken < ActiveRecord::Base
-    include AccessTokenMixin
-
     self.table_name = "#{table_name_prefix}oauth_access_tokens#{table_name_suffix}".to_sym
+
+    include AccessTokenMixin
 
     def self.delete_all_for(application_id, resource_owner)
       where(application_id: application_id,

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -1,8 +1,8 @@
 module Doorkeeper
   class Application < ActiveRecord::Base
-    include ApplicationMixin
-
     self.table_name = "#{table_name_prefix}oauth_applications#{table_name_suffix}".to_sym
+
+    include ApplicationMixin
 
     if ActiveRecord::VERSION::MAJOR >= 4
       has_many :authorized_tokens, -> { where(revoked_at: nil) }, class_name: 'AccessToken'


### PR DESCRIPTION
Included uses respond_to? which queries the incorrect table name in ActiveRecord.

This was introduced in v2.2.2 (https://github.com/doorkeeper-gem/doorkeeper/commit/c3d1a8318027b1ec5d8665511cf448b2ee45b73a).

In postgresql I see the following errors:

```
ERROR:  relation "access_grants" does not exist at character 323
STATEMENT:                SELECT a.attname, format_type(a.atttypid, a.atttypmod),
	                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
	                FROM pg_attribute a LEFT JOIN pg_attrdef d
	                  ON a.attrelid = d.adrelid AND a.attnum = d.adnum
	               WHERE a.attrelid = '"access_grants"'::regclass
	                 AND a.attnum > 0 AND NOT a.attisdropped
	               ORDER BY a.attnum
	
ERROR:  relation "access_tokens" does not exist at character 323
STATEMENT:                SELECT a.attname, format_type(a.atttypid, a.atttypmod),
	                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
	                FROM pg_attribute a LEFT JOIN pg_attrdef d
	                  ON a.attrelid = d.adrelid AND a.attnum = d.adnum
	               WHERE a.attrelid = '"access_tokens"'::regclass
	                 AND a.attnum > 0 AND NOT a.attisdropped
	               ORDER BY a.attnum
	
ERROR:  relation "applications" does not exist at character 323
STATEMENT:                SELECT a.attname, format_type(a.atttypid, a.atttypmod),
	                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
	                FROM pg_attribute a LEFT JOIN pg_attrdef d
	                  ON a.attrelid = d.adrelid AND a.attnum = d.adnum
	               WHERE a.attrelid = '"applications"'::regclass
	                 AND a.attnum > 0 AND NOT a.attisdropped
	               ORDER BY a.attnum
```