### PR TITLE
Specify default error translation key

### DIFF
--- a/lib/doorkeeper/oauth/error.rb
+++ b/lib/doorkeeper/oauth/error.rb
@@ -2,9 +2,11 @@ module Doorkeeper
   module OAuth
     class Error < Struct.new(:name, :state)
       def description
-        I18n.translate name,
+        I18n.translate(
+          name,
           scope: [:doorkeeper, :errors, :messages],
           default: :server_error
+        )
       end
     end
   end

--- a/lib/doorkeeper/oauth/error.rb
+++ b/lib/doorkeeper/oauth/error.rb
@@ -2,7 +2,9 @@ module Doorkeeper
   module OAuth
     class Error < Struct.new(:name, :state)
       def description
-        I18n.translate name, scope: [:doorkeeper, :errors, :messages]
+        I18n.translate name,
+          scope: [:doorkeeper, :errors, :messages],
+          default: :server_error
       end
     end
   end

--- a/spec/lib/oauth/error_spec.rb
+++ b/spec/lib/oauth/error_spec.rb
@@ -4,15 +4,19 @@ require 'doorkeeper/oauth/error'
 
 module Doorkeeper::OAuth
   describe Error do
-    subject { Error.new(:some_error, :some_state) }
+    subject(:error) { Error.new(:some_error, :some_state) }
 
     it { expect(subject).to respond_to(:name) }
     it { expect(subject).to respond_to(:state) }
 
     describe :description do
       it 'is translated from translation messages' do
-        expect(I18n).to receive(:translate).with(:some_error, scope: [:doorkeeper, :errors, :messages])
-        subject.description
+        expect(I18n).to receive(:translate).with(
+          :some_error,
+          scope: [:doorkeeper, :errors, :messages],
+          default: :server_error
+        )
+        error.description
       end
     end
   end


### PR DESCRIPTION
I ran into this while working on my custom token generation.

- I accidentally triggered a `NoMethodError` which was rescued and wrapped here: https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib/doorkeeper/models/access_token_mixin.rb#L137
- This was then fed into https://github.com/doorkeeper-gem/doorkeeper/blob/master/app/controllers/doorkeeper/tokens_controller.rb#L9 and I got an error message from I18n about a missing translation key.

This PR adds a default to prevent that from happening.