### PR TITLE
Revoke Refresh Token on access token use

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,12 @@ User-visible changes worth mentioning.
 
 - Toughen parameters filter with exact match
 - Drop `attr_accessible` from models
+- [#769] Revoke refresh token on access token use. To make use of the new config
+  add `previous_refresh_token` column to `oauth_access_tokens`:
+
+  ```
+  rails generate doorkeeper:previous_refresh_token
+  ```
 
 ### Backward incompatible changes
 - Force all timezones to use UTC to prevent comparison issues.

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -236,6 +236,18 @@ doorkeeper.
       @token_grant_types ||= calculate_token_grant_types
     end
 
+    def refresh_token_revoked_on_use?
+      unless @refresh_token_revoked_on_use.nil?
+        return @refresh_token_revoked_on_use
+      end
+
+      @refresh_token_revoked_on_use =
+        ActiveRecord::Base.connection.column_exists?(
+          :oauth_access_tokens,
+          :previous_refresh_token
+        )
+    end
+
     private
 
     # Determines what values are acceptable for 'response_type' param in

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -8,6 +8,23 @@ module Doorkeeper
       def revoked?
         !!(revoked_at && revoked_at <= Time.now.utc)
       end
+
+      def revoke_previous_refresh_token!
+        return unless refresh_token_revoked_on_use?
+        old_refresh_token.revoke if old_refresh_token
+        update_attribute :previous_refresh_token, ""
+      end
+
+      private
+
+      def old_refresh_token
+        @old_refresh_token ||=
+          AccessToken.by_refresh_token(previous_refresh_token)
+      end
+
+      def refresh_token_revoked_on_use?
+        Doorkeeper.configuration.refresh_token_revoked_on_use?
+      end
     end
   end
 end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -36,9 +36,13 @@ module Doorkeeper
           refresh_token.lock!
           raise Errors::InvalidTokenReuse if refresh_token.revoked?
 
-          refresh_token.revoke
+          refresh_token.revoke unless refresh_token_revoked_on_use?
           create_access_token
         end
+      end
+
+      def refresh_token_revoked_on_use?
+        server.refresh_token_revoked_on_use?
       end
 
       def default_scopes
@@ -46,17 +50,25 @@ module Doorkeeper
       end
 
       def create_access_token
-        expires_in = Authorization::Token.access_token_expires_in(
-          server,
-          client
-        )
+        @access_token = AccessToken.create!(access_token_attributes)
+      end
 
-        @access_token = AccessToken.create!(
+      def access_token_attributes
+        {
           application_id: refresh_token.application_id,
           resource_owner_id: refresh_token.resource_owner_id,
           scopes: scopes.to_s,
-          expires_in: expires_in,
-          use_refresh_token: true)
+          expires_in: access_token_expires_in,
+          use_refresh_token: true
+        }.tap do |attributes|
+          if refresh_token_revoked_on_use?
+            attributes[:previous_refresh_token] = refresh_token.refresh_token
+          end
+        end
+      end
+
+      def access_token_expires_in
+        Authorization::Token.access_token_expires_in(server, client)
       end
 
       def validate_token_presence

--- a/lib/doorkeeper/oauth/token.rb
+++ b/lib/doorkeeper/oauth/token.rb
@@ -55,7 +55,9 @@ module Doorkeeper
 
       def self.authenticate(request, *methods)
         if token = from_request(request, *methods)
-          AccessToken.by_token(token)
+          access_token = AccessToken.by_token(token)
+          access_token.revoke_previous_refresh_token! if access_token
+          access_token
         end
       end
     end

--- a/lib/generators/doorkeeper/previous_refresh_token_generator.rb
+++ b/lib/generators/doorkeeper/previous_refresh_token_generator.rb
@@ -1,0 +1,29 @@
+require 'rails/generators/active_record'
+
+class Doorkeeper::PreviousRefreshTokenGenerator < Rails::Generators::Base
+  include Rails::Generators::Migration
+  source_root File.expand_path('../templates', __FILE__)
+  desc 'Support revoke refresh token on access token use'
+
+  def self.next_migration_number(path)
+    ActiveRecord::Generators::Base.next_migration_number(path)
+  end
+
+  def previous_refresh_token
+    if no_previous_refresh_token_column?
+      migration_template(
+        'add_previous_refresh_token_to_access_tokens.rb',
+        'db/migrate/add_previous_refresh_token_to_access_tokens.rb'
+      )
+    end
+  end
+
+  private
+
+  def no_previous_refresh_token_column?
+    !ActiveRecord::Base.connection.column_exists?(
+      :oauth_access_tokens,
+      :previous_refresh_token
+    )
+  end
+end

--- a/lib/generators/doorkeeper/templates/add_previous_refresh_token_to_access_tokens.rb
+++ b/lib/generators/doorkeeper/templates/add_previous_refresh_token_to_access_tokens.rb
@@ -1,0 +1,11 @@
+class AddPreviousRefreshTokenToAccessTokens < ActiveRecord::Migration
+  def change
+    add_column(
+      :oauth_access_tokens,
+      :previous_refresh_token,
+      :string,
+      default: "",
+      null: false
+    )
+  end
+end

--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -39,13 +39,21 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
       #
       # t.text     :token,             null: false
-      t.string   :token,             null: false
+      t.string   :token,                  null: false
 
       t.string   :refresh_token
       t.integer  :expires_in
       t.datetime :revoked_at
-      t.datetime :created_at,        null: false
+      t.datetime :created_at,             null: false
       t.string   :scopes
+
+      # If there is a previous_refresh_token column,
+      # refresh tokens will be revoked after a related access token is used.
+      # If there is no previous_refresh_token column,
+      # previous tokens are revoked as soon as a new access token is created.
+      # Comment out this line if you'd rather have refresh tokens
+      # instantly revoked.
+      t.string   :previous_refresh_token, null: false, default: ""
     end
 
     add_index :oauth_access_tokens, :token, unique: true

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -28,7 +28,9 @@ describe 'doorkeeper authorize filter' do
 
     let(:token_string) { '1A2BC3' }
     let(:token) do
-      double(Doorkeeper::AccessToken, acceptable?: true)
+      double(Doorkeeper::AccessToken,
+             acceptable?: true, previous_refresh_token: "",
+             revoke_previous_refresh_token!: true)
     end
 
     it 'access_token param' do
@@ -106,16 +108,26 @@ describe 'doorkeeper authorize filter' do
     let(:token_string) { '1A2DUWE' }
 
     it 'allows if the token has particular scopes' do
-      token = double(Doorkeeper::AccessToken, accessible?: true, scopes: %w(write public))
+      token = double(Doorkeeper::AccessToken,
+                     accessible?: true, scopes: %w(write public),
+                     previous_refresh_token: "",
+                     revoke_previous_refresh_token!: true)
       expect(token).to receive(:acceptable?).with([:write]).and_return(true)
-      expect(Doorkeeper::AccessToken).to receive(:by_token).with(token_string).and_return(token)
+      expect(
+        Doorkeeper::AccessToken
+      ).to receive(:by_token).with(token_string).and_return(token)
       get :index, access_token: token_string
       expect(response).to be_success
     end
 
     it 'does not allow if the token does not include given scope' do
-      token = double(Doorkeeper::AccessToken, accessible?: true, scopes: ['public'], revoked?: false, expired?: false)
-      expect(Doorkeeper::AccessToken).to receive(:by_token).with(token_string).and_return(token)
+      token = double(Doorkeeper::AccessToken,
+                     accessible?: true, scopes: ['public'], revoked?: false,
+                     expired?: false, previous_refresh_token: "",
+                     revoke_previous_refresh_token!: true)
+      expect(
+        Doorkeeper::AccessToken
+      ).to receive(:by_token).with(token_string).and_return(token)
       expect(token).to receive(:acceptable?).with([:write]).and_return(false)
       get :index, access_token: token_string
       expect(response.status).to eq 403
@@ -207,7 +219,9 @@ describe 'doorkeeper authorize filter' do
 
     let(:token) do
       double(Doorkeeper::AccessToken,
-             accessible?: true, scopes: ['public'], revoked?: false, expired?: false)
+             accessible?: true, scopes: ['public'], revoked?: false,
+             expired?: false, previous_refresh_token: "",
+             revoke_previous_refresh_token!: true)
     end
     let(:token_string) { '1A2DUWE' }
 

