### PR TITLE
Add support for public client in password grant flow

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 User-visible changes worth mentioning.
 
+- [#777] Add support for public client in password grant flow
+
 ---
 
 ## 4.0.0.rc3

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -9,19 +9,14 @@ module Doorkeeper
       validate :resource_owner, error: :invalid_resource_owner
       validate :scopes,         error: :invalid_scope
 
-      attr_accessor :server, :resource_owner, :credentials, :access_token
-      attr_accessor :client
+      attr_accessor :server, :client, :resource_owner, :parameters, :access_token
 
-      def initialize(server, credentials, resource_owner, parameters = {})
+      def initialize(server, client, resource_owner, parameters = {})
         @server          = server
         @resource_owner  = resource_owner
-        @credentials     = credentials
+        @client          = client
+        @parameters      = parameters
         @original_scopes = parameters[:scope]
-
-        if credentials
-          @client = Application.by_uid_and_secret credentials.uid,
-                                                  credentials.secret
-        end
       end
 
       private
@@ -40,7 +35,7 @@ module Doorkeeper
       end
 
       def validate_client
-        !credentials || !!client
+        !parameters[:client_id] || !!client
       end
     end
   end

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -9,7 +9,8 @@ module Doorkeeper
       validate :resource_owner, error: :invalid_resource_owner
       validate :scopes,         error: :invalid_scope
 
-      attr_accessor :server, :client, :resource_owner, :parameters, :access_token
+      attr_accessor :server, :client, :resource_owner, :parameters,
+                    :access_token
 
       def initialize(server, client, resource_owner, parameters = {})
         @server          = server

--- a/lib/doorkeeper/request/password.rb
+++ b/lib/doorkeeper/request/password.rb
@@ -8,10 +8,20 @@ module Doorkeeper
       def request
         @request ||= OAuth::PasswordAccessTokenRequest.new(
           Doorkeeper.configuration,
-          credentials,
+          client,
           resource_owner,
           parameters
         )
+      end
+
+      private
+
+      def client
+        if credentials
+          server.client
+        elsif parameters[:client_id]
+          server.client_via_uid
+        end
       end
     end
   end

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -11,12 +11,11 @@ module Doorkeeper::OAuth
         custom_access_token_expires_in: ->(_app) { nil }
       )
     end
-    let(:credentials) { Client::Credentials.new(client.uid, client.secret) }
     let(:client) { FactoryGirl.create(:application) }
     let(:owner)  { double :owner, id: 99 }
 
     subject do
-      PasswordAccessTokenRequest.new(server, credentials, owner)
+      PasswordAccessTokenRequest.new(server, client, owner)
     end
 
     it 'issues a new token for the client' do
@@ -27,7 +26,7 @@ module Doorkeeper::OAuth
 
     it 'issues a new token without a client' do
       expect do
-        subject.credentials = nil
+        subject.client = nil
         subject.authorize
       end.to change { Doorkeeper::AccessToken.count }.by(1)
     end
@@ -35,6 +34,7 @@ module Doorkeeper::OAuth
     it 'does not issue a new token with an invalid client' do
       expect do
         subject.client = nil
+        subject.parameters = { client_id: 'bad_id' }
         subject.authorize
       end.to_not change { Doorkeeper::AccessToken.count }
 
@@ -48,7 +48,7 @@ module Doorkeeper::OAuth
     end
 
     it 'optionally accepts the client' do
-      subject.credentials = nil
+      subject.client = nil
       expect(subject).to be_valid
     end
 

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -24,13 +24,25 @@ describe 'Resource Owner Password Credentials Flow' do
   end
 
   context 'with valid user credentials' do
-    it 'should issue new token' do
+    it 'should issue new token with confidential client' do
       expect do
         post password_token_endpoint_url(client: @client, resource_owner: @resource_owner)
       end.to change { Doorkeeper::AccessToken.count }.by(1)
 
       token = Doorkeeper::AccessToken.first
 
+      expect(token.application_id).to eq @client.id
+      should_have_json 'access_token',  token.token
+    end
+
+    it 'should issue new token with public client (only client_id present)' do
+      expect do
+        post password_token_endpoint_url(client_id: @client.uid, resource_owner: @resource_owner)
+      end.to change { Doorkeeper::AccessToken.count }.by(1)
+
+      token = Doorkeeper::AccessToken.first
+
+      expect(token.application_id).to eq @client.id
       should_have_json 'access_token',  token.token
     end
 
@@ -41,6 +53,7 @@ describe 'Resource Owner Password Credentials Flow' do
 
       token = Doorkeeper::AccessToken.first
 
+      expect(token.application_id).to be_nil
       should_have_json 'access_token',  token.token
     end
 
@@ -82,12 +95,20 @@ describe 'Resource Owner Password Credentials Flow' do
     end
   end
 
-  context 'with invalid client credentials' do
+  context 'with invalid confidential client credentials' do
     it 'should not issue new token with bad client credentials' do
       expect do
         post password_token_endpoint_url(client_id: @client.uid,
                                          client_secret: 'bad_secret',
                                          resource_owner: @resource_owner)
+      end.to_not change { Doorkeeper::AccessToken.count }
+    end
+  end
+
+  context 'with invalid public client id' do
+    it 'should not issue new token with bad client id' do
+      expect do
+        post password_token_endpoint_url(client_id: 'bad_id', resource_owner: @resource_owner)
       end.to_not change { Doorkeeper::AccessToken.count }
     end
   end

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -32,7 +32,7 @@ describe 'Resource Owner Password Credentials Flow' do
       token = Doorkeeper::AccessToken.first
 
       expect(token.application_id).to eq @client.id
-      should_have_json 'access_token',  token.token
+      should_have_json 'access_token', token.token
     end
 
     it 'should issue new token with public client (only client_id present)' do
@@ -43,7 +43,7 @@ describe 'Resource Owner Password Credentials Flow' do
       token = Doorkeeper::AccessToken.first
 
       expect(token.application_id).to eq @client.id
-      should_have_json 'access_token',  token.token
+      should_have_json 'access_token', token.token
     end
 
     it 'should issue new token without client credentials' do
@@ -54,7 +54,7 @@ describe 'Resource Owner Password Credentials Flow' do
       token = Doorkeeper::AccessToken.first
 
       expect(token.application_id).to be_nil
-      should_have_json 'access_token',  token.token
+      should_have_json 'access_token', token.token
     end
 
     it 'should issue a refresh token if enabled' do
@@ -64,7 +64,7 @@ describe 'Resource Owner Password Credentials Flow' do
 
       token = Doorkeeper::AccessToken.first
 
-      should_have_json 'refresh_token',  token.refresh_token
+      should_have_json 'refresh_token', token.refresh_token
     end
 
     it 'should return the same token if it is still accessible' do


### PR DESCRIPTION
As discussed in https://github.com/doorkeeper-gem/doorkeeper/issues/669 a public client (without `client_secret`) should be allowed in the _password_ grand flow and then set the `AccessToken#application_id` properly.

Close #669