### PR TITLE
Refactor request strategy classes

### DIFF
--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -9,22 +9,22 @@ module Doorkeeper
   module Request
     module_function
 
-    def authorization_strategy(strategy)
-      get_strategy strategy, Doorkeeper.configuration.authorization_response_types
+    def authorization_strategy(response_type)
+      get_strategy response_type, Doorkeeper.configuration.authorization_response_types
     rescue NameError
       raise Errors::InvalidAuthorizationStrategy
     end
 
-    def token_strategy(strategy)
-      get_strategy strategy, Doorkeeper.configuration.token_grant_types
+    def token_strategy(grant_type)
+      get_strategy grant_type, Doorkeeper.configuration.token_grant_types
     rescue NameError
       raise Errors::InvalidTokenStrategy
     end
 
-    def get_strategy(strategy, available)
-      fail Errors::MissingRequestStrategy unless strategy.present?
-      fail NameError unless available.include?(strategy.to_s)
-      "Doorkeeper::Request::#{strategy.to_s.camelize}".constantize
+    def get_strategy(grant_or_request_type, available)
+      fail Errors::MissingRequestStrategy unless grant_or_request_type.present?
+      fail NameError unless available.include?(grant_or_request_type.to_s)
+      "Doorkeeper::Request::#{grant_or_request_type.to_s.camelize}".constantize
     end
   end
 end

--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -10,13 +10,13 @@ module Doorkeeper
     module_function
 
     def authorization_strategy(response_type)
-      get_strategy response_type, Doorkeeper.configuration.authorization_response_types
+      get_strategy response_type, authorization_response_types
     rescue NameError
       raise Errors::InvalidAuthorizationStrategy
     end
 
     def token_strategy(grant_type)
-      get_strategy grant_type, Doorkeeper.configuration.token_grant_types
+      get_strategy grant_type, token_grant_types
     rescue NameError
       raise Errors::InvalidTokenStrategy
     end
@@ -26,5 +26,15 @@ module Doorkeeper
       fail NameError unless available.include?(grant_or_request_type.to_s)
       "Doorkeeper::Request::#{grant_or_request_type.to_s.camelize}".constantize
     end
+
+    def authorization_response_types
+      Doorkeeper.configuration.authorization_response_types
+    end
+    private_class_method :authorization_response_types
+
+    def token_grant_types
+      Doorkeeper.configuration.token_grant_types
+    end
+    private_class_method :token_grant_types
   end
 end

--- a/lib/doorkeeper/request/authorization_code.rb
+++ b/lib/doorkeeper/request/authorization_code.rb
@@ -1,18 +1,17 @@
+require 'doorkeeper/request/strategy'
+
 module Doorkeeper
   module Request
-    class AuthorizationCode
-      attr_accessor :grant, :client, :server
+    class AuthorizationCode < Strategy
+      attr_accessor :grant, :client
 
       def initialize(server)
-        @grant, @client, @server = server.grant, server.client, server
+        super
+        @grant, @client = server.grant, server.client
       end
 
       def request
         @request ||= OAuth::AuthorizationCodeRequest.new(Doorkeeper.configuration, grant, client, server.parameters)
-      end
-
-      def authorize
-        request.authorize
       end
     end
   end

--- a/lib/doorkeeper/request/authorization_code.rb
+++ b/lib/doorkeeper/request/authorization_code.rb
@@ -6,7 +6,12 @@ module Doorkeeper
       delegate :grant, :client, :parameters, to: :server
 
       def request
-        @request ||= OAuth::AuthorizationCodeRequest.new(Doorkeeper.configuration, grant, client, parameters)
+        @request ||= OAuth::AuthorizationCodeRequest.new(
+          Doorkeeper.configuration,
+          grant,
+          client,
+          parameters
+        )
       end
     end
   end

--- a/lib/doorkeeper/request/authorization_code.rb
+++ b/lib/doorkeeper/request/authorization_code.rb
@@ -1,14 +1,10 @@
 module Doorkeeper
   module Request
     class AuthorizationCode
-      def self.build(server)
-        new(server.grant, server.client, server)
-      end
-
       attr_accessor :grant, :client, :server
 
