### PR TITLE
compat with rails 5's default belongs_to presence validation

### DIFF
--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -10,16 +10,17 @@ module Doorkeeper
     include ActiveModel::MassAssignmentSecurity if defined?(::ProtectedAttributes)
 
     included do
-      belongs_to_options = {
+      belongs_to_opts = {
         class_name: 'Doorkeeper::Application',
         inverse_of: :access_tokens
       }
 
-      if defined?(ActiveRecord) && defined?(ActiveRecord::Base) && self < ActiveRecord::Base
-        belongs_to_options.merge! :optional => true if ActiveRecord::VERSION::MAJOR >= 5
+      if defined?(ActiveRecord) && defined?(ActiveRecord::Base) &&
+         self < ActiveRecord::Base
+        belongs_to_opts[:optional] = true if ActiveRecord::VERSION::MAJOR >= 5
       end
 
-      belongs_to :application, belongs_to_options
+      belongs_to :application, belongs_to_opts
 
       validates :token, presence: true, uniqueness: true
       validates :refresh_token, uniqueness: true, if: :use_refresh_token?

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -10,9 +10,16 @@ module Doorkeeper
     include ActiveModel::MassAssignmentSecurity if defined?(::ProtectedAttributes)
 
     included do
-      belongs_to :application,
-                 class_name: 'Doorkeeper::Application',
-                 inverse_of: :access_tokens
+      belongs_to_options = {
+        class_name: 'Doorkeeper::Application',
+        inverse_of: :access_tokens
+      }
+
+      if defined?(ActiveRecord) && defined?(ActiveRecord::Base) && self < ActiveRecord::Base
+        belongs_to_options.merge! :optional => true if ActiveRecord::VERSION::MAJOR >= 5
+      end
+
+      belongs_to :application, belongs_to_options
 
       validates :token, presence: true, uniqueness: true
       validates :refresh_token, uniqueness: true, if: :use_refresh_token?

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -143,6 +143,12 @@ module Doorkeeper
         subject.resource_owner_id = nil
         expect(subject).to be_valid
       end
+
+      it 'is valid without application_id' do
+        # For resource owner credentials flow
+        subject.application_id = nil
+        expect(subject).to be_valid
+      end
     end
 
     describe '#same_credential?' do


### PR DESCRIPTION
Rails 5 adds default presence validation on belongs_to associations:
rails/rails#18233

Application object need not be present for access token creation in Resource
Owner Password Credentials grant flow.

This is an alternative to #780 for backwards compatibility with rails 4