### PR TITLE
Require rake >10.5 when running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ rvm:
   - 2.3.0
   - jruby-head
 
+before_install:
+  - gem install bundler -v '~> 1.10'
+
 env:
   - rails=4.2.0
   - rails=5.0.0.beta3

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "database_cleaner", "~> 1.3.0"
   s.add_development_dependency "factory_girl", "~> 4.5.0"
   s.add_development_dependency "generator_spec", "~> 0.9.0"
-  s.add_development_dependency "rake", "~> 10.5.0"
+  s.add_development_dependency "rake", "> 10.5.0"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "timecop", "~> 0.7.0"
 end


### PR DESCRIPTION
`rake` is already at version 11. This is a follow up to commit
f9772bd985a86eddea2c5624240ce6e78ef59288.