### PR TITLE
Add registration for grant flows

### DIFF
--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -5,6 +5,7 @@ require 'doorkeeper/config'
 require 'doorkeeper/errors'
 require 'doorkeeper/server'
 require 'doorkeeper/request'
+require 'doorkeeper/grant_flow'
 require 'doorkeeper/validations'
 
 require 'doorkeeper/oauth/authorization/code'

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -229,7 +229,7 @@ doorkeeper.
     end
 
     def enabled_grant_flows
-      @enabled_grant_flows ||= grant_flows.map{|name| GrantFlow.get(name) }
+      @enabled_grant_flows ||= grant_flows.map{ |name| GrantFlow.get(name) }
     end
 
     def authorization_response_flows

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -228,33 +228,24 @@ doorkeeper.
       @realm ||= 'Doorkeeper'
     end
 
-    def authorization_response_types
-      @authorization_response_types ||= calculate_authorization_response_types
+    def enabled_grant_flows
+      @enabled_grant_flows ||= grant_flows.map{|name| GrantFlow.get(name) }
     end
 
-    def token_grant_types
-      @token_grant_types ||= calculate_token_grant_types
+    def authorization_response_flows
+      @authorization_response_types ||= enabled_grant_flows.select(&:handles_response_type?)
+    end
+
+    def token_grant_flows
+      @token_grant_types ||= calculate_token_grant_flows
     end
 
     private
 
-    # Determines what values are acceptable for 'response_type' param in
-    # authorization request endpoint, and return them as an array of strings.
-    #
-    def calculate_authorization_response_types
-      types = []
-      types << 'code'  if grant_flows.include? 'authorization_code'
-      types << 'token' if grant_flows.include? 'implicit'
-      types
-    end
-
-    # Determines what values are acceptable for 'grant_type' param token
-    # request endpoint, and return them in array.
-    #
-    def calculate_token_grant_types
-      types = grant_flows - ['implicit']
-      types << 'refresh_token' if refresh_token_enabled?
-      types
+    def calculate_token_grant_flows
+      flows = enabled_grant_flows.select(&:handles_grant_type?)
+      flows << GrantFlow.get('refresh_token') if refresh_token_enabled?
+      flows
     end
   end
 end

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -229,7 +229,7 @@ doorkeeper.
     end
 
     def enabled_grant_flows
-      @enabled_grant_flows ||= grant_flows.map{ |name| GrantFlow.get(name) }
+      @enabled_grant_flows ||= grant_flows.map { |name| GrantFlow.get(name) }
     end
 
     def authorization_response_flows

--- a/lib/doorkeeper/grant_flow.rb
+++ b/lib/doorkeeper/grant_flow.rb
@@ -1,0 +1,44 @@
+require 'doorkeeper/grant_flow/flow'
+
+module Doorkeeper
+  module GrantFlow
+    mattr_accessor(:registered_flows) { Hash.new }
+
+    module_function
+
+    def register(name_or_flow, options = {})
+      if name_or_flow.is_a? Doorkeeper::GrantFlow::Flow
+        registered_flows[name_or_flow.name.to_sym] = name_or_flow
+      else
+        registered_flows[name_or_flow.to_sym] = Flow.new(name_or_flow, options)
+      end
+    end
+
+    def get(name)
+      registered_flows.fetch(name.to_sym)
+    end
+  end
+end
+
+Doorkeeper::GrantFlow.register :implicit, 
+  response_type_matches: 'token',
+  response_type_strategy: Doorkeeper::Request::Token
+
+Doorkeeper::GrantFlow.register :authorization_code,
+  response_type_matches: 'code',
+  response_type_strategy: Doorkeeper::Request::Code,
+  grant_type_matches: 'authorization_code',
+  grant_type_strategy: Doorkeeper::Request::AuthorizationCode
+
+Doorkeeper::GrantFlow.register :client_credentials,
+  grant_type_matches: 'client_credentials',
+  grant_type_strategy: Doorkeeper::Request::ClientCredentials
+
+Doorkeeper::GrantFlow.register :password,
+  grant_type_matches: 'password',
+  grant_type_strategy: Doorkeeper::Request::Password
+
+Doorkeeper::GrantFlow.register :refresh_token,
+  grant_type_matches: 'refresh_token',
+  grant_type_strategy: Doorkeeper::Request::RefreshToken
+

