### PR TITLE
Allow localhost in redirect URI option, and fixed attr_accessible issue with Rails 4.0.x

### DIFF
--- a/app/validators/redirect_uri_validator.rb
+++ b/app/validators/redirect_uri_validator.rb
@@ -14,7 +14,7 @@ class RedirectUriValidator < ActiveModel::EachValidator
         return if native_redirect_uri?(uri)
         record.errors.add(attribute, :fragment_present) unless uri.fragment.nil?
         record.errors.add(attribute, :relative_uri) if uri.scheme.nil? || uri.host.nil?
-        record.errors.add(attribute, :secured_uri) if invalid_ssl_uri?(uri)
+        record.errors.add(attribute, :secured_uri) if invalid_ssl_uri?(uri) && !allowed_localhost_uri?(uri)
       end
     end
   rescue URI::InvalidURIError
@@ -30,5 +30,10 @@ class RedirectUriValidator < ActiveModel::EachValidator
   def invalid_ssl_uri?(uri)
     forces_ssl = Doorkeeper.configuration.force_ssl_in_redirect_uri
     forces_ssl && uri.try(:scheme) == 'http'
+  end
+
+  def allowed_localhost_uri?(uri)
+    allow_localhost = Doorkeeper.configuration.allow_localhost_in_redirect_uri
+    allow_localhost && uri.host == 'localhost'
   end
 end

--- a/app/validators/redirect_uri_validator.rb
+++ b/app/validators/redirect_uri_validator.rb
@@ -14,7 +14,9 @@ class RedirectUriValidator < ActiveModel::EachValidator
         return if native_redirect_uri?(uri)
         record.errors.add(attribute, :fragment_present) unless uri.fragment.nil?
         record.errors.add(attribute, :relative_uri) if uri.scheme.nil? || uri.host.nil?
-        record.errors.add(attribute, :secured_uri) if invalid_ssl_uri?(uri) && !allowed_localhost_uri?(uri)
+        if invalid_ssl_uri?(uri) && !allowed_localhost_uri?(uri)
+          record.errors.add(attribute, :secured_uri)
+        end
       end
     end
   rescue URI::InvalidURIError
@@ -33,7 +35,8 @@ class RedirectUriValidator < ActiveModel::EachValidator
   end
 
   def allowed_localhost_uri?(uri)
-    allow_localhost = Doorkeeper.configuration.allow_localhost_in_redirect_uri
+    allow_localhost = Doorkeeper.configuration
+                                .allow_localhost_in_redirect_uri
     allow_localhost && uri.host == 'localhost'
   end
 end

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -93,6 +93,10 @@ doorkeeper.
         @config.instance_variable_set("@force_ssl_in_redirect_uri", boolean)
       end
 
+      def allow_localhost_in_redirect_uri(boolean)
+        @config.instance_variable_set("@allow_localhost_in_redirect_uri", boolean)
+      end
+
       def access_token_generator(access_token_generator)
         @config.instance_variable_set(
           '@access_token_generator', access_token_generator
@@ -178,17 +182,18 @@ doorkeeper.
              nil
            end)
 
-    option :skip_authorization,             default: ->(_routes) {}
-    option :access_token_expires_in,        default: 7200
-    option :custom_access_token_expires_in, default: lambda { |_app| nil }
-    option :authorization_code_expires_in,  default: 600
-    option :orm,                            default: :active_record
-    option :native_redirect_uri,            default: 'urn:ietf:wg:oauth:2.0:oob'
-    option :active_record_options,          default: {}
-    option :realm,                          default: 'Doorkeeper'
-    option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
-    option :grant_flows,                    default: %w(authorization_code client_credentials)
-    option :access_token_generator,         default: "Doorkeeper::OAuth::Helpers::UniqueToken"
+    option :skip_authorization,               default: ->(_routes) {}
+    option :access_token_expires_in,          default: 7200
+    option :custom_access_token_expires_in,   default: lambda { |_app| nil }
+    option :authorization_code_expires_in,    default: 600
+    option :orm,                              default: :active_record
+    option :native_redirect_uri,              default: 'urn:ietf:wg:oauth:2.0:oob'
+    option :active_record_options,            default: {}
+    option :realm,                            default: 'Doorkeeper'
+    option :force_ssl_in_redirect_uri,        default: !Rails.env.development?
+    option :allow_localhost_in_redirect_uri,  default: Rails.env.development?
+    option :grant_flows,                      default: %w(authorization_code client_credentials)
+    option :access_token_generator,           default: "Doorkeeper::OAuth::Helpers::UniqueToken"
 
     attr_reader :reuse_access_token
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -94,7 +94,10 @@ doorkeeper.
       end
 
       def allow_localhost_in_redirect_uri(boolean)
