### PR TITLE
Fix rspec warnings, require env in spec_helper.rb

### DIFF
--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -131,9 +131,9 @@ module Doorkeeper
         token1 = FactoryGirl.create :access_token, use_refresh_token: true
         token2 = FactoryGirl.create :access_token, use_refresh_token: true
         expect do
-          token2.write_attribute :refresh_token, token1.refresh_token
+          token2.send(:write_attribute, :refresh_token, token1.refresh_token)
           token2.save(validate: false)
-        end.to raise_error
+        end.to raise_error(ActiveRecord::RecordNotUnique)
       end
     end
 

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -90,7 +90,7 @@ module Doorkeeper
       app1 = FactoryGirl.create(:application)
       app2 = FactoryGirl.create(:application)
       app2.uid = app1.uid
-      expect { app2.save!(validate: false) }.to raise_error
+      expect { app2.save!(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it 'generate secret on create' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,5 @@
 $LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '../lib'))
 $LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '../app'))
+
+require 'capybara/rspec'
+require 'dummy/config/environment'

--- a/spec/support/shared/models_shared_examples.rb
+++ b/spec/support/shared/models_shared_examples.rb
@@ -46,7 +46,7 @@ shared_examples 'a unique token' do
       token2.token = token1.token
       expect do
         token2.save!(validate: false)
-      end.to raise_error
+      end.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
 end


### PR DESCRIPTION
My first little takeaway:

Rspec threw warnings as raise_error didn’t provide an Error Class to assert on. Indeed in one case the wrong error was raised than expected. In addition, requiring the app env in spec_helper allows to run single test.