-      def initialize(grant, client, server)
-        @grant, @client, @server = grant, client, server
+      def initialize(server)
+        @grant, @client, @server = server.grant, server.client, server
       end
 
       def request

--- a/lib/doorkeeper/request/authorization_code.rb
+++ b/lib/doorkeeper/request/authorization_code.rb
@@ -3,15 +3,10 @@ require 'doorkeeper/request/strategy'
 module Doorkeeper
   module Request
     class AuthorizationCode < Strategy
-      attr_accessor :grant, :client
-
-      def initialize(server)
-        super
-        @grant, @client = server.grant, server.client
-      end
+      delegate :grant, :client, :parameters, to: :server
 
       def request
-        @request ||= OAuth::AuthorizationCodeRequest.new(Doorkeeper.configuration, grant, client, server.parameters)
+        @request ||= OAuth::AuthorizationCodeRequest.new(Doorkeeper.configuration, grant, client, parameters)
       end
     end
   end

--- a/lib/doorkeeper/request/client_credentials.rb
+++ b/lib/doorkeeper/request/client_credentials.rb
@@ -1,14 +1,10 @@
 module Doorkeeper
   module Request
     class ClientCredentials
-      def self.build(server)
-        new(server.client, server)
-      end
-
       attr_accessor :client, :server
 
-      def initialize(client, server)
-        @client, @server = client, server
+      def initialize(server)
+        @client, @server = server.client, server
       end
 
       def request

--- a/lib/doorkeeper/request/client_credentials.rb
+++ b/lib/doorkeeper/request/client_credentials.rb
@@ -3,15 +3,10 @@ require 'doorkeeper/request/strategy'
 module Doorkeeper
   module Request
     class ClientCredentials < Strategy
-      attr_accessor :client
-
-      def initialize(server)
-        super
-        @client = server.client
-      end
+      delegate :client, :parameters, to: :server
 
       def request
-        @request ||= OAuth::ClientCredentialsRequest.new(Doorkeeper.configuration, client, server.parameters)
+        @request ||= OAuth::ClientCredentialsRequest.new(Doorkeeper.configuration, client, parameters)
       end
     end
   end

--- a/lib/doorkeeper/request/client_credentials.rb
+++ b/lib/doorkeeper/request/client_credentials.rb
@@ -1,18 +1,17 @@
+require 'doorkeeper/request/strategy'
+
 module Doorkeeper
   module Request
-    class ClientCredentials
-      attr_accessor :client, :server
+    class ClientCredentials < Strategy
+      attr_accessor :client
 
       def initialize(server)
-        @client, @server = server.client, server
+        super
+        @client = server.client
       end
 
       def request
         @request ||= OAuth::ClientCredentialsRequest.new(Doorkeeper.configuration, client, server.parameters)
-      end
-
-      def authorize
-        request.authorize
       end
     end
   end

--- a/lib/doorkeeper/request/client_credentials.rb
+++ b/lib/doorkeeper/request/client_credentials.rb
@@ -6,7 +6,11 @@ module Doorkeeper
       delegate :client, :parameters, to: :server
 
       def request
-        @request ||= OAuth::ClientCredentialsRequest.new(Doorkeeper.configuration, client, parameters)
+        @request ||= OAuth::ClientCredentialsRequest.new(
+          Doorkeeper.configuration,
+          client,
+          parameters
+        )
       end
     end
   end

--- a/lib/doorkeeper/request/code.rb
+++ b/lib/doorkeeper/request/code.rb
@@ -3,15 +3,14 @@ require 'doorkeeper/request/strategy'
 module Doorkeeper
   module Request
     class Code < Strategy
-      attr_accessor :pre_auth
+      delegate :current_resource_owner, to: :server
 
-      def initialize(server)
-        super
-        @pre_auth = server.context.send(:pre_auth)
+      def pre_auth
+        server.context.send(:pre_auth)
       end
 
       def request
-        @request ||= OAuth::CodeRequest.new(pre_auth, server.current_resource_owner)
+        @request ||= OAuth::CodeRequest.new(pre_auth, current_resource_owner)
       end
     end
   end

--- a/lib/doorkeeper/request/code.rb
+++ b/lib/doorkeeper/request/code.rb
@@ -1,14 +1,11 @@
 module Doorkeeper
   module Request
     class Code
