### PR TITLE
Configurable table names

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -197,7 +197,7 @@ doorkeeper.
     option :access_token_generator,         default: "Doorkeeper::OAuth::Helpers::UniqueToken"
 
     %w(applications access_grants access_tokens).each do |model_name|
-      option :"#{model_name}_table_name",   default: "oauth_#{model_name}"
+      option :"#{model_name}_table_name",   default: :"oauth_#{model_name}"
     end
 
     attr_reader :reuse_access_token

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -10,6 +10,7 @@ module Doorkeeper
     setup_orm_adapter
     setup_orm_models
     setup_application_owner if @config.enable_application_owner?
+    setup_table_names
     check_requirements
   end
 
@@ -39,6 +40,10 @@ doorkeeper.
 
   def self.setup_application_owner
     @orm_adapter.initialize_application_owner!
+  end
+
+  def self.setup_table_names
+    @orm_adapter.initialize_table_names!
   end
 
   class Config

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -191,6 +191,10 @@ doorkeeper.
     option :grant_flows,                    default: %w(authorization_code client_credentials)
     option :access_token_generator,         default: "Doorkeeper::OAuth::Helpers::UniqueToken"
 
+    %w(applications access_grants access_tokens).each do |model_name|
+      option :"#{model_name}_table_name",   default: "oauth_#{model_name}"
+    end
+
     attr_reader :reuse_access_token
 
     def refresh_token_enabled?

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -24,7 +24,7 @@ module Doorkeeper
           entity = model.model_name.element # application, access_grant, access_token
 
           table_name = Doorkeeper.configuration.send("#{entity.pluralize}_table_name")
-          fail "#{model.to_s} can't be initialized with blank table name!" if table_name.blank?
+          fail "#{model} can't be initialized with blank table name!" if table_name.blank?
 
           model.table_name = table_name.to_sym
         end

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -19,6 +19,12 @@ module Doorkeeper
         Doorkeeper::Application.send :include, Doorkeeper::Models::Ownership
       end
 
