### PR TITLE
Allow Doorkeeper::Models::Scopes#scopes to accept an array

### DIFF
--- a/lib/doorkeeper/models/concerns/scopes.rb
+++ b/lib/doorkeeper/models/concerns/scopes.rb
@@ -4,7 +4,17 @@ module Doorkeeper
       def scopes
         OAuth::Scopes.from_string(self[:scopes])
       end
-
+      
+      # Accept a string or an array of scopes
+      def scopes=(*values)
+        value = if values.is_a?(Array)
+          values.join(' ')
+        else
+          values
+        end
+        self[:scopes] = value
+      end
+      
       def scopes_string
         self[:scopes]
       end

--- a/lib/doorkeeper/models/concerns/scopes.rb
+++ b/lib/doorkeeper/models/concerns/scopes.rb
@@ -4,17 +4,17 @@ module Doorkeeper
       def scopes
         OAuth::Scopes.from_string(self[:scopes])
       end
-      
+
       # Accept a string or an array of scopes
       def scopes=(*values)
         value = if values.is_a?(Array)
-          values.join(' ')
-        else
-          values
-        end
+                  values.join(' ')
+                else
+                  values
+                end
         self[:scopes] = value
       end
-      
+
       def scopes_string
         self[:scopes]
       end

--- a/spec/lib/models/scopes_spec.rb
+++ b/spec/lib/models/scopes_spec.rb
@@ -23,6 +23,20 @@ describe 'Doorkeeper::Models::Scopes' do
     it 'includes scopes' do
       expect(subject.scopes).to include('public')
     end
+
+    it 'writes scopes as string' do
+      subject.scopes = 'read write'
+      expect(subject.scopes).to include('read')
+    end
+
+    it 'writes scopes as array' do
+      subject.scopes = %w(read write)
+      expect(subject.scopes).to include('read')
+
+      subject.scopes = [:foo, :bar]
+      expect(subject.scopes).to include('foo')
+    end
+
   end
 
   describe :scopes_string do

--- a/spec/lib/models/scopes_spec.rb
+++ b/spec/lib/models/scopes_spec.rb
@@ -36,7 +36,6 @@ describe 'Doorkeeper::Models::Scopes' do
       subject.scopes = [:foo, :bar]
       expect(subject.scopes).to include('foo')
     end
-
   end
 
   describe :scopes_string do


### PR DESCRIPTION
Given that OAuth scopes can be many, it seems more intuitive to accept an array in addition to the current string with spaces.

Specs accompany the PR.