-      def self.build(server)
-        new(server.context.send(:pre_auth), server)
-      end
-
       attr_accessor :pre_auth, :server
 
-      def initialize(pre_auth, server)
-        @pre_auth, @server = pre_auth, server
+      def initialize(server)
+        @pre_auth = server.context.send(:pre_auth)
+        @server = server
       end
 
       def request

--- a/lib/doorkeeper/request/code.rb
+++ b/lib/doorkeeper/request/code.rb
@@ -1,19 +1,17 @@
+require 'doorkeeper/request/strategy'
+
 module Doorkeeper
   module Request
-    class Code
-      attr_accessor :pre_auth, :server
+    class Code < Strategy
+      attr_accessor :pre_auth
 
       def initialize(server)
+        super
         @pre_auth = server.context.send(:pre_auth)
-        @server = server
       end
 
       def request
         @request ||= OAuth::CodeRequest.new(pre_auth, server.current_resource_owner)
-      end
-
-      def authorize
-        request.authorize
       end
     end
   end

--- a/lib/doorkeeper/request/password.rb
+++ b/lib/doorkeeper/request/password.rb
@@ -3,16 +3,10 @@ require 'doorkeeper/request/strategy'
 module Doorkeeper
   module Request
     class Password < Strategy
-      attr_accessor :credentials, :resource_owner
-
-      def initialize(server)
-        super
-        @credentials = server.credentials
-        @resource_owner = server.resource_owner
-      end
+      delegate :credentials, :resource_owner, :parameters, to: :server
 
       def request
-        @request ||= OAuth::PasswordAccessTokenRequest.new(Doorkeeper.configuration, credentials, resource_owner, server.parameters)
+        @request ||= OAuth::PasswordAccessTokenRequest.new(Doorkeeper.configuration, credentials, resource_owner, parameters)
       end
     end
   end

--- a/lib/doorkeeper/request/password.rb
+++ b/lib/doorkeeper/request/password.rb
@@ -1,20 +1,18 @@
+require 'doorkeeper/request/strategy'
+
 module Doorkeeper
   module Request
-    class Password
-      attr_accessor :credentials, :resource_owner, :server
+    class Password < Strategy
+      attr_accessor :credentials, :resource_owner
 
       def initialize(server)
+        super
         @credentials = server.credentials
         @resource_owner = server.resource_owner
-        @server = server
       end
 
       def request
         @request ||= OAuth::PasswordAccessTokenRequest.new(Doorkeeper.configuration, credentials, resource_owner, server.parameters)
-      end
-
-      def authorize
-        request.authorize
       end
     end
   end

--- a/lib/doorkeeper/request/password.rb
+++ b/lib/doorkeeper/request/password.rb
@@ -1,14 +1,12 @@
 module Doorkeeper
   module Request
     class Password
-      def self.build(server)
-        new(server.credentials, server.resource_owner, server)
-      end
-
       attr_accessor :credentials, :resource_owner, :server
 
-      def initialize(credentials, resource_owner, server)
-        @credentials, @resource_owner, @server = credentials, resource_owner, server
+      def initialize(server)
+        @credentials = server.credentials
+        @resource_owner = server.resource_owner
+        @server = server
       end
 
       def request

--- a/lib/doorkeeper/request/password.rb
+++ b/lib/doorkeeper/request/password.rb
@@ -6,7 +6,12 @@ module Doorkeeper
       delegate :credentials, :resource_owner, :parameters, to: :server
 
       def request
-        @request ||= OAuth::PasswordAccessTokenRequest.new(Doorkeeper.configuration, credentials, resource_owner, parameters)
+        @request ||= OAuth::PasswordAccessTokenRequest.new(
+          Doorkeeper.configuration,
+          credentials,
+          resource_owner,
+          parameters
+        )
       end
     end
   end

--- a/lib/doorkeeper/request/refresh_token.rb
+++ b/lib/doorkeeper/request/refresh_token.rb
@@ -10,7 +10,11 @@ module Doorkeeper
       end
 
       def request
