### PR TITLE
Update applications_controller.rb

### DIFF
--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -2,8 +2,8 @@ module Doorkeeper
   class ApplicationsController < Doorkeeper::ApplicationController
     layout 'doorkeeper/admin'
 
-    before_filter :authenticate_admin!
-    before_filter :set_application, only: [:show, :edit, :update, :destroy]
+    before_action :authenticate_admin!
+    before_action :set_application, only: [:show, :edit, :update, :destroy]
 
     def index
       @applications = Application.all


### PR DESCRIPTION
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead.