### PR TITLE
Add support for overriding forbidden status code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ User-visible changes worth mentioning.
 
 ---
 
+- [#722] `doorkeeper_forbidden_render_options` now supports returning a 404 by
+  specifying `respond_not_found_when_forbidden: true` in the
+  `doorkeeper_forbidden_render_options` method.
+
 ## 3.0.1
 
 - [#712] Wrap exchange of grant token for access token and access token refresh

--- a/lib/doorkeeper/rails/helpers.rb
+++ b/lib/doorkeeper/rails/helpers.rb
@@ -31,10 +31,12 @@ module Doorkeeper
 
       def doorkeeper_render_error_with(error)
         options = doorkeeper_render_options(error) || {}
+        status = doorkeeper_status_for_error(
+          error, options.delete(:respond_not_found_when_forbidden))
         if options.blank?
-          head error.status
+          head status
         else
-          options[:status] = error.status
+          options[:status] = status
           options[:layout] = false if options[:layout].nil?
           render options
         end
@@ -53,6 +55,14 @@ module Doorkeeper
           doorkeeper_unauthorized_render_options(error: error)
         else
           doorkeeper_forbidden_render_options(error: error)
+        end
+      end
+
+      def doorkeeper_status_for_error(error, respond_not_found_when_forbidden)
+        if respond_not_found_when_forbidden && error.status == :forbidden
+          :not_found
+        else
+          error.status
         end
       end
 


### PR DESCRIPTION
Doorkeeper allows you to specify the message returned when a forbidden error is triggered (*e.g.*, a token does not have the correct scope). However, it does not allow you to specify the status code. A common practice is to return a 404 for 403s. This updates `doorkeeper_forbidden_render_options` to allow specifying `not_found_for_forbidden: true` as well as `text`/`json` and `layout` in order to return `:not_found` instead of `:forbidden`.

I didn't find any tests for `doorkeeper_forbidden_render_options`, so I added coverage similar to `doorkeeper_unauthorized_render_options`.

This includes a changelog message, though it might make more sense to update https://github.com/doorkeeper-gem/doorkeeper/wiki/Customizing-the-response-body-when-unauthorized to detail both the unauthorized and forbidden options 

I also fixed a misnamed test.
