### PR TITLE
Fix model_helper.rb to support different ORMs

### DIFF
--- a/spec/support/helpers/model_helper.rb
+++ b/spec/support/helpers/model_helper.rb
@@ -13,14 +13,20 @@ module ModelHelper
 
   def access_grant_should_exist_for(client, resource_owner)
     grant = Doorkeeper::AccessGrant.first
-    expect(grant.application).to eq(client)
-    grant.resource_owner_id  == resource_owner.id
+
+    expect(grant.application).to have_attributes(id: client.id).
+      and(be_instance_of(Doorkeeper::Application))
+
+    expect(grant.resource_owner_id).to eq(resource_owner.id)
   end
 
   def access_token_should_exist_for(client, resource_owner)
-    grant = Doorkeeper::AccessToken.first
-    expect(grant.application).to eq(client)
-    grant.resource_owner_id  == resource_owner.id
+    token = Doorkeeper::AccessToken.first
+
+    expect(token.application).to have_attributes(id: client.id).
+      and(be_instance_of(Doorkeeper::Application))
+
+    expect(token.resource_owner_id).to eq(resource_owner.id)
   end
 
   def access_grant_should_not_exist


### PR DESCRIPTION
Fixes #833 - expectations of 'access_grant_should_exist_for' and 'access_token_should_exist_for' methods checks for the same object ID, class and Resource Owner ID.