### PR TITLE
upgrade rspec-rails

### DIFF
--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "railties", ">= 3.2"
 
-  s.add_development_dependency "rspec-rails", "~> 3.2.0"
+  s.add_development_dependency "rspec-rails", "~> 3.4.0"
   s.add_development_dependency "capybara", "~> 2.3.0"
   s.add_development_dependency "generator_spec", "~> 0.9.0"
   s.add_development_dependency "factory_girl", "~> 4.5.0"


### PR DESCRIPTION
that's will help to resolve warnings like `warning: Comparable#== will no more rescue exceptions of #<=> in the next release.`