--- a/lib/doorkeeper/grant_flow.rb
+++ b/lib/doorkeeper/grant_flow.rb
@@ -20,7 +20,7 @@ module Doorkeeper
   end
 end
 
-Doorkeeper::GrantFlow.register :implicit, 
+Doorkeeper::GrantFlow.register :implicit,
   response_type_matches: 'token',
   response_type_strategy: Doorkeeper::Request::Token
 
@@ -41,4 +41,3 @@ Doorkeeper::GrantFlow.register :password,
 Doorkeeper::GrantFlow.register :refresh_token,
   grant_type_matches: 'refresh_token',
   grant_type_strategy: Doorkeeper::Request::RefreshToken
-

--- a/lib/doorkeeper/grant_flow.rb
+++ b/lib/doorkeeper/grant_flow.rb
@@ -21,24 +21,34 @@ module Doorkeeper
   end
 end
 
-Doorkeeper::GrantFlow.register :implicit,
+Doorkeeper::GrantFlow.register(
+  :implicit,
   response_type_matches: 'token',
   response_type_strategy: Doorkeeper::Request::Token
+)
 
-Doorkeeper::GrantFlow.register :authorization_code,
+Doorkeeper::GrantFlow.register(
+  :authorization_code,
   response_type_matches: 'code',
   response_type_strategy: Doorkeeper::Request::Code,
   grant_type_matches: 'authorization_code',
   grant_type_strategy: Doorkeeper::Request::AuthorizationCode
+)
 
-Doorkeeper::GrantFlow.register :client_credentials,
+Doorkeeper::GrantFlow.register(
+  :client_credentials,
   grant_type_matches: 'client_credentials',
   grant_type_strategy: Doorkeeper::Request::ClientCredentials
+)
 
-Doorkeeper::GrantFlow.register :password,
+Doorkeeper::GrantFlow.register(
+  :password,
   grant_type_matches: 'password',
   grant_type_strategy: Doorkeeper::Request::Password
+)
 
-Doorkeeper::GrantFlow.register :refresh_token,
+Doorkeeper::GrantFlow.register(
+  :refresh_token,
   grant_type_matches: 'refresh_token',
   grant_type_strategy: Doorkeeper::Request::RefreshToken
+)

--- a/lib/doorkeeper/grant_flow.rb
+++ b/lib/doorkeeper/grant_flow.rb
@@ -2,7 +2,8 @@ require 'doorkeeper/grant_flow/flow'
 
 module Doorkeeper
   module GrantFlow
-    mattr_accessor(:registered_flows) { Hash.new }
+    mattr_accessor :registered_flows
+    self.registered_flows = {}
 
     module_function
 

--- a/lib/doorkeeper/grant_flow/flow.rb
+++ b/lib/doorkeeper/grant_flow/flow.rb
@@ -1,0 +1,33 @@
+module Doorkeeper
+  module GrantFlow
+    class Flow
+      attr_accessor :name, 
+        :grant_type_matches, :grant_type_strategy,
+        :response_type_matches, :response_type_strategy
+
+      def initialize(name, options = {})
+        self.name = name
+        self.grant_type_matches = options[:grant_type_matches]
+        self.grant_type_strategy = options[:grant_type_strategy]
+        self.response_type_matches = options[:response_type_matches]
+        self.response_type_strategy = options[:response_type_strategy]
+      end
+
+      def handles_grant_type?
+        grant_type_matches.present?
+      end
+
+      def handles_response_type?
+        response_type_matches.present?
+      end
+
+      def matches_grant_type?(value)
+        grant_type_matches === value
+      end
+
+      def matches_response_type?(value)
+        response_type_matches === value
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/grant_flow/flow.rb
+++ b/lib/doorkeeper/grant_flow/flow.rb
@@ -2,8 +2,8 @@ module Doorkeeper
   module GrantFlow
     class Flow
       attr_accessor :name,
