### PR TITLE
Use application scopes as default if no global default scope

### DIFF
--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -29,7 +29,7 @@ module Doorkeeper
       end
 
       def scope
-        @scope.presence || server.default_scopes.to_s
+        @scope.presence || default_scope
       end
 
       def error_response
@@ -37,6 +37,14 @@ module Doorkeeper
       end
 
       private
+
+      def default_scope
+        if server.default_scopes.empty? && client.application.scopes.present?
+          client.application.scopes.to_s
+        else
+          server.default_scopes.to_s
+        end
+      end
 
       def validate_response_type
         server.authorization_response_types.include? response_type

--- a/spec/dummy/config/locales/doorkeeper.en.yml
+++ b/spec/dummy/config/locales/doorkeeper.en.yml
@@ -1,5 +1,6 @@
 en:
   doorkeeper:
     scopes:
-      public: "Access your public data"
-      write:  "Update your data"
+      public:  "Access your public data"
+      write:   "Update your data"
+      billing: "Update your billing information"

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -123,6 +123,13 @@ module Doorkeeper::OAuth
       expect(subject.scopes).to eq(Scopes.from_string('default'))
     end
 
+    it 'uses application scopes as default if no global default scope' do
+      allow(application).to receive(:scopes).and_return(Scopes.from_string('billing test'))
+      subject.scope = nil
+      expect(subject.scope).to eq('billing test')
+      expect(subject.scopes).to eq(Scopes.from_string('billing test'))
+    end
+
     it 'accepts test uri' do
       subject.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
       expect(subject).to be_authorizable


### PR DESCRIPTION
This allows scopes defined on applications that are available outside of
the globally defined default/optional scope list (as allowed from #678)
to still show up in the default scopes for resource owners going through an
authorization flow. The application scope list is chosen as the scope list if:

1. There is no scope defined in the request and a default must be determined
2. There is no global Doorkeeper.default_scope option configured
3. The application is configured with a list of scopes.

I think would be considered backwards incompatible, so I could see the case for adding a config option (or a special value that can be passed to the existing default_scopes config option) to enable this feature. I could add that if that's preferable. 

My particular use case for wanting this change is I have some applications relying on default scopes right now and have added new scopes I want to only give to a subset of those applications. I upgraded to the latest Doorkeeper to support application specific scopes, but now I'm stuck because I will not be able to access these scopes without going back to edit these clients and pass them in (unless this PR is merged). I feel like it's logical if you have application specific scopes to pick those as default when no scope is defined, but if not that's okay.