-        @config.instance_variable_set("@allow_localhost_in_redirect_uri", boolean)
+        @config.instance_variable_set(
+          "@allow_localhost_in_redirect_uri",
+          boolean
+        )
       end
 
       def access_token_generator(access_token_generator)

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -13,8 +13,8 @@ module Doorkeeper
       belongs_to :application, class_name: 'Doorkeeper::Application', inverse_of: :access_grants
 
       if defined?(ActiveModel::MassAssignmentSecurity) &&
-        included_modules.include?(ActiveModel::MassAssignmentSecurity)
-        
+         included_modules.include?(ActiveModel::MassAssignmentSecurity)
+
         attr_accessible :resource_owner_id, :application_id, :expires_in, :redirect_uri, :scopes
       end
 

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -12,7 +12,7 @@ module Doorkeeper
     included do
       belongs_to :application, class_name: 'Doorkeeper::Application', inverse_of: :access_grants
 
-      if respond_to?(:attr_accessible)
+      if defined?(::ProtectedAttributes)
         attr_accessible :resource_owner_id, :application_id, :expires_in, :redirect_uri, :scopes
       end
 

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -12,7 +12,9 @@ module Doorkeeper
     included do
       belongs_to :application, class_name: 'Doorkeeper::Application', inverse_of: :access_grants
 
-      if defined?(::ProtectedAttributes)
+      if defined?(ActiveModel::MassAssignmentSecurity) &&
+        included_modules.include?(ActiveModel::MassAssignmentSecurity)
+        
         attr_accessible :resource_owner_id, :application_id, :expires_in, :redirect_uri, :scopes
       end
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -19,7 +19,7 @@ module Doorkeeper
 
       attr_writer :use_refresh_token
 
-      if respond_to?(:attr_accessible)
+      if defined?(::ProtectedAttributes)
         attr_accessible :application_id, :resource_owner_id, :expires_in,
                         :scopes, :use_refresh_token
       end

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -20,8 +20,8 @@ module Doorkeeper
       attr_writer :use_refresh_token
 
       if defined?(ActiveModel::MassAssignmentSecurity) &&
-        included_modules.include?(ActiveModel::MassAssignmentSecurity)
-        
+         included_modules.include?(ActiveModel::MassAssignmentSecurity)
+
         attr_accessible :application_id, :resource_owner_id, :expires_in,
                         :scopes, :use_refresh_token
       end

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -19,7 +19,9 @@ module Doorkeeper
 
       attr_writer :use_refresh_token
 
-      if defined?(::ProtectedAttributes)
+      if defined?(ActiveModel::MassAssignmentSecurity) &&
+        included_modules.include?(ActiveModel::MassAssignmentSecurity)
+        
         attr_accessible :application_id, :resource_owner_id, :expires_in,
                         :scopes, :use_refresh_token
       end

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -16,7 +16,7 @@ module Doorkeeper
 
       before_validation :generate_uid, :generate_secret, on: :create
 
-      if respond_to?(:attr_accessible)
+      if defined?(::ProtectedAttributes)
         attr_accessible :name, :redirect_uri, :scopes
       end
     end

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -17,8 +17,8 @@ module Doorkeeper
       before_validation :generate_uid, :generate_secret, on: :create
 
       if defined?(ActiveModel::MassAssignmentSecurity) &&
-        included_modules.include?(ActiveModel::MassAssignmentSecurity)
-        
+         included_modules.include?(ActiveModel::MassAssignmentSecurity)
+
         attr_accessible :name, :redirect_uri, :scopes
       end
     end

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -16,7 +16,9 @@ module Doorkeeper
 
       before_validation :generate_uid, :generate_secret, on: :create
 
-      if defined?(::ProtectedAttributes)
+      if defined?(ActiveModel::MassAssignmentSecurity) &&
+        included_modules.include?(ActiveModel::MassAssignmentSecurity)
+        
         attr_accessible :name, :redirect_uri, :scopes
       end
     end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -77,6 +77,11 @@ Doorkeeper.configure do
   #
   # force_ssl_in_redirect_uri !Rails.env.development?
 
+  # Allows the usage of localhost (http://localhost:port/) in non-native redirect uris (enabled
+  # by default only in development environments).
+  #
+  # force_ssl_in_redirect_uri !Rails.env.development?
+
   # Specify what grant flows are enabled in array of Strings. The valid
   # strings and the flows they enable are:
   #

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -80,7 +80,7 @@ Doorkeeper.configure do
   # Allows the usage of localhost (http://localhost:port/) in non-native redirect uris (enabled
   # by default only in development environments).
   #