-        :grant_type_matches, :grant_type_strategy,
-        :response_type_matches, :response_type_strategy
+                    :grant_type_matches, :grant_type_strategy,
+                    :response_type_matches, :response_type_strategy
 
       def initialize(name, options = {})
         self.name = name

--- a/lib/doorkeeper/grant_flow/flow.rb
+++ b/lib/doorkeeper/grant_flow/flow.rb
@@ -1,7 +1,7 @@
 module Doorkeeper
   module GrantFlow
     class Flow
-      attr_accessor :name, 
+      attr_accessor :name,
         :grant_type_matches, :grant_type_strategy,
         :response_type_matches, :response_type_strategy
 

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -39,7 +39,9 @@ module Doorkeeper
       private
 
       def validate_response_type
-        server.authorization_response_flows.any? {|f| f.matches_response_type?(response_type) }
+        server.authorization_response_flows.any? do |flow|
+          flow.matches_response_type?(response_type)
+        end
       end
 
       def validate_client

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -39,7 +39,7 @@ module Doorkeeper
       private
 
       def validate_response_type
-        server.authorization_response_types.include? response_type
+        server.authorization_response_flows.any? {|f| f.matches_response_type?(response_type) }
       end
 
       def validate_client

--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -12,7 +12,7 @@ module Doorkeeper
     def authorization_strategy(response_type)
       fail Errors::MissingRequestStrategy unless response_type.present?
 
-      flow = authorization_flows.find{|f| f.matches_response_type?(response_type) }
+      flow = authorization_flows.detect { |flow| flow.matches_response_type?(response_type) }
 
       if flow
         flow.response_type_strategy
@@ -24,7 +24,7 @@ module Doorkeeper
     def token_strategy(grant_type)
       fail Errors::MissingRequestStrategy unless grant_type.present?
 
-      flow = token_flows.find{|f| f.matches_grant_type?(grant_type) }
+      flow = token_flows.detect { |flow| flow.matches_grant_type?(grant_type) }
 
       if flow
         flow.grant_type_strategy

--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -12,7 +12,9 @@ module Doorkeeper
     def authorization_strategy(response_type)
       fail Errors::MissingRequestStrategy unless response_type.present?
 
-      flow = authorization_flows.detect { |f| f.matches_response_type?(response_type) }
+      flow = authorization_flows.detect do |f|
+        f.matches_response_type?(response_type)
+      end
 
       if flow
         flow.response_type_strategy
@@ -24,7 +26,9 @@ module Doorkeeper
     def token_strategy(grant_type)
       fail Errors::MissingRequestStrategy unless grant_type.present?
 
-      flow = token_flows.detect { |f| f.matches_grant_type?(grant_type) }
+      flow = token_flows.detect do |f|
+        f.matches_grant_type?(grant_type)
+      end
 
       if flow
         flow.grant_type_strategy

--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -12,7 +12,7 @@ module Doorkeeper
     def authorization_strategy(response_type)
       fail Errors::MissingRequestStrategy unless response_type.present?
 
-      flow = authorization_flows.detect { |flow| flow.matches_response_type?(response_type) }
+      flow = authorization_flows.detect { |f| f.matches_response_type?(response_type) }
 
       if flow
         flow.response_type_strategy
@@ -24,7 +24,7 @@ module Doorkeeper
     def token_strategy(grant_type)
       fail Errors::MissingRequestStrategy unless grant_type.present?
 
-      flow = token_flows.detect { |flow| flow.matches_grant_type?(grant_type) }
+      flow = token_flows.detect { |f| f.matches_grant_type?(grant_type) }
 
       if flow
         flow.grant_type_strategy

--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -9,22 +9,36 @@ module Doorkeeper
   module Request
     module_function
 
-    def authorization_strategy(strategy)
-      get_strategy strategy, Doorkeeper.configuration.authorization_response_types
-    rescue NameError
-      raise Errors::InvalidAuthorizationStrategy
+    def authorization_strategy(response_type)
+      fail Errors::MissingRequestStrategy unless response_type.present?
+
+      flow = authorization_flows.find{|f| f.matches_response_type?(response_type) }
+
+      if flow
+        flow.response_type_strategy
+      else
+        raise Errors::InvalidAuthorizationStrategy
+      end
     end
 
