### PR TITLE
Prefer forcing timezones

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,11 @@
 User-visible changes worth mentioning.
 
 ---
-
+## 4.0.0.rc3
 - Toughen parameters filter with exact match
+
+### Backward incompatible changes
+- Force all timezones to use UTC to prevent comparison issues.
 
 ## 4.0.0.rc2
 

--- a/lib/doorkeeper/models/concerns/expirable.rb
+++ b/lib/doorkeeper/models/concerns/expirable.rb
@@ -2,12 +2,12 @@ module Doorkeeper
   module Models
     module Expirable
       def expired?
-        expires_in && Time.now > expired_time
+        expires_in && Time.now.utc > expired_time
       end
 
       def expires_in_seconds
         return nil if expires_in.nil?
-        expires = (created_at + expires_in.seconds) - Time.now
+        expires = (created_at + expires_in.seconds) - Time.now.utc
         expires_sec = expires.seconds.round(0)
         expires_sec > 0 ? expires_sec : 0
       end

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -2,11 +2,11 @@ module Doorkeeper
   module Models
     module Revocable
       def revoke(clock = Time)
-        update_attribute :revoked_at, clock.now
+        update_attribute :revoked_at, clock.now.utc
       end
 
       def revoked?
-        !!(revoked_at && revoked_at <= Time.now)
+        !!(revoked_at && revoked_at <= Time.now.utc)
       end
     end
   end

--- a/lib/doorkeeper/version.rb
+++ b/lib/doorkeeper/version.rb
@@ -1,3 +1,3 @@
 module Doorkeeper
-  VERSION = "4.0.0.rc2"
+  VERSION = "4.0.0.rc3"
 end

--- a/spec/lib/models/revocable_spec.rb
+++ b/spec/lib/models/revocable_spec.rb
@@ -11,20 +11,21 @@ describe 'Revocable' do
 
   describe :revoke do
     it 'updates :revoked_at attribute with current time' do
-      clock = double now: double
-      expect(subject).to receive(:update_attribute).with(:revoked_at, clock.now)
+      utc = double utc: double
+      clock = double now: utc
+      expect(subject).to receive(:update_attribute).with(:revoked_at, clock.now.utc)
       subject.revoke(clock)
     end
   end
 
   describe :revoked? do
     it 'is revoked if :revoked_at has passed' do
-      allow(subject).to receive(:revoked_at).and_return(Time.now - 1000)
+      allow(subject).to receive(:revoked_at).and_return(Time.now.utc - 1000)
       expect(subject).to be_revoked
     end
 
     it 'is not revoked if :revoked_at has not passed' do
-      allow(subject).to receive(:revoked_at).and_return(Time.now + 1000)
+      allow(subject).to receive(:revoked_at).and_return(Time.now.utc + 1000)
       expect(subject).not_to be_revoked
     end
 

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -129,7 +129,7 @@ module Doorkeeper
 
       it 'should destroy its access tokens' do
         FactoryGirl.create(:access_token, application: new_application)
-        FactoryGirl.create(:access_token, application: new_application, revoked_at: Time.now)
+        FactoryGirl.create(:access_token, application: new_application, revoked_at: Time.now.utc)
         expect do
           new_application.destroy
         end.to change { Doorkeeper::AccessToken.count }.by(-2)


### PR DESCRIPTION
I believe this repositories hound settings encourage not using Time.now without specifying something like timezone or UTC. This should fix those hound errors.