### PR TITLE
Fix optional belongs_to for Rails 5

### DIFF
--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -10,7 +10,15 @@ module Doorkeeper
     include ActiveModel::MassAssignmentSecurity if defined?(::ProtectedAttributes)
 
     included do
-      belongs_to :application, class_name: 'Doorkeeper::Application', inverse_of: :access_grants
+      belongs_to_options = {
+        class_name: 'Doorkeeper::Application',
+        inverse_of: :access_grants
+      }
+      if defined?(ActiveRecord::Base) && ActiveRecord::VERSION::MAJOR >= 5
+        belongs_to_options.merge!(optional: true)
+      end
+
+      belongs_to :application, belongs_to_options
 
       if respond_to?(:attr_accessible)
         attr_accessible :resource_owner_id, :application_id, :expires_in, :redirect_uri, :scopes

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -15,7 +15,7 @@ module Doorkeeper
         inverse_of: :access_tokens
       }
       if defined?(ActiveRecord::Base) && ActiveRecord::VERSION::MAJOR >= 5
-        belongs_to_options.merge(optional: true)
+        belongs_to_options.merge!(optional: true)
       end
 
       belongs_to :application, belongs_to_options

--- a/lib/doorkeeper/models/concerns/ownership.rb
+++ b/lib/doorkeeper/models/concerns/ownership.rb
@@ -4,7 +4,12 @@ module Doorkeeper
       extend ActiveSupport::Concern
 
       included do
-        belongs_to :owner, polymorphic: true
+        belongs_to_options = { polymorphic: true }
+        if defined?(ActiveRecord::Base) && ActiveRecord::VERSION::MAJOR >= 5
+          belongs_to_options.merge!(optional: true)
+        end
+
+        belongs_to :owner, belongs_to_options
         validates :owner, presence: true, if: :validate_owner?
       end
 

--- a/spec/dummy/config/initializers/active_record_belongs_to_required_by_default.rb
+++ b/spec/dummy/config/initializers/active_record_belongs_to_required_by_default.rb
@@ -1,0 +1,6 @@
+# Require `belongs_to` associations by default. This is a new Rails 5.0
+# default, so it is introduced as a configuration option to ensure that apps
+# made on earlier versions of Rails are not affected when upgrading.
+if Rails.version.to_i >= 5
+  Rails.application.config.active_record.belongs_to_required_by_default = true
+end

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -143,6 +143,12 @@ module Doorkeeper
         subject.resource_owner_id = nil
         expect(subject).to be_valid
       end
+
+      it 'is valid without resource_owner_id' do
+        # For resource owner credentials flow
+        subject.application_id = nil
+        expect(subject).to be_valid
+      end
     end
 
     describe '#same_credential?' do


### PR DESCRIPTION
* Add spec for access token application relation
* Add default active_record_belongs_to_required_by_default initializer
  generated by rails
* Adjust `belongs_to` relations
* Remove access_token_mixin application_id validation

[closes #794]