### PR TITLE
Allow user to raise authorization error with a custom message

### DIFF
--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -45,6 +45,8 @@ module Doorkeeper
                        :invalid_request
                      when Errors::InvalidGrantReuse
                        :invalid_grant
+                     when Errors::DoorkeeperError
+                       exception.message
                      end
 
         OAuth::ErrorResponse.new name: error_name, state: params[:state]


### PR DESCRIPTION
Adding the `otherwise` option on authorization error handler in order to allow users to add custom messages for custom authentication failures. The idea is that under `resource_owner_authenticator` block a user can `raise Doorkeeper::Errors::DoorkeeperError.new('custom_message')`.

This is related to: #746

Example:

`config/initializers/doorkeeper.rb`
```ruby
  resource_owner_from_credentials do |routes|
    # Some custom logic that needs to happen before raise the error
    raise Doorkeeper::Errors::DoorkeeperError.new('my_custom_message')
    # Some custom logic that should not be execute is the error happens
  end
```

`config/locales/doorkeeper.en.yml`
```yml
en.doorkeeper.errors.messages.my_custom_message: Dead customer some custom authentication logic failed.
```