### PR TITLE
Guard against nil ‘created_at’ in Models::Expirable

### DIFF
--- a/lib/doorkeeper/models/concerns/expirable.rb
+++ b/lib/doorkeeper/models/concerns/expirable.rb
@@ -6,8 +6,8 @@ module Doorkeeper
       end
 
       def expires_in_seconds
-        return nil if expires_in.nil?
-        expires = (created_at + expires_in.seconds) - Time.now
+        return nil if created_at.nil? || expires_in.nil?
+        expires = expired_time - Time.now
         expires_sec = expires.seconds.round(0)
         expires_sec > 0 ? expires_sec : 0
       end

--- a/spec/lib/models/expirable_spec.rb
+++ b/spec/lib/models/expirable_spec.rb
@@ -47,5 +47,10 @@ describe 'Expirable' do
       expect(subject.expires_in_seconds).to be_nil
     end
 
+    it 'should return nil when created_at is nil' do
+      allow(subject).to receive(:expires_in).and_return(30.seconds)
+      allow(subject).to receive(:created_at).and_return(nil)
+      expect(subject.expires_in_seconds).to be_nil
+    end
   end
 end


### PR DESCRIPTION
I've noticed an issue in Doorkeeper where, if AccessToken#created_at is nil, the Models::Expirable#expires_in_seconds method will raise `NoMethodError (undefined method '+' for nil:NilClass)`.

I came across this issue when playing around with the doorkeeper API and submitting multiple Client Credentials requests in quick succession to `/oauth/token` so I guess there is some kind of race condition (didn't have time to fully explore it, but I think there should be a guard for this case no matter what).