### PR TITLE
Disallow to issue a new token without a client

### DIFF
--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -36,7 +36,7 @@ module Doorkeeper
       end
 
       def validate_client
-        !parameters[:client_id] || !!client
+        !!client
       end
     end
   end

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -24,11 +24,11 @@ module Doorkeeper::OAuth
       end.to change { client.reload.access_tokens.count }.by(1)
     end
 
-    it 'issues a new token without a client' do
+    it 'does not issue a new token without a client' do
       expect do
         subject.client = nil
         subject.authorize
-      end.to change { Doorkeeper::AccessToken.count }.by(1)
+      end.to_not change { Doorkeeper::AccessToken.count }
     end
 
     it 'does not issue a new token with an invalid client' do

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -46,15 +46,10 @@ describe 'Resource Owner Password Credentials Flow' do
       should_have_json 'access_token', token.token
     end
 
-    it 'should issue new token without client credentials' do
+    it 'does not issue a new token without a client' do
       expect do
         post password_token_endpoint_url(resource_owner: @resource_owner)
-      end.to change { Doorkeeper::AccessToken.count }.by(1)
-
-      token = Doorkeeper::AccessToken.first
-
-      expect(token.application_id).to be_nil
-      should_have_json 'access_token', token.token
+      end.not_to change { Doorkeeper::AccessToken.count }
     end
 
     it 'should issue a refresh token if enabled' do


### PR DESCRIPTION
A new token is issued without a client in case of ResourceOwnerPasswordCredentials flow.
However it doesn't work in version `4.0.0.rc4` by the constraint of database schema.

If you change as PR https://github.com/doorkeeper-gem/doorkeeper/pull/841, is necessary to change the database schema. Also a new token isn't issued without a client in case of RefreshToken flow.
I don't think it's a good way.

It should change `client_id` to required parameter. It is well enough to support public client.

I want you to merge one of https://github.com/doorkeeper-gem/doorkeeper/pull/841 or this PR.