### PR TITLE
Make application relationship optional in access token model

### DIFF
--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -12,7 +12,8 @@ module Doorkeeper
     included do
       belongs_to :application,
                  class_name: 'Doorkeeper::Application',
-                 inverse_of: :access_tokens
+                 inverse_of: :access_tokens,
+                 optional: true
 
       validates :token, presence: true, uniqueness: true
       validates :refresh_token, uniqueness: true, if: :use_refresh_token?


### PR DESCRIPTION
This PR (https://github.com/rails/rails/pull/18937) makes all `belongs_to` relations in rails 5 as `required` by default. But application object need not be present for access token creation in Resource Owner Password Credentials grant flow. So this makes application relationship in access token model as optional.

This fixes #774 