### PR TITLE
Make configuration and specs ORM independent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 User-visible changes worth mentioning.
 
+- [#823] Make configuration and specs ORM independent
 - [#777] Add support for public client in password grant flow
 
 ---

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -236,18 +236,6 @@ doorkeeper.
       @token_grant_types ||= calculate_token_grant_types
     end
 
-    def refresh_token_revoked_on_use?
-      unless @refresh_token_revoked_on_use.nil?
-        return @refresh_token_revoked_on_use
-      end
-
-      @refresh_token_revoked_on_use =
-        ActiveRecord::Base.connection.column_exists?(
-          :oauth_access_tokens,
-          :previous_refresh_token
-        )
-    end
-
     private
 
     # Determines what values are acceptable for 'response_type' param in

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -23,7 +23,7 @@ module Doorkeeper
       end
 
       def refresh_token_revoked_on_use?
-        Doorkeeper.configuration.refresh_token_revoked_on_use?
+        AccessToken.refresh_token_revoked_on_use?
       end
     end
   end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -42,7 +42,7 @@ module Doorkeeper
       end
 
       def refresh_token_revoked_on_use?
-        server.refresh_token_revoked_on_use?
+        Doorkeeper::AccessToken.refresh_token_revoked_on_use?
       end
 
       def default_scopes

--- a/lib/doorkeeper/orm/active_record/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/access_token.rb
@@ -14,6 +14,10 @@ module Doorkeeper
       :order
     end
 
+    def self.refresh_token_revoked_on_use?
+      column_names.include?('previous_refresh_token')
+    end
+
     def self.created_at_desc
       'created_at desc'
     end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -18,7 +18,7 @@ module Doorkeeper::OAuth
     it 'issues a new token for the client' do
       expect do
         subject.authorize
-      end.to change { client.access_tokens.count }.by(1)
+      end.to change { client.reload.access_tokens.count }.by(1)
     end
 
     it "issues the token with same grant's scopes" do

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -21,7 +21,7 @@ module Doorkeeper::OAuth
     it 'issues a new token for the client' do
       expect do
         subject.authorize
-      end.to change { client.access_tokens.count }.by(1)
+      end.to change { client.reload.access_tokens.count }.by(1)
     end
 
     it 'issues a new token without a client' do

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -154,7 +154,7 @@ module Doorkeeper
         expect do
           token2.refresh_token = token1.refresh_token
           token2.save(validate: false)
-        end.to raise_error(ActiveRecord::RecordNotUnique)
+        end.to raise_error(uniqueness_error)
       end
     end
 

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -90,7 +90,7 @@ module Doorkeeper
       app1 = FactoryGirl.create(:application)
       app2 = FactoryGirl.create(:application)
       app2.uid = app1.uid
-      expect { app2.save!(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect { app2.save!(validate: false) }.to raise_error(uniqueness_error)
     end
 
     it 'generate secret on create' do

--- a/spec/requests/flows/refresh_token_spec.rb
+++ b/spec/requests/flows/refresh_token_spec.rb
@@ -70,7 +70,7 @@ describe 'Refresh Token Flow' do
 
     context "refresh_token revoked on refresh_token request" do
       before do
-        config_is_set(:refresh_token_revoked_on_use, false)
+        allow(Doorkeeper::AccessToken).to receive(:refresh_token_revoked_on_use?).and_return(false)
       end
 
       it 'client request a token with refresh token' do
@@ -152,7 +152,7 @@ describe 'Refresh Token Flow' do
 
     context "refresh_token revoked on refresh_token request" do
       before do
-        config_is_set(:refresh_token_revoked_on_use, false)
+        allow(Doorkeeper::AccessToken).to receive(:refresh_token_revoked_on_use?).and_return(false)
       end
 
       it 'client request a token after creating another token with the same user' do

--- a/spec/support/helpers/model_helper.rb
+++ b/spec/support/helpers/model_helper.rb
@@ -40,6 +40,22 @@ module ModelHelper
     grant = Doorkeeper::AccessToken.last
     expect(grant.scopes).to eq(Doorkeeper::OAuth::Scopes.from_array(args))
   end
+
+  def uniqueness_error
+    case DOORKEEPER_ORM
+    when :active_record
+      ActiveRecord::RecordNotUnique
+    when :sequel
+      error_classes = [Sequel::UniqueConstraintViolation, Sequel::ValidationFailed]
+      proc { |error| expect(error.class).to be_in(error_classes) }
+    when :mongo_mapper
+      MongoMapper::DocumentNotValid
+    when /mongoid/
+      Mongoid::Errors::Validations
+    else
+      raise "'#{DOORKEEPER_ORM}' ORM is not supported!"
+    end
+  end
 end
 
 RSpec.configuration.send :include, ModelHelper

--- a/spec/support/shared/models_shared_examples.rb
+++ b/spec/support/shared/models_shared_examples.rb
@@ -46,7 +46,7 @@ shared_examples 'a unique token' do
       token2.token = token1.token
       expect do
         token2.save!(validate: false)
-      end.to raise_error(ActiveRecord::RecordNotUnique)
+      end.to raise_error(uniqueness_error)
     end
   end
 end


### PR DESCRIPTION
Hi. This PR fixes a few issues with dependence on the ORM:

1. Models _Uniquenes validations_ in specs - previously caught only `ActiveRecord::RecordNotUnique` exceptions, now [error class(es) depends on configured ORM](https://github.com/nbulaj/doorkeeper/blob/master/spec/support/helpers/model_helper.rb#L44). Tests attached.
2. Method `refresh_token_revoked_on_use?` in Doorkeeper configuration - was not actually a config option. [Extracted to `AccessToken` model](https://github.com/nbulaj/doorkeeper/blob/master/lib/doorkeeper/orm/active_record/access_token.rb#L17) due to it's logic and can be override in any Doorkeeper ORM. Tests attached.
3. `expect { ... }.to change { relation.associations.count }` expectations - [fixed missed `reload` method](https://github.com/nbulaj/doorkeeper/blob/master/spec/lib/oauth/refresh_token_request_spec.rb#L22) to get actual information. Tests attached.