--- a/spec/dummy/db/migrate/20160320211015_add_previous_refresh_token_to_access_tokens.rb
+++ b/spec/dummy/db/migrate/20160320211015_add_previous_refresh_token_to_access_tokens.rb
@@ -1,0 +1,11 @@
+class AddPreviousRefreshTokenToAccessTokens < ActiveRecord::Migration
+  def change
+    add_column(
+      :oauth_access_tokens,
+      :previous_refresh_token,
+      :string,
+      default: "",
+      null: false
+    )
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151223200000) do
+ActiveRecord::Schema.define(version: 20160320211015) do
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", null: false
@@ -29,12 +29,13 @@ ActiveRecord::Schema.define(version: 20151223200000) do
   create_table "oauth_access_tokens", force: :cascade do |t|
     t.integer  "resource_owner_id"
     t.integer  "application_id"
-    t.string   "token",             null: false
+    t.string   "token",                               null: false
     t.string   "refresh_token"
     t.integer  "expires_in"
     t.datetime "revoked_at"
-    t.datetime "created_at",        null: false
+    t.datetime "created_at",                          null: false
     t.string   "scopes"
+    t.string   "previous_refresh_token", default: "", null: false
   end
 
   add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true

--- a/spec/lib/models/revocable_spec.rb
+++ b/spec/lib/models/revocable_spec.rb
@@ -34,4 +34,26 @@ describe 'Revocable' do
       expect(subject).not_to be_revoked
     end
   end