-  # force_ssl_in_redirect_uri !Rails.env.development?
+  # allow_localhost_in_redirect_uri Rails.env.development?
 
   # Specify what grant flows are enabled in array of Strings. The valid
   # strings and the flows they enable are:

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -77,8 +77,9 @@ Doorkeeper.configure do
   #
   # force_ssl_in_redirect_uri !Rails.env.development?
 
-  # Allows the usage of localhost (http://localhost:port/) in non-native redirect uris (enabled
-  # by default only in development environments).
+  # Allows the usage of localhost (http://localhost:port/)
+  # in non-native redirect uris (enabled by default only in
+  # development environments).
   #
   # allow_localhost_in_redirect_uri Rails.env.development?
 

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
-  if respond_to?(:attr_accessible)
+  if defined?(ActiveModel::MassAssignmentSecurity) &&
+     included_modules.include?(ActiveModel::MassAssignmentSecurity)
     attr_accessible :name, :password
   end
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -149,6 +149,20 @@ describe Doorkeeper, 'configuration' do
     end
   end
 
+  describe 'allow_localhost_in_redirect_uri' do
+    it 'is false by default in non-development environments' do
+      expect(subject.allow_localhost_in_redirect_uri).to be_falsey
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        allow_localhost_in_redirect_uri(true)
+      end
+      expect(subject.allow_localhost_in_redirect_uri).to be_truthy
+    end
+  end
+
   describe 'access_token_credentials' do
     it 'has defaults order' do
       expect(subject.access_token_methods).to eq([:from_bearer_authorization, :from_access_token_param, :from_bearer_param])

--- a/spec/validators/redirect_uri_validator_spec.rb
+++ b/spec/validators/redirect_uri_validator_spec.rb
@@ -75,4 +75,36 @@ describe RedirectUriValidator do
       expect(error).to eq('must be an HTTPS/SSL URI.')
     end
   end
+
+  context 'allow localhost' do
+    it 'accepts an valid uri' do
+      subject.redirect_uri = 'https://example.com/callback'
+      expect(subject).to be_valid
+    end
+
+    it 'accepts native redirect uri' do
+      subject.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
+      expect(subject).to be_valid
+    end
+
+    it 'accepts app redirect uri' do
+      subject.redirect_uri = 'some-awesome-app://oauth/callback'
+      expect(subject).to be_valid
+    end
+
+    it 'accepts a localhost uri when allowed' do
+      subject.redirect_uri = 'http://localhost:3000/callback'
+      allow(Doorkeeper.configuration).to receive(
+                                             :allow_localhost_in_redirect_uri
+                                         ).and_return(true)
+      expect(subject).to be_valid
+    end
+
+    it 'invalidates the localhost uri when the uri does not use a secure protocol and localhost is not allowed' do
+      subject.redirect_uri = 'http://localhost:3000/callback'
+      expect(subject).not_to be_valid
+      error = subject.errors[:redirect_uri].first
+      expect(error).to eq('must be an HTTPS/SSL URI.')
+    end
+  end
 end

--- a/spec/validators/redirect_uri_validator_spec.rb
+++ b/spec/validators/redirect_uri_validator_spec.rb
@@ -63,8 +63,8 @@ describe RedirectUriValidator do
     it 'accepts a non secured protocol when disabled' do
       subject.redirect_uri = 'http://example.com/callback'
       allow(Doorkeeper.configuration).to receive(
-                                             :force_ssl_in_redirect_uri
-                                         ).and_return(false)
+        :force_ssl_in_redirect_uri
+      ).and_return(false)
       expect(subject).to be_valid
     end
 
@@ -95,8 +95,8 @@ describe RedirectUriValidator do
     it 'accepts a localhost uri when allowed' do
       subject.redirect_uri = 'http://localhost:3000/callback'
       allow(Doorkeeper.configuration).to receive(
-                                             :allow_localhost_in_redirect_uri
-                                         ).and_return(true)
+        :allow_localhost_in_redirect_uri
+      ).and_return(true)
       expect(subject).to be_valid
     end
 


### PR DESCRIPTION
Hey,

This pull request covers 2 things:

- The main one is the addition of a `allow_localhost_in_redirect_uri` option which allows to specify a localhost (e.g. `http://localhost:3000/callback`) even when `force_ssl_in_redirect_uri` is true. This has been a use case in our situation where an internal OAuth provider could be used for local dev (just as you can use Google OAuth for local dev too)
- The second, minor one, was an issue when upgrading from Doorkeeper 2.2.0 to 2.2.2 where `attr_accessible` was added to model mixins. In the `included` block, it tests for `respond_to?(:attr_accessible)` before using it but Rails 4.0.x still provides the method and raises a deprecation error... I've changed the condition to fix that.

Let me know if there's any issue with my updates!

Thanks
Thomas 