-    def token_strategy(strategy)
-      get_strategy strategy, Doorkeeper.configuration.token_grant_types
-    rescue NameError
-      raise Errors::InvalidTokenStrategy
+    def token_strategy(grant_type)
+      fail Errors::MissingRequestStrategy unless grant_type.present?
+
+      flow = token_flows.find{|f| f.matches_grant_type?(grant_type) }
+
+      if flow
+        flow.grant_type_strategy
+      else
+        raise Errors::InvalidTokenStrategy
+      end
     end
 
-    def get_strategy(strategy, available)
-      fail Errors::MissingRequestStrategy unless strategy.present?
-      fail NameError unless available.include?(strategy.to_s)
-      "Doorkeeper::Request::#{strategy.to_s.camelize}".constantize
+    def authorization_flows
+      Doorkeeper.configuration.authorization_response_flows
+    end
+
+    def token_flows
+      Doorkeeper.configuration.token_grant_flows
     end
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -103,8 +103,8 @@ describe Doorkeeper, 'configuration' do
       expect(subject.refresh_token_enabled?).to be_truthy
     end
 
-    it "does not includes 'refresh_token' in authorization_response_types" do
-      expect(subject.token_grant_types).not_to include 'refresh_token'
+    it "does not includes 'refresh_token' in token_grant_flows" do
+      expect(subject.token_grant_flows).not_to include Doorkeeper::GrantFlow.get('refresh_token')
     end
 
     context "is enabled" do
@@ -115,8 +115,8 @@ describe Doorkeeper, 'configuration' do
         }
       end
 
-      it "includes 'refresh_token' in authorization_response_types" do
-        expect(subject.token_grant_types).to include 'refresh_token'
+      it "includes 'refresh_token' in token_grant_flows" do
+        expect(subject.token_grant_flows).to include Doorkeeper::GrantFlow.get('refresh_token')
       end
     end
   end
@@ -235,12 +235,12 @@ describe Doorkeeper, 'configuration' do
         }
       end
 
-      it "includes 'code' in authorization_response_types" do
-        expect(subject.authorization_response_types).to include 'code'
+      it "includes 'authorization_code' in authorization_response_flows" do
+        expect(subject.authorization_response_flows).to include Doorkeeper::GrantFlow.get('authorization_code')
       end
 
-      it "includes 'authorization_code' in token_grant_types" do
-        expect(subject.token_grant_types).to include 'authorization_code'
+      it "includes 'authorization_code' in token_grant_flows" do
+        expect(subject.token_grant_flows).to include Doorkeeper::GrantFlow.get('authorization_code')
       end
     end
 
@@ -252,8 +252,8 @@ describe Doorkeeper, 'configuration' do
         }
       end
 
-      it "includes 'token' in authorization_response_types" do
-        expect(subject.authorization_response_types).to include 'token'
+      it "includes 'implicit' in authorization_response_flows" do
+        expect(subject.authorization_response_flows).to include Doorkeeper::GrantFlow.get('implicit')
       end
     end
 
@@ -265,8 +265,8 @@ describe Doorkeeper, 'configuration' do
         }
       end
 
-      it "includes 'password' in token_grant_types" do
-        expect(subject.token_grant_types).to include 'password'
+      it "includes 'password' in token_grant_flows" do
+        expect(subject.token_grant_flows).to include Doorkeeper::GrantFlow.get('password')
       end
     end
 
@@ -278,8 +278,8 @@ describe Doorkeeper, 'configuration' do
         }
       end
 
-      it "includes 'client_credentials' in token_grant_types" do
-        expect(subject.token_grant_types).to include 'client_credentials'
+      it "includes 'client_credentials' in token_grant_flows" do
+        expect(subject.token_grant_flows).to include Doorkeeper::GrantFlow.get('client_credentials')
       end
     end
   end

