### PR TITLE
Delete I18n logic from engine

### DIFF
--- a/lib/doorkeeper/engine.rb
+++ b/lib/doorkeeper/engine.rb
@@ -4,12 +4,6 @@ module Doorkeeper
       app.config.filter_parameters += [:client_secret, :code, :token]
     end
 
-    initializer "doorkeeper.locales" do |app|
-      if app.config.i18n.fallbacks.blank?
-        app.config.i18n.fallbacks = [:en]
-      end
-    end
-
     initializer "doorkeeper.routes" do
       Doorkeeper::Rails::Routes.install!
     end


### PR DESCRIPTION
The lines deleted in the PR are unnecessary, and they inadvertently change the I18n behavior of your entire app.

(In my case, it breaks the i18n-js gem's export, but others may be affected.)

It looks like this was added by @jasl here: https://github.com/doorkeeper-gem/doorkeeper/commit/78fa331710476532349b879fce0ccba536622952

My guess was he wanted the English error messages for Doorkeeper to appear even when using a different default locale. But the Doorkeeper gem should **NOT** reconfigure your Rails app globally in order to achieve this goal!