-        @request ||= OAuth::RefreshTokenRequest.new(Doorkeeper.configuration, refresh_token, credentials, parameters)
+        @request ||= OAuth::RefreshTokenRequest.new(
+          Doorkeeper.configuration,
+          refresh_token, credentials,
+          parameters
+        )
       end
     end
   end

--- a/lib/doorkeeper/request/refresh_token.rb
+++ b/lib/doorkeeper/request/refresh_token.rb
@@ -1,20 +1,18 @@
+require 'doorkeeper/request/strategy'
+
 module Doorkeeper
   module Request
-    class RefreshToken
-      attr_accessor :refresh_token, :credentials, :server
+    class RefreshToken < Strategy
+      attr_accessor :refresh_token, :credentials
 
       def initialize(server)
+        super
         @refresh_token = server.current_refresh_token
         @credentials = server.credentials
-        @server = server
       end
 
       def request
         @request ||= OAuth::RefreshTokenRequest.new(Doorkeeper.configuration, refresh_token, credentials, server.parameters)
-      end
-
-      def authorize
-        request.authorize
       end
     end
   end

--- a/lib/doorkeeper/request/refresh_token.rb
+++ b/lib/doorkeeper/request/refresh_token.rb
@@ -3,16 +3,14 @@ require 'doorkeeper/request/strategy'
 module Doorkeeper
   module Request
     class RefreshToken < Strategy
-      attr_accessor :refresh_token, :credentials
+      delegate :credentials, :parameters, to: :server
 
-      def initialize(server)
-        super
-        @refresh_token = server.current_refresh_token
-        @credentials = server.credentials
+      def refresh_token
+        server.current_refresh_token
       end
 
       def request
-        @request ||= OAuth::RefreshTokenRequest.new(Doorkeeper.configuration, refresh_token, credentials, server.parameters)
+        @request ||= OAuth::RefreshTokenRequest.new(Doorkeeper.configuration, refresh_token, credentials, parameters)
       end
     end
   end

--- a/lib/doorkeeper/request/refresh_token.rb
+++ b/lib/doorkeeper/request/refresh_token.rb
@@ -1,14 +1,12 @@
 module Doorkeeper
   module Request
     class RefreshToken
-      def self.build(server)
-        new(server.current_refresh_token, server.credentials, server)
-      end
-
       attr_accessor :refresh_token, :credentials, :server
 
-      def initialize(refresh_token, credentials, server)
-        @refresh_token, @credentials, @server = refresh_token, credentials, server
+      def initialize(server)
+        @refresh_token = server.current_refresh_token
+        @credentials = server.credentials
+        @server = server
       end
 
       def request

--- a/lib/doorkeeper/request/strategy.rb
+++ b/lib/doorkeeper/request/strategy.rb
@@ -1,0 +1,19 @@
+module Doorkeeper
+  module Request
+    class Strategy
+      attr_accessor :server
+
+      def initialize(server)
+        self.server = server
+      end
+
+      def request
+        raise NotImplementedError, "request strategies must define #request"
+      end
+
+      def authorize
+        request.authorize
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/request/strategy.rb
+++ b/lib/doorkeeper/request/strategy.rb
@@ -3,16 +3,14 @@ module Doorkeeper
     class Strategy
       attr_accessor :server
 
+      delegate :authorize, to: :request
+
       def initialize(server)
         self.server = server
       end
 
       def request
         raise NotImplementedError, "request strategies must define #request"
-      end
-
-      def authorize
-        request.authorize
       end
     end
   end

--- a/lib/doorkeeper/request/token.rb
+++ b/lib/doorkeeper/request/token.rb
@@ -3,15 +3,14 @@ require 'doorkeeper/request/strategy'
 module Doorkeeper
   module Request
     class Token < Strategy
-      attr_accessor :pre_auth
+      delegate :current_resource_owner, to: :server
 
-      def initialize(server)
-        super
-        @pre_auth = server.context.send(:pre_auth)
+      def pre_auth
+        server.context.send(:pre_auth)
       end
 
       def request
-        @request ||= OAuth::TokenRequest.new(pre_auth, server.current_resource_owner)
+        @request ||= OAuth::TokenRequest.new(pre_auth, current_resource_owner)
       end
     end
   end