--- a/spec/lib/grant_flow/flow_spec.rb
+++ b/spec/lib/grant_flow/flow_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'doorkeeper/grant_flow'
+
+module Doorkeeper
+  module GrantFlow
+    describe Flow do
+      let(:name) { 'secret_handshake' }
+      let(:options) { {} }
+      subject(:flow) { Flow.new(name, options) }
+
+      it "should reflect the given name" do
+        expect(flow.name).to eq name
+      end
+
+      context "with neither grant_type nor response_type" do
+        it "should not handle grant_type" do
+          expect(flow.handles_grant_type?).to be false
+        end
+
+        it "should not handle response_type" do
+          expect(flow.handles_response_type?).to be false
+        end
+      end
+
+      context "when given a grant_type to match" do
+        let(:grant_type_matches) { "secret_handshake" }
+        let(:options) { { grant_type_matches: grant_type_matches }  }
+
+        it "should handle grant_type" do
+          expect(flow.handles_grant_type?).to be true
+        end
+
+        context "when grant_type_matches is a string" do
+          it "should match grant_type values" do
+            expect( flow.matches_grant_type?(grant_type_matches) ).to be true
+          end
+        end
+
+        context "when grant_type_matches is a regular expression" do
+          let(:grant_type_matches) { /^secret_(.*)$/ }
+
+          it "should match grant_type values" do
+            expect( flow.matches_grant_type?("secret_boogie") ).to be true
+          end
+        end
+      end
+
+      context "when given a response_type to match" do
+        let(:response_type_matches) { "secret_handshake" }
+        let(:options) { { response_type_matches: response_type_matches }  }
+
+        it "should handle response_type" do
+          expect(flow.handles_response_type?).to be true
+        end
+
+        context "when response_type_matches is a string" do
+          it "should match response_type values" do
+            expect( flow.matches_response_type?(response_type_matches) ).to be true
+          end
+        end
+
+        context "when response_type_matches is a regular expression" do
+          let(:response_type_matches) { /^secret_(.*)$/ }
+
+          it "should match response_type values" do
+            expect( flow.matches_response_type?("secret_boogie") ).to be true
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/lib/grant_flow/flow_spec.rb
+++ b/spec/lib/grant_flow/flow_spec.rb
@@ -24,7 +24,7 @@ module Doorkeeper
 
       context "when given a grant_type to match" do
         let(:grant_type_matches) { "secret_handshake" }
-        let(:options) { { grant_type_matches: grant_type_matches }  }
+        let(:options) { { grant_type_matches: grant_type_matches } }
 
         it "should handle grant_type" do
           expect(flow.handles_grant_type?).to be true
@@ -32,7 +32,7 @@ module Doorkeeper
 
         context "when grant_type_matches is a string" do
           it "should match grant_type values" do
-            expect( flow.matches_grant_type?(grant_type_matches) ).to be true
+            expect(flow.matches_grant_type?(grant_type_matches)).to be true
           end
         end
 
@@ -40,14 +40,14 @@ module Doorkeeper
           let(:grant_type_matches) { /^secret_(.*)$/ }
 
           it "should match grant_type values" do
-            expect( flow.matches_grant_type?("secret_boogie") ).to be true
+            expect(flow.matches_grant_type?("secret_boogie")).to be true
           end
         end
       end
 
       context "when given a response_type to match" do
         let(:response_type_matches) { "secret_handshake" }
-        let(:options) { { response_type_matches: response_type_matches }  }
+        let(:options) { { response_type_matches: response_type_matches } }
 
         it "should handle response_type" do
           expect(flow.handles_response_type?).to be true
@@ -55,7 +55,7 @@ module Doorkeeper
 
         context "when response_type_matches is a string" do
           it "should match response_type values" do
-            expect( flow.matches_response_type?(response_type_matches) ).to be true
+            expect(flow.matches_response_type?(response_type_matches)).to be true
           end
         end
 
@@ -63,11 +63,10 @@ module Doorkeeper
           let(:response_type_matches) { /^secret_(.*)$/ }
 
           it "should match response_type values" do
-            expect( flow.matches_response_type?("secret_boogie") ).to be true
+            expect(flow.matches_response_type?("secret_boogie")).to be true
           end
         end
       end
-
     end
   end
 end

--- a/spec/lib/grant_flow_spec.rb
+++ b/spec/lib/grant_flow_spec.rb
@@ -10,10 +10,11 @@ module Doorkeeper
         let(:grant_type_strategy) { double }
 
         before do
