### PR TITLE
 Fix Rails 5 warning messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source "https://rubygems.org"
 
 gem "rails", "~> #{ENV["rails"]}"
 
+if ENV['rails'].start_with?('5')
+  gem 'rspec-rails', '3.5.0.beta3'
+end
+
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", platform: [:ruby, :mswin, :mingw]
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 - [#745] Add created_at timestamp to token generation options
 - [#838] Drop `Application#scopes` generator and warning, introduced for
   upgrading doorkeeper from v2 to v3.
+- [#801] Fix Rails 5 warning messages
 
 ---
 

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper_integration'
 
 module ControllerActions
   def index
-    render text: 'index'
+    render plain: 'index'
   end
 
   def show
-    render text: 'show'
+    render plain: 'show'
   end
 
   def doorkeeper_unauthorized_render_options(*)
@@ -22,7 +22,7 @@ describe 'doorkeeper authorize filter' do
       before_action :doorkeeper_authorize!
 
       def index
-        render text: 'index'
+        render plain: 'index'
       end
     end
 
@@ -100,7 +100,7 @@ describe 'doorkeeper authorize filter' do
 
   context 'defined with scopes' do
     controller do
-      before_filter -> { doorkeeper_authorize! :write }
+      before_action -> { doorkeeper_authorize! :write }
 
       include ControllerActions
     end
@@ -137,7 +137,7 @@ describe 'doorkeeper authorize filter' do
 
   context 'when custom unauthorized render options are configured' do
     controller do
-      before_filter :doorkeeper_authorize!
+      before_action :doorkeeper_authorize!
 
       include ControllerActions
     end
@@ -175,7 +175,7 @@ describe 'doorkeeper authorize filter' do
         module ControllerActions
           remove_method :doorkeeper_unauthorized_render_options
           def doorkeeper_unauthorized_render_options(error: nil)
-            { text: 'Unauthorized' }
+            { plain: 'Unauthorized' }
           end
         end
       end
@@ -190,7 +190,7 @@ describe 'doorkeeper authorize filter' do
       it 'it renders a custom text response', token: :invalid do
         get :index, access_token: token_string
         expect(response.status).to eq 401
-        expect(response.content_type).to eq('text/html')
+        expect(response.content_type).to eq('text/plain')
         expect(response.header['WWW-Authenticate']).to match(/^Bearer/)
         expect(response.body).to eq('Unauthorized')
       end
@@ -212,7 +212,7 @@ describe 'doorkeeper authorize filter' do
     end
 
     controller do
-      before_filter -> { doorkeeper_authorize! :write }
+      before_action -> { doorkeeper_authorize! :write }
 
       include ControllerActions
     end
@@ -268,7 +268,7 @@ describe 'doorkeeper authorize filter' do
         module ControllerActions
           remove_method :doorkeeper_forbidden_render_options
           def doorkeeper_forbidden_render_options(*)
-            { text: 'Forbidden' }
+            { plain: 'Forbidden' }
           end
         end
       end
@@ -286,7 +286,7 @@ describe 'doorkeeper authorize filter' do
         module ControllerActions
           remove_method :doorkeeper_forbidden_render_options
           def doorkeeper_forbidden_render_options(*)
-            { respond_not_found_when_forbidden: true, text: 'Not Found' }
+            { respond_not_found_when_forbidden: true, plain: 'Not Found' }
           end
         end
       end

--- a/spec/dummy/app/controllers/full_protected_resources_controller.rb
+++ b/spec/dummy/app/controllers/full_protected_resources_controller.rb
@@ -3,10 +3,10 @@ class FullProtectedResourcesController < ApplicationController
   before_action :doorkeeper_authorize!, only: :index
 
   def index
-    render text: 'index'
+    render plain: 'index'
   end
 
   def show
-    render text: 'show'
+    render plain: 'show'
   end
 end

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -12,6 +12,6 @@ class HomeController < ApplicationController
   end
 
   def callback
-    render text: 'ok'
+    render plain: 'ok'
   end
 end

--- a/spec/dummy/app/controllers/semi_protected_resources_controller.rb
+++ b/spec/dummy/app/controllers/semi_protected_resources_controller.rb
@@ -2,10 +2,10 @@ class SemiProtectedResourcesController < ApplicationController
   before_action :doorkeeper_authorize!, only: :index
 
   def index
-    render text: 'protected index'
+    render plain: 'protected index'
   end
 
   def show
-    render text: 'non protected show'
+    render plain: 'non protected show'
   end
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -7,9 +7,6 @@ Dummy::Application.configure do
   # and recreated between test runs.  Don't rely on the data there!
   config.cache_classes = true
 
-  # Configure static asset server for tests with Cache-Control for performance
-  config.static_cache_control = 'public, max-age=3600'
-
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -35,6 +35,9 @@ ENGINE_RAILS_ROOT = File.join(File.dirname(__FILE__), '../')
 
 Dir["#{File.dirname(__FILE__)}/support/{dependencies,helpers,shared}/*.rb"].each { |f| require f }
 
+# Remove after dropping support of Rails 4.2
+require "#{File.dirname(__FILE__)}/support/http_method_shim.rb"
+
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.mock_with :rspec

--- a/spec/support/http_method_shim.rb
+++ b/spec/support/http_method_shim.rb
@@ -1,0 +1,24 @@
+# Rails 5 deprecates calling HTTP action methods with positional arguments
+# in favor of keyword arguments. However, the keyword argument form is only
+# supported in Rails 5+. Since we support back to 4, we need some sort of shim
+# to avoid super noisy deprecations when running tests.
+module HTTPMethodShim
+  def get(path, params = nil, headers = nil)
+    super(path, params: params, headers: headers)
+  end
+
+  def post(path, params = nil, headers = nil)
+    super(path, params: params, headers: headers)
+  end
+
+  def put(path, params = nil, headers = nil)
+    super(path, params: params, headers: headers)
+  end
+end
+
+if ::Rails::VERSION::MAJOR >= 5
+  RSpec.configure do |config|
+    config.include HTTPMethodShim, type: :controller
+    config.include HTTPMethodShim, type: :request
+  end
+end


### PR DESCRIPTION
Fixes #801: removes deprecation messages, uses a new version of RSpec with Rails 5.

Checked with Rails 5.0.0.beta3 and 5.0.0.rc1.