### PR TITLE
Reuse the existing token in client_credentials flow

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 User-visible changes worth mentioning.
 
 ---
-
+- [#736] Existing valid tokens are now resused in client_credentials flow
 - [#722] `doorkeeper_forbidden_render_options` now supports returning a 404 by
   specifying `respond_not_found_when_forbidden: true` in the
   `doorkeeper_forbidden_render_options` method.

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -3,10 +3,9 @@ module Doorkeeper
     class ClientCredentialsRequest
       class Creator
         def call(client, scopes, attributes = {})
-          AccessToken.create(attributes.merge(
-            application_id: client.id,
-            scopes: scopes.to_s
-          ))
+          AccessToken.find_or_create_for(
+            client, nil, scopes, attributes[:expires_in],
+            attributes[:use_refresh_token])
         end
       end
     end

--- a/spec/lib/oauth/client_credentials/creator_spec.rb
+++ b/spec/lib/oauth/client_credentials/creator_spec.rb
@@ -11,8 +11,32 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
       end.to change { Doorkeeper::AccessToken.count }.by(1)
     end
 
+    context "when reuse_access_token is true" do
+      it "returns the existing valid token" do
+        allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
+        existing_token = subject.call(client, scopes)
+
+        result = subject.call(client, scopes)
+
+        expect(Doorkeeper::AccessToken.count).to eq(1)
+        expect(result).to eq(existing_token)
+      end
+    end
+
+    context "when reuse_access_token is false" do
+      it "returns a new token" do
+        allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(false)
+        existing_token = subject.call(client, scopes)
+
+        result = subject.call(client, scopes)
+
+        expect(Doorkeeper::AccessToken.count).to eq(2)
+        expect(result).not_to eq(existing_token)
+      end
+    end
+
     it 'returns false if creation fails' do
-      expect(Doorkeeper::AccessToken).to receive(:create).and_return(false)
+      expect(Doorkeeper::AccessToken).to receive(:find_or_create_for).and_return(false)
       created = subject.call(client, scopes)
       expect(created).to be_falsey
     end


### PR DESCRIPTION
Fixes issue 661: https://github.com/doorkeeper-gem/doorkeeper/issues/661