### PR TITLE
Made code responses return the actual time that a token is still valid

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ User-visible changes worth mentioning.
 
 ---
 
+- [#778] Use the remaining time that a token is still valid when building the
+  redirect URI for the implicit grant flow
+
 ## 3.1.0
 
 - [#736] Existing valid tokens are now reused in client_credentials flow

--- a/lib/doorkeeper/oauth/code_response.rb
+++ b/lib/doorkeeper/oauth/code_response.rb
@@ -24,7 +24,7 @@ module Doorkeeper
               pre_auth.redirect_uri,
               access_token: auth.token.token,
               token_type: auth.token.token_type,
-              expires_in: auth.token.expires_in,
+              expires_in: auth.token.expires_in_seconds,
               state: pre_auth.state
             )
           else

--- a/spec/lib/oauth/code_response_spec.rb
+++ b/spec/lib/oauth/code_response_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+module Doorkeeper::OAuth
+  describe CodeResponse do
+    describe '.redirect_uri' do
+      context 'when generating the redirect URI for an implicit grant' do
+        let :pre_auth do
+          double(
+            :pre_auth,
+            client: double(:application, id: 1),
+            redirect_uri: 'http://tst.com/cb',
+            state: nil,
+            scopes: Scopes.from_string('public'),
+          )
+        end
+
+        let :auth do
+          Authorization::Token.new(pre_auth, double(id: 1)).tap do |c|
+            c.issue_token
+            allow(c.token).to receive(:expires_in_seconds).and_return(3600)
+          end
+        end
+
+        subject { CodeResponse.new(pre_auth, auth, response_on_fragment: true).redirect_uri }
+
+        it 'includes the remaining TTL of the token relative to the time the token was generated' do
+          expect(subject).to include('expires_in=3600')
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/oauth/code_response_spec.rb
+++ b/spec/lib/oauth/code_response_spec.rb
@@ -1,30 +1,32 @@
 require 'spec_helper'
 
-module Doorkeeper::OAuth
-  describe CodeResponse do
-    describe '.redirect_uri' do
-      context 'when generating the redirect URI for an implicit grant' do
-        let :pre_auth do
-          double(
-            :pre_auth,
-            client: double(:application, id: 1),
-            redirect_uri: 'http://tst.com/cb',
-            state: nil,
-            scopes: Scopes.from_string('public'),
-          )
-        end
-
-        let :auth do
-          Authorization::Token.new(pre_auth, double(id: 1)).tap do |c|
-            c.issue_token
-            allow(c.token).to receive(:expires_in_seconds).and_return(3600)
+module Doorkeeper
+  module OAuth
+    describe CodeResponse do
+      describe '.redirect_uri' do
+        context 'when generating the redirect URI for an implicit grant' do
+          let :pre_auth do
+            double(
+              :pre_auth,
+              client: double(:application, id: 1),
+              redirect_uri: 'http://tst.com/cb',
+              state: nil,
+              scopes: Scopes.from_string('public'),
+            )
           end
-        end
 
-        subject { CodeResponse.new(pre_auth, auth, response_on_fragment: true).redirect_uri }
+          let :auth do
+            Authorization::Token.new(pre_auth, double(id: 1)).tap do |c|
+              c.issue_token
+              allow(c.token).to receive(:expires_in_seconds).and_return(3600)
+            end
+          end
 
-        it 'includes the remaining TTL of the token relative to the time the token was generated' do
-          expect(subject).to include('expires_in=3600')
+          subject { CodeResponse.new(pre_auth, auth, response_on_fragment: true).redirect_uri }
+
+          it 'includes the remaining TTL of the token relative to the time the token was generated' do
+            expect(subject).to include('expires_in=3600')
+          end
         end
       end
     end


### PR DESCRIPTION
I've spent the last hour debugging what turned out to be a problem with Doorkeeper.

If the `reuse_access_token` option is configured, then code responses will always return the token's initial `expires_in` value instead of the remaining time the token is still valid. This PR fixes that ;)