### PR TITLE
Remove Ruby Warnings

### DIFF
--- a/lib/doorkeeper/oauth/client_credentials_request.rb
+++ b/lib/doorkeeper/oauth/client_credentials_request.rb
@@ -8,7 +8,8 @@ module Doorkeeper
       include Validations
       include OAuth::RequestConcern
 
-      attr_accessor :issuer, :server, :client, :original_scopes
+      attr_writer :issuer
+      attr_accessor :server, :client, :original_scopes
       attr_reader :response
       alias :error_response :response
 

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -13,7 +13,7 @@ module Doorkeeper
 
           def valid?
             scope_str.present? &&
-              scope_str !~ /[\n|\r|\t]/ &&
+              scope_str !~ /[\n\r\t]/ &&
               @valid_scopes.has_scopes?(parsed_scopes)
           end
 

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -12,7 +12,9 @@ module Doorkeeper
       validate :scope,        error: :invalid_scope
 
       attr_accessor :access_token, :client, :credentials, :refresh_token,
-                    :server
+                    :server, :refresh_token_parameter
+
+      private :refresh_token_parameter, :refresh_token_parameter=
 
       def initialize(server, refresh_token, credentials, parameters = {})
         @server          = server
@@ -28,8 +30,6 @@ module Doorkeeper
       end
 
       private
-
-      attr_reader :refresh_token_parameter
 
       def before_successful_response
         refresh_token.transaction do

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -8,6 +8,12 @@ module ControllerActions
   def show
     render text: 'show'
   end
+
+  def doorkeeper_unauthorized_render_options(*)
+  end
+
+  def doorkeeper_forbidden_render_options(*)
+  end
 end
 
 describe 'doorkeeper authorize filter' do
@@ -127,6 +133,7 @@ describe 'doorkeeper authorize filter' do
     context 'with a JSON custom render', token: :invalid do
       before do
         module ControllerActions
+          remove_method :doorkeeper_unauthorized_render_options
           def doorkeeper_unauthorized_render_options(error: nil)
             { json: ActiveSupport::JSON.encode(error_message: error.description) }
           end
@@ -134,6 +141,7 @@ describe 'doorkeeper authorize filter' do
       end
       after do
         module ControllerActions
+          remove_method :doorkeeper_unauthorized_render_options
           def doorkeeper_unauthorized_render_options(error: nil)
           end
         end
@@ -153,6 +161,7 @@ describe 'doorkeeper authorize filter' do
     context 'with a text custom render', token: :invalid do
       before do
         module ControllerActions
+          remove_method :doorkeeper_unauthorized_render_options
           def doorkeeper_unauthorized_render_options(error: nil)
             { text: 'Unauthorized' }
           end
@@ -160,6 +169,7 @@ describe 'doorkeeper authorize filter' do
       end
       after do
         module ControllerActions
+          remove_method :doorkeeper_unauthorized_render_options
           def doorkeeper_unauthorized_render_options(error: nil)
           end
         end
@@ -183,6 +193,7 @@ describe 'doorkeeper authorize filter' do
 
     after do
       module ControllerActions
+        remove_method :doorkeeper_forbidden_render_options
         def doorkeeper_forbidden_render_options(*)
         end
       end
@@ -203,6 +214,7 @@ describe 'doorkeeper authorize filter' do
     context 'with a JSON custom render' do
       before do
         module ControllerActions
+          remove_method :doorkeeper_forbidden_render_options
           def doorkeeper_forbidden_render_options(*)
             { json: { error_message: 'Forbidden' } }
           end
@@ -223,6 +235,7 @@ describe 'doorkeeper authorize filter' do
     context 'with a status and JSON custom render' do
       before do
         module ControllerActions
+          remove_method :doorkeeper_forbidden_render_options
           def doorkeeper_forbidden_render_options(*)
             { json: { error_message: 'Not Found' },
               respond_not_found_when_forbidden: true }
@@ -239,6 +252,7 @@ describe 'doorkeeper authorize filter' do
     context 'with a text custom render' do
       before do
         module ControllerActions
+          remove_method :doorkeeper_forbidden_render_options
           def doorkeeper_forbidden_render_options(*)
             { text: 'Forbidden' }
           end
@@ -256,6 +270,7 @@ describe 'doorkeeper authorize filter' do
     context 'with a status and text custom render' do
       before do
         module ControllerActions
+          remove_method :doorkeeper_forbidden_render_options
           def doorkeeper_forbidden_render_options(*)
             { respond_not_found_when_forbidden: true, text: 'Not Found' }
           end

--- a/spec/lib/oauth/scopes_spec.rb
+++ b/spec/lib/oauth/scopes_spec.rb
@@ -67,7 +67,6 @@ module Doorkeeper::OAuth
 
       it 'does not change the existing object' do
         origin = Scopes.from_string('public')
-        new_scope = origin + Scopes.from_string('admin')
         expect(origin.to_s).to eq('public')
       end
 

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -12,6 +12,12 @@ module Doorkeeper
       let(:factory_name) { :access_token }
     end
 
