### PR TITLE
Check count, not merely presence of `scopes`

### DIFF
--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -7,7 +7,7 @@
     <%= raw t('.prompt', client_name: "<strong class=\"text-info\">#{ @pre_auth.client.name }</strong>") %>
   </p>
 
-  <% if @pre_auth.scopes %>
+  <% if @pre_auth.scopes.count > 0 %>
     <div id="oauth-permissions">
       <p><%= t('.able_to') %>:</p>
 


### PR DESCRIPTION
Without this, we're getting the `able_to` string even with no scopes defined