### PR TITLE
Wrap access token grant and refresh  in transactions.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ User-visible changes worth mentioning.
 
 ---
 
+- [#712] Wrap exchange of grant token for access token and access token refresh in transactions.
+
 ## 3.0.0
 
 ### Other changes

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -6,6 +6,12 @@ module Doorkeeper
     class InvalidAuthorizationStrategy < DoorkeeperError
     end
 
+    class InvalidTokenReuse < DoorkeeperError
+    end
+
+    class InvalidGrantReuse < DoorkeeperError
+    end
+
     class InvalidTokenStrategy < DoorkeeperError
     end
 

--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -41,6 +41,10 @@ module Doorkeeper
                        :unsupported_response_type
                      when Errors::MissingRequestStrategy
                        :invalid_request
+                     when Errors::InvalidTokenReuse
+                       :invalid_request
+                     when Errors::InvalidGrantReuse
+                       :invalid_grant
                      end
 
         OAuth::ErrorResponse.new name: error_name, state: params[:state]

--- a/spec/requests/flows/refresh_token_spec.rb
+++ b/spec/requests/flows/refresh_token_spec.rb
@@ -65,6 +65,14 @@ describe 'Refresh Token Flow' do
       should_not_have_json 'refresh_token'
       should_have_json 'error', 'invalid_grant'
     end
+
+    it 'second of simultaneous client requests get an error for revoked acccess token' do
+      allow_any_instance_of(Doorkeeper::AccessToken).to receive(:revoked?).and_return(false, true)
+      post refresh_token_endpoint_url(client: @client, refresh_token: @token.refresh_token)
+
+      should_not_have_json 'refresh_token'
+      should_have_json 'error', 'invalid_request'
+    end
   end
 
   context 'refreshing the token with multiple sessions (devices)' do


### PR DESCRIPTION
It's possible to exchange a single grant/refresh token for multiple access tokens. This is definitely _unexpected_ behavior, whether its a vulnerability is a bit murkier. In a highly concurrent environment, it may provide unexpected results to consumers of the API as well.

For the initial exchange of grant for access token, using a grant more than once
seems to violate Section 4.2.1 [1]:

```
4.1.2.  Authorization Response
code
The authorization code generated by the
authorization server. ...The client MUST NOT use the authorization code
more than once.
```

In the transaction, the `lock!` and error raise is the important part to prevent
multiple writes concurrently. In ActiveRecord, `lock!` reloads the record after
doing a SELECT ... FOR UPDATE so if two parallel requests come, the first one to
the DB locks and revokes the token, while the second waits for the lock to be
be released, then acquires the lock, reloading the (now revoked) record and raises
an error.

A side effect of this change is that granting and refreshing tokens is now
transactional - a token cannot be granted without also revoking the grant which
should improve consistency.

[1] https://tools.ietf.org/html/rfc6749#section-4.1.2