--- a/lib/doorkeeper/request/token.rb
+++ b/lib/doorkeeper/request/token.rb
@@ -1,14 +1,11 @@
 module Doorkeeper
   module Request
     class Token
-      def self.build(server)
-        new(server.context.send(:pre_auth), server)
-      end
-
       attr_accessor :pre_auth, :server
 
-      def initialize(pre_auth, server)
-        @pre_auth, @server = pre_auth, server
+      def initialize(server)
+        @pre_auth = server.context.send(:pre_auth)
+        @server = server
       end
 
       def request

--- a/lib/doorkeeper/request/token.rb
+++ b/lib/doorkeeper/request/token.rb
@@ -1,19 +1,17 @@
+require 'doorkeeper/request/strategy'
+
 module Doorkeeper
   module Request
-    class Token
-      attr_accessor :pre_auth, :server
+    class Token < Strategy
+      attr_accessor :pre_auth
 
       def initialize(server)
+        super
         @pre_auth = server.context.send(:pre_auth)
-        @server = server
       end
 
       def request
         @request ||= OAuth::TokenRequest.new(pre_auth, server.current_resource_owner)
-      end
-
-      def authorize
-        request.authorize
       end
     end
   end

--- a/lib/doorkeeper/server.rb
+++ b/lib/doorkeeper/server.rb
@@ -8,12 +8,12 @@ module Doorkeeper
 
     def authorization_request(strategy)
       klass = Request.authorization_strategy strategy
-      klass.build self
+      klass.new self
     end
 
     def token_request(strategy)
       klass = Request.token_strategy strategy
-      klass.build self
+      klass.new self
     end
 
     # TODO: context should be the request

--- a/spec/lib/request/strategy_spec.rb
+++ b/spec/lib/request/strategy_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'doorkeeper/request/strategy'
+
+module Doorkeeper
+  module Request
+    describe Strategy do
+      let(:server) { double }
+      subject(:strategy) { Strategy.new(server) }
+
+      describe :initialize do
+        it "sets the server attribute" do
+          expect(strategy.server).to eq server
+        end
+      end
+
+      describe :request do
+        it "requires an implementation" do
+          expect { strategy.request }.to raise_exception NotImplementedError
+        end
+      end
+
+      describe "a sample Strategy subclass" do
+        let(:fake_request) { double }
+        let(:strategy_class) {
+          subclass = Class.new(Strategy) do
+            class << self
+              attr_accessor :fake_request
+            end
+
+            def request
+              self.class.fake_request
+            end
+          end
+
+          subclass.fake_request = fake_request
+          subclass
+        }
+        subject(:strategy) { strategy_class.new(server) }
+
+        it "provides a request implementation" do
+          expect(strategy.request).to eq fake_request
+        end
+
+        it "authorizes the request" do
+          expect(fake_request).to receive :authorize
+          strategy.authorize
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/request/strategy_spec.rb
+++ b/spec/lib/request/strategy_spec.rb
@@ -21,7 +21,8 @@ module Doorkeeper
 
       describe "a sample Strategy subclass" do
         let(:fake_request) { double }
-        let(:strategy_class) {
+
+        let(:strategy_class) do
           subclass = Class.new(Strategy) do
             class << self
               attr_accessor :fake_request
@@ -34,7 +35,8 @@ module Doorkeeper
 
           subclass.fake_request = fake_request
           subclass
-        }
+        end
+
         subject(:strategy) { strategy_class.new(server) }
 
         it "provides a request implementation" do

--- a/spec/lib/server_spec.rb
+++ b/spec/lib/server_spec.rb
@@ -45,7 +45,7 @@ describe Doorkeeper::Server do
 
     it 'builds the request with selected strategy' do
       stub_const 'Doorkeeper::Request::Code', fake_class
-      expect(fake_class).to receive(:build).with(subject)
+      expect(fake_class).to receive(:new).with(subject)
       subject.authorization_request :code
     end
   end


### PR DESCRIPTION
While putting together #733, I came across what seemed like an opportunity to simplify and remove some duplication in the request strategy classes. I'd thought some of this might be necessary for to get #733 to a working state, but they ended up being easily separable.

Is this a bit of refactoring you'd be interested in?