+
+  describe :revoke_previous_refresh_token! do
+    it "revokes the previous token if existing, and resets the
+      `previous_refresh_token` attribute" do
+      previous_token = FactoryGirl.create(
+        :access_token,
+        refresh_token: "refresh_token"
+      )
+      current_token = FactoryGirl.create(
+        :access_token,
+        previous_refresh_token: previous_token.refresh_token
+      )
+
+      expect_any_instance_of(
+        Doorkeeper::AccessToken
+      ).to receive(:revoke).and_call_original
+      current_token.revoke_previous_refresh_token!
+
+      expect(current_token.previous_refresh_token).to be_empty
+      expect(previous_token.reload).to be_revoked
+    end
+  end
 end

--- a/spec/lib/oauth/token_spec.rb
+++ b/spec/lib/oauth/token_spec.rb
@@ -30,7 +30,7 @@ module Doorkeeper
         it 'stops at the first credentials found' do
           not_called_method = double
           expect(not_called_method).not_to receive(:call)
-          Token.from_request request, ->(r) {}, method, not_called_method
+          Token.from_request request, ->(_r) {}, method, not_called_method
         end
 
         it 'returns the credential from extractor method' do
@@ -96,11 +96,18 @@ module Doorkeeper
       end
 
       describe :authenticate do
-        let(:finder) { double :finder }
-
-        it 'calls the finder if token was found' do
-          token = ->(r) { 'token' }
+        it 'calls the finder if token was returned' do
+          token = ->(_r) { 'token' }
           expect(AccessToken).to receive(:by_token).with('token')
+          Token.authenticate double, token
+        end
+
+        it 'revokes previous refresh_token if token was found' do
+          token = ->(_r) { 'token' }
+          expect(
+            AccessToken
+          ).to receive(:by_token).with('token').and_return(token)
+          expect(token).to receive(:revoke_previous_refresh_token!)
           Token.authenticate double, token
         end
       end

--- a/spec/support/shared/controllers_shared_context.rb
+++ b/spec/support/shared/controllers_shared_context.rb
@@ -4,11 +4,15 @@ shared_context 'valid token', token: :valid do
   end
 
   let :token do
-    double(Doorkeeper::AccessToken, accessible?: true, includes_scope?: true, acceptable?: true)
+    double(Doorkeeper::AccessToken,
+           accessible?: true, includes_scope?: true, acceptable?: true,
+           previous_refresh_token: "", revoke_previous_refresh_token!: true)
   end
 
   before :each do
-    allow(Doorkeeper::AccessToken).to receive(:by_token).with(token_string).and_return(token)
+    allow(
+      Doorkeeper::AccessToken
+    ).to receive(:by_token).with(token_string).and_return(token)
   end
 end
 
@@ -18,11 +22,16 @@ shared_context 'invalid token', token: :invalid do
   end
 
   let :token do
-    double(Doorkeeper::AccessToken, accessible?: false, revoked?: false, expired?: false, includes_scope?: false, acceptable?: false)
+    double(Doorkeeper::AccessToken,
+           accessible?: false, revoked?: false, expired?: false,
+           includes_scope?: false, acceptable?: false,
+           previous_refresh_token: "", revoke_previous_refresh_token!: true)
   end
 
   before :each do
-    allow(Doorkeeper::AccessToken).to receive(:by_token).with(token_string).and_return(token)
+    allow(
+      Doorkeeper::AccessToken
+    ).to receive(:by_token).with(token_string).and_return(token)
   end
 end
 


### PR DESCRIPTION
Creating another PR based on https://github.com/doorkeeper-gem/doorkeeper/pull/691. Copying description:

>This PR allows refresh tokens to not either revoke at some point in the future (if you want to allow some wiggle room for network failures, etc) set refresh_token_revoked_in to some number of seconds in the future.

>Also allows for refresh tokens to not be revoked until an access token created with that refresh token is successfully used once. Set refresh_token_revoked_on_use to true.

>Both are off by default.