+    module CustomGeneratorArgs
+      def self.generate
+
+      end
+    end
+
     describe :generate_token do
       it 'generates a token using the default method' do
         FactoryGirl.create :access_token
@@ -21,6 +27,10 @@ module Doorkeeper
       end
 
       it 'generates a token using a custom object' do
+        eigenclass = class << CustomGeneratorArgs; self; end
+        eigenclass.class_eval do
+          remove_method :generate
+        end
         module CustomGeneratorArgs
           def self.generate(opts = {})
             "custom_generator_token_#{opts[:resource_owner_id]}"
@@ -37,6 +47,10 @@ module Doorkeeper
       end
 
       it 'allows the custom generator to access the application details' do
+        eigenclass = class << CustomGeneratorArgs; self; end
+        eigenclass.class_eval do
+          remove_method :generate
+        end
         module CustomGeneratorArgs
           def self.generate(opts = {})
             "custom_generator_token_#{opts[:application].name}"
@@ -53,6 +67,10 @@ module Doorkeeper
       end
 
       it 'allows the custom generator to access the scopes' do
+        eigenclass = class << CustomGeneratorArgs; self; end
+        eigenclass.class_eval do
+          remove_method :generate
+        end
         module CustomGeneratorArgs
           def self.generate(opts = {})
             "custom_generator_token_#{opts[:scopes].count}_#{opts[:scopes]}"
@@ -70,6 +88,10 @@ module Doorkeeper
       end
 
       it 'allows the custom generator to access the expiry length' do
+        eigenclass = class << CustomGeneratorArgs; self; end
+        eigenclass.class_eval do
+          remove_method :generate
+        end
         module CustomGeneratorArgs
           def self.generate(opts = {})
             "custom_generator_token_#{opts[:expires_in]}"


### PR DESCRIPTION
#799 

Before this PR here were the warnings from running `RUBYOPT=-w rake 2>&1 1>/dev/null | grep doorkeeper | sort --unique`

```
doorkeeper/lib/doorkeeper/oauth/client_credentials_request.rb:17: warning: method redefined; discarding old issuer
doorkeeper/lib/doorkeeper/oauth/helpers/scope_checker.rb:16: warning: character class has duplicated range: /[\n|\r|\t]/
doorkeeper/lib/doorkeeper/oauth/refresh_token_request.rb:32: warning: private attribute?
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:130: warning: method redefined; discarding old doorkeeper_unauthorized_render_options
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:130: warning: previous definition of doorkeeper_unauthorized_render_options was here
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:137: warning: method redefined; discarding old doorkeeper_unauthorized_render_options
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:156: warning: previous definition of doorkeeper_unauthorized_render_options was here
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:163: warning: method redefined; discarding old doorkeeper_unauthorized_render_options
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:163: warning: previous definition of doorkeeper_unauthorized_render_options was here
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:186: warning: method redefined; discarding old doorkeeper_forbidden_render_options
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:186: warning: previous definition of doorkeeper_forbidden_render_options was here
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:206: warning: method redefined; discarding old doorkeeper_forbidden_render_options
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:206: warning: previous definition of doorkeeper_forbidden_render_options was here
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:226: warning: method redefined; discarding old doorkeeper_forbidden_render_options
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:226: warning: previous definition of doorkeeper_forbidden_render_options was here
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:242: warning: method redefined; discarding old doorkeeper_forbidden_render_options
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:242: warning: previous definition of doorkeeper_forbidden_render_options was here
doorkeeper/spec/controllers/protected_resources_controller_spec.rb:259: warning: previous definition of doorkeeper_forbidden_render_options was here
doorkeeper/spec/lib/oauth/scopes_spec.rb:70: warning: assigned but unused variable - new_scope
doorkeeper/spec/models/doorkeeper/access_token_spec.rb:25: warning: method redefined; discarding old generate
doorkeeper/spec/models/doorkeeper/access_token_spec.rb:25: warning: previous definition of generate was here
doorkeeper/spec/models/doorkeeper/access_token_spec.rb:41: warning: method redefined; discarding old generate
doorkeeper/spec/models/doorkeeper/access_token_spec.rb:57: warning: method redefined; discarding old generate
doorkeeper/spec/models/doorkeeper/access_token_spec.rb:57: warning: previous definition of generate was here
doorkeeper/spec/models/doorkeeper/access_token_spec.rb:74: warning: previous definition of generate was here
```

After this PR there are no warnings.

Here were the fixes for the warnings:

`client_credentials_request`: attr_accessor creates a get method for `issuer`. However we redefine this method in this file. The fix is to use attr_writer
`scope_checker`: [\r|\n|\t] includes the pipe character twice. I assume we don't want to match for the pipe character at all.
`refresh_token_request`: We don't want to set the attribute to private or else we will get a warning. Setting the getter/setter to private drops the warning.
"spec" files: We are redefining methods and that produces warnings. We need to remove_method before redefining them to remove warnings.