### PR TITLE
Allow to issue new token without client credentials

### DIFF
--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -31,7 +31,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
 
     create_table :oauth_access_tokens do |t|
       t.integer  :resource_owner_id
-      t.references :application,       null: false
+      t.references :application
 
       # If you use a custom token generator you may need to change this column
       # from string to text, so that it accepts tokens larger than 255


### PR DESCRIPTION
[This spec](https://github.com/doorkeeper-gem/doorkeeper/blob/master/spec/requests/flows/password_spec.rb#L49) is successful, but `ActiveRecord::StatementInvalid` is caused by the constraint of database schema.

I want you to check PR https://github.com/doorkeeper-gem/doorkeeper/pull/842 before to merge.