### PR TITLE
Add created_at to token generation options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ User-visible changes worth mentioning.
 
 - [#823] Make configuration and specs ORM independent
 - [#777] Add support for public client in password grant flow
+- [#745] Add created_at timestamp to token generation options
 
 ---
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -129,10 +129,16 @@ module Doorkeeper
     end
 
     def generate_token
+      self.created_at ||= Time.now.utc
+
       generator = Doorkeeper.configuration.access_token_generator.constantize
-      self.token = generator.generate(resource_owner_id: resource_owner_id,
-                                      scopes: scopes, application: application,
-                                      expires_in: expires_in)
+      self.token = generator.generate(
+        resource_owner_id: resource_owner_id,
+        scopes: scopes,
+        application: application,
+        expires_in: expires_in,
+        created_at: created_at
+      )
     rescue NoMethodError
       raise Errors::UnableToGenerateToken, "#{generator} does not respond to `.generate`."
     rescue NameError

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -106,6 +106,23 @@ module Doorkeeper
         expect(token.token).to eq 'custom_generator_token_7200'
       end
 
+      it 'allows the custom generator to access the created time' do
+        module CustomGeneratorArgs
+          def self.generate(opts = {})
+            "custom_generator_token_#{opts[:created_at].to_i}"
+          end
+        end
+
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          access_token_generator "Doorkeeper::CustomGeneratorArgs"
+        end
+
+        token = FactoryGirl.create :access_token
+        created_at = token.created_at
+        expect(token.token).to eq "custom_generator_token_#{created_at.to_i}"
+      end
+
       it 'raises an error if the custom object does not support generate' do
         module NoGenerate
         end


### PR DESCRIPTION
I'm using doorkeeper-jwt to add a JWT as my access token.  I'd like to support stateless auth but I need to be able to use the `iat` (issued at) and `exp` (expires at) claims and I need them to match doorkeeper's internal state.  This PR ensures the `created_at` and `updated_at` are set on the access token before generating the token string itself.

Example use:
```ruby
Doorkeeper::JWT.configure do
  token_payload do |opts|
    {
      iat: opts[:created_at].to_i,
      exp: opts[:created_at].to_i + opts[:expires_in],
      sub: opts[:resource_owner_id]
    }
  end
end
```