-          GrantFlow.register(name,
-                              grant_type_matches: grant_type_matches,
-                              grant_type_strategy: grant_type_strategy
-                            )
+          GrantFlow.register(
+            name,
+            grant_type_matches: grant_type_matches,
+            grant_type_strategy: grant_type_strategy
+          )
         end
 
         subject(:the_registered_flow) { GrantFlow.get(name) }

--- a/spec/lib/grant_flow_spec.rb
+++ b/spec/lib/grant_flow_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'doorkeeper/grant_flow'
+
+module Doorkeeper
+  describe GrantFlow do
+    describe :register do
+      context "with a name and options" do
+        let(:name) { "puzzle_box" }
+        let(:grant_type_matches) { "tile_position" }
+        let(:grant_type_strategy) { double }
+
+        before do
+          GrantFlow.register(name, 
+            grant_type_matches: grant_type_matches,
+            grant_type_strategy: grant_type_strategy
+          )
+        end
+
+        subject(:the_registered_flow) { GrantFlow.get(name) }
+
+        it "should create a new Flow" do
+          expect(the_registered_flow).to be_a GrantFlow::Flow
+        end
+
+        it "should pass on the given name" do
+          expect(the_registered_flow.name).to eq name
+        end
+
+        it "should set the options" do
+          expect(the_registered_flow.grant_type_matches).to eq grant_type_matches
+          expect(the_registered_flow.grant_type_strategy).to eq grant_type_strategy
+        end
+      end
+
+      context "with an existing flow" do
+        let(:existing_flow) { GrantFlow::Flow.new('light') }
+
+        before do
+          GrantFlow.register existing_flow
+        end
+
+        it "should record the existing Flow using its name" do
+          expect(GrantFlow.get(existing_flow.name)).to eq existing_flow
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/grant_flow_spec.rb
+++ b/spec/lib/grant_flow_spec.rb
@@ -10,10 +10,10 @@ module Doorkeeper
         let(:grant_type_strategy) { double }
 
         before do
-          GrantFlow.register(name, 
-            grant_type_matches: grant_type_matches,
-            grant_type_strategy: grant_type_strategy
-          )
+          GrantFlow.register(name,
+                              grant_type_matches: grant_type_matches,
+                              grant_type_strategy: grant_type_strategy
+                            )
         end
 
         subject(:the_registered_flow) { GrantFlow.get(name) }

--- a/spec/lib/server_spec.rb
+++ b/spec/lib/server_spec.rb
@@ -4,8 +4,6 @@ require 'doorkeeper/errors'
 require 'doorkeeper/server'
 
 describe Doorkeeper::Server do
-  let(:fake_class) { double :fake_class }
-
   subject do
     described_class.new
   end
@@ -44,9 +42,8 @@ describe Doorkeeper::Server do
     end
 
     it 'builds the request with selected strategy' do
-      stub_const 'Doorkeeper::Request::Code', fake_class
-      expect(fake_class).to receive(:build).with(subject)
-      subject.authorization_request :code
+      expect(Doorkeeper::Request::Code).to receive(:build).with(subject)
+      subject.authorization_request 'code'
     end
   end
 end


### PR DESCRIPTION
This is a proposal inspired by comments on https://github.com/doorkeeper-gem/doorkeeper-grants_assertion/issues/9, where the possibility of adding strategy registration to Doorkeeper is mentioned.

This adds a `Doorkeeper::GrantFlow` module, which handles registration, and a `Doorkeeper::GrantFlow::Flow` class to handle the actual matching of `grant_type` and `response_type` values.

A new flow is registered like so:

```ruby
Doorkeeper::GrantFlow.register :authorization_code,
  response_type_matches: 'code',
  response_type_strategy: Doorkeeper::Request::Code,
  grant_type_matches: 'authorization_code',
  grant_type_strategy: Doorkeeper::Request::AuthorizationCode
```

Instead of relying on constantizing the param values, requests are now routed to their corresponding strategy by matching against the `response_type_matches` and `grant_type_matches` attributes. This uses the `===` operator, so regular expressions may be used.

Is this an approach you'd be interested in? I'd be happy to iterate and improve on this idea.