+      def self.initialize_table_names!
+        Doorkeeper::AccessGrant.table_name = Doorkeeper.configuration.access_grants_table_name
+        Doorkeeper::AccessToken.table_name = Doorkeeper.configuration.access_tokens_table_name
+        Doorkeeper::Application.table_name = Doorkeeper.configuration.applications_table_name
+      end
+
       def self.check_requirements!(_config)
         if ::ActiveRecord::Base.connected? &&
            ::ActiveRecord::Base.connection.table_exists?(

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -26,7 +26,7 @@ module Doorkeeper
           table_name = Doorkeeper.configuration.send("#{entity.pluralize}_table_name")
           fail "#{model.to_s} can't be initialized with blank table name!" if table_name.blank?
 
-          model.table_name = table_name
+          model.table_name = table_name.to_sym
         end
       end
 

--- a/lib/doorkeeper/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/access_grant.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   class AccessGrant < ActiveRecord::Base
-    self.table_name = "#{table_name_prefix}oauth_access_grants#{table_name_suffix}".to_sym
+    self.table_name = Doorkeeper.configuration.access_grants_table_name
 
     include AccessGrantMixin
   end

--- a/lib/doorkeeper/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/access_grant.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   class AccessGrant < ActiveRecord::Base
-    self.table_name = Doorkeeper.configuration.access_grants_table_name
+    self.table_name = Doorkeeper.configuration.access_grants_table_name.to_sym
 
     include AccessGrantMixin
   end

--- a/lib/doorkeeper/orm/active_record/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/access_token.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   class AccessToken < ActiveRecord::Base
-    self.table_name = "#{table_name_prefix}oauth_access_tokens#{table_name_suffix}".to_sym
+    self.table_name = Doorkeeper.configuration.access_tokens_table_name
 
     include AccessTokenMixin
 

--- a/lib/doorkeeper/orm/active_record/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/access_token.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   class AccessToken < ActiveRecord::Base
-    self.table_name = Doorkeeper.configuration.access_tokens_table_name
+    self.table_name = Doorkeeper.configuration.access_tokens_table_name.to_sym
 
     include AccessTokenMixin
 

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   class Application < ActiveRecord::Base
-    self.table_name = Doorkeeper.configuration.applications_table_name
+    self.table_name = Doorkeeper.configuration.applications_table_name.to_sym
 
     include ApplicationMixin
 

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   class Application < ActiveRecord::Base
-    self.table_name = "#{table_name_prefix}oauth_applications#{table_name_suffix}".to_sym
+    self.table_name = Doorkeeper.configuration.applications_table_name
 
     include ApplicationMixin
 

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -17,6 +17,18 @@ Doorkeeper.configure do
   #   Admin.find_by_id(session[:admin_id]) || redirect_to(new_admin_session_url)
   # end
 
+  # Name of the `applications` table (default is :oauth_applications)
+  # Doorkeeper::Application model will be associated with this table
+  # applications_table_name :apps
+
+  # Name of the `access grants` table (default is :oauth_access_grants)
+  # Doorkeeper::AccessGrant model will be associated with this table
+  # applications_table_name :grants
+
+  # Name of the `access tokens` table (default is :oauth_access_tokens)
+  # Doorkeeper::AccessToken model will be associated with this table
+  # applications_table_name :tokens
+
   # Authorization Code expiration time (default 10 minutes).
   # authorization_code_expires_in 10.minutes
 

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -15,6 +15,18 @@ Doorkeeper.configure do
   #   Admin.find_by_id(session[:admin_id]) || redirect_to(new_admin_session_url)
   # end
 
+  # Name of the `applications` table (default is :oauth_applications)
+  # Doorkeeper::Application model will be associated with this table
+  # applications_table_name :apps
+
+  # Name of the `access grants` table (default is :oauth_access_grants)
+  # Doorkeeper::AccessGrant model will be associated with this table
+  # applications_table_name :grants
+
+  # Name of the `access tokens` table (default is :oauth_access_tokens)
+  # Doorkeeper::AccessToken model will be associated with this table
+  # applications_table_name :tokens
+
   # Authorization Code expiration time (default 10 minutes).
   # authorization_code_expires_in 10.minutes
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -314,4 +314,49 @@ describe Doorkeeper, 'configuration' do
       expect(subject.access_token_generator).to eq('Example')
     end
   end
+
+  describe 'applications_table_name' do
+    it 'is :oauth_applications by default' do
+      expect(Doorkeeper.configuration.applications_table_name).to eq(:oauth_applications)
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        applications_table_name 'example'
+      end
+
+      expect(subject.applications_table_name).to eq('example')
+    end
+  end
+
+  describe 'access_grants_table_name' do
+    it 'is :oauth_access_grants by default' do
+      expect(Doorkeeper.configuration.access_grants_table_name).to eq(:oauth_access_grants)
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        access_grants_table_name 'example'
+      end
+
+      expect(subject.access_grants_table_name).to eq('example')
+    end
+  end
+
+  describe 'access_tokens_table_name' do
+    it 'is :oauth_access_tokens by default' do
+      expect(Doorkeeper.configuration.access_tokens_table_name).to eq(:oauth_access_tokens)
+    end
+
+    it 'can change the value' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        access_tokens_table_name 'example'
+      end
+
+      expect(subject.access_tokens_table_name).to eq('example')
+    end
+  end
 end

--- a/spec/models/doorkeeper/access_grant_spec.rb
+++ b/spec/models/doorkeeper/access_grant_spec.rb
@@ -5,6 +5,7 @@ describe Doorkeeper::AccessGrant do
 
   it { expect(subject).to be_valid }
 
+  it_behaves_like 'a model with custom table', :grants
   it_behaves_like 'an accessible token'
   it_behaves_like 'a revocable token'
   it_behaves_like 'a unique token' do

--- a/spec/models/doorkeeper/access_grant_spec.rb
+++ b/spec/models/doorkeeper/access_grant_spec.rb
@@ -5,11 +5,19 @@ describe Doorkeeper::AccessGrant do
 
   it { expect(subject).to be_valid }
 
-  it_behaves_like 'a model with custom table', :grants
   it_behaves_like 'an accessible token'
   it_behaves_like 'a revocable token'
   it_behaves_like 'a unique token' do
     let(:factory_name) { :access_grant }
+  end
+
+  it_behaves_like 'a model with custom table', :access_grants_table_name, :grants do
+    let(:custom_configuration) {
+      Doorkeeper.configure do
+         orm DOORKEEPER_ORM
+         access_grants_table_name :grants
+      end
+    }
   end
 
   describe 'validations' do

--- a/spec/models/doorkeeper/access_grant_spec.rb
+++ b/spec/models/doorkeeper/access_grant_spec.rb
@@ -12,12 +12,12 @@ describe Doorkeeper::AccessGrant do
   end
 
   it_behaves_like 'a model with custom table', :access_grants_table_name, :grants do
-    let(:custom_configuration) {
+    let(:custom_configuration) do
       Doorkeeper.configure do
          orm DOORKEEPER_ORM
          access_grants_table_name :grants
       end
-    }
+    end
   end
 
   describe 'validations' do

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -6,6 +6,7 @@ module Doorkeeper
 
     it { expect(subject).to be_valid }
 
+    it_behaves_like 'a model with custom table', :tokens
     it_behaves_like 'an accessible token'
     it_behaves_like 'a revocable token'
     it_behaves_like 'a unique token' do

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -13,12 +13,12 @@ module Doorkeeper
     end
 
     it_behaves_like 'a model with custom table', :access_tokens_table_name, :tokens do
-      let(:custom_configuration) {
+      let(:custom_configuration) do
         Doorkeeper.configure do
-           orm DOORKEEPER_ORM
-           access_tokens_table_name :tokens
+          orm DOORKEEPER_ORM
+          access_tokens_table_name :tokens
         end
-      }
+      end
     end
 
     module CustomGeneratorArgs

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -6,11 +6,19 @@ module Doorkeeper
 
     it { expect(subject).to be_valid }
 
-    it_behaves_like 'a model with custom table', :tokens
     it_behaves_like 'an accessible token'
     it_behaves_like 'a revocable token'
     it_behaves_like 'a unique token' do
       let(:factory_name) { :access_token }
+    end
+
+    it_behaves_like 'a model with custom table', :access_tokens_table_name, :tokens do
+      let(:custom_configuration) {
+        Doorkeeper.configure do
+           orm DOORKEEPER_ORM
+           access_tokens_table_name :tokens
+        end
+      }
     end
 
     module CustomGeneratorArgs

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -9,7 +9,14 @@ module Doorkeeper
     let(:uid) { SecureRandom.hex(8) }
     let(:secret) { SecureRandom.hex(8) }
 
-    it_behaves_like 'a model with custom table', :apps
+    it_behaves_like 'a model with custom table', :applications_table_name, :apps do
+      let(:custom_configuration) {
+        Doorkeeper.configure do
+           orm DOORKEEPER_ORM
+           applications_table_name :apps
+        end
+      }
+    end
 
     context 'application_owner is enabled' do
       before do

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -10,12 +10,12 @@ module Doorkeeper
     let(:secret) { SecureRandom.hex(8) }
 
     it_behaves_like 'a model with custom table', :applications_table_name, :apps do
-      let(:custom_configuration) {
+      let(:custom_configuration) do
         Doorkeeper.configure do
-           orm DOORKEEPER_ORM
-           applications_table_name :apps
+          orm DOORKEEPER_ORM
+          applications_table_name :apps
         end
-      }
+      end
     end
 
     context 'application_owner is enabled' do

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -9,6 +9,8 @@ module Doorkeeper
     let(:uid) { SecureRandom.hex(8) }
     let(:secret) { SecureRandom.hex(8) }
 
+    it_behaves_like 'a model with custom table', :apps
+
     context 'application_owner is enabled' do
       before do
         Doorkeeper.configure do

--- a/spec/support/shared/models_shared_examples.rb
+++ b/spec/support/shared/models_shared_examples.rb
@@ -50,3 +50,25 @@ shared_examples 'a unique token' do
     end
   end
 end
+
+shared_examples 'a model with custom table' do |custom_table_name|
+  describe 'table name' do
+    it 'has a default table name for the default config' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+      end
+
+      default_name = # TODO
+      expect(described_class.table_name).to eq(default_name)
+    end
+
+    it 'has a custom table name for the specific config' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        change_me custom_table_name # TODO
+      end
+
+      expect(described_class.table_name).to eq(custom_table_name)
+    end
+  end
+end

--- a/spec/support/shared/models_shared_examples.rb
+++ b/spec/support/shared/models_shared_examples.rb
@@ -64,8 +64,8 @@ shared_examples 'a model with custom table' do |config_option, custom_table_name
     end
 
     it 'has a custom table name for the specific config' do
-      expect { custom_configuration }.to change { described_class.table_name.to_s }
-                                             .from(default_name).to(custom_table_name.to_s)
+      expect { custom_configuration }.to change { described_class.table_name.to_s }.
+                                             from(default_name).to(custom_table_name.to_s)
     end
   end
 end

--- a/spec/support/shared/models_shared_examples.rb
+++ b/spec/support/shared/models_shared_examples.rb
@@ -51,24 +51,21 @@ shared_examples 'a unique token' do
   end
 end
 
-shared_examples 'a model with custom table' do |custom_table_name|
+shared_examples 'a model with custom table' do |config_option, custom_table_name|
+  let!(:default_name) { Doorkeeper.configuration.send(config_option).try(:to_s) }
+
   describe 'table name' do
     it 'has a default table name for the default config' do
       Doorkeeper.configure do
         orm DOORKEEPER_ORM
       end
 
-      default_name = # TODO
       expect(described_class.table_name).to eq(default_name)
     end
 
     it 'has a custom table name for the specific config' do
-      Doorkeeper.configure do
-        orm DOORKEEPER_ORM
-        change_me custom_table_name # TODO
-      end
-
-      expect(described_class.table_name).to eq(custom_table_name)
+      expect { custom_configuration }.to change { described_class.table_name.to_s }
+                                             .from(default_name).to(custom_table_name.to_s)
     end
   end
 end


### PR DESCRIPTION
This PR allows to customize `Application`, `AccessToken` and `AccessGrant` table names. It may be necessary for at least two reasons:

* Developer don't want to use default table names like "oauth_xxx" for any reason. Instead of using something like 
`Doorkeeper::Application.class_eval { self.table_name = :apps }` 
he can simply change corresponding Doorkeeper configuration option now.
* ORM extensions become independent of strong Doorkeeper table names.

All the current names is saved by default (`oauth_applications`, `oauth_access_tokens`, `oauth_access_grants`). Tests are present.

The problem with strong table names appeared when I was working on [doorkeeper-sequel](https://github.com/nbulaj/doorkeeper-sequel) adapter, in part of migrating associations (many-to-many :through, ).