### PR TITLE
Use Ruby 1.9 hash syntax in initializer configuration file.

### DIFF
--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -41,10 +41,10 @@ Doorkeeper.configure do
   # use_refresh_token
 
   # Provide support for an owner to be assigned to each registered application (disabled by default)
-  # Optional parameter :confirmation => true (default false) if you want to enforce ownership of
+  # Optional parameter confirmation: true (default false) if you want to enforce ownership of
   # a registered application
   # Note: you must also run the rails g doorkeeper:application_owner generator to provide the necessary support
-  # enable_application_owner :confirmation => false
+  # enable_application_owner confirmation: false
 
   # Define access token scopes for your provider
   # For more information go to

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -30,10 +30,10 @@ Doorkeeper.configure do
   use_refresh_token
 
   # Provide support for an owner to be assigned to each registered application (disabled by default)
-  # Optional parameter :confirmation => true (default false) if you want to enforce ownership of
+  # Optional parameter confirmation: true (default false) if you want to enforce ownership of
   # a registered application
   # Note: you must also run the rails g doorkeeper:application_owner generator to provide the necessary support
-  # enable_application_owner :confirmation => false
+  # enable_application_owner :confirmation: false
 
   # Define access token scopes for your provider
   # For more information go to


### PR DESCRIPTION
I change this line manually every time when install Doorkeeper on new
project.

Particularly relevant to recent drop of Ruby 2.0 support in v4.0.0.rc1