### PR TITLE
Revert "Fix validation error messages"

### DIFF
--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -7,7 +7,7 @@ module Doorkeeper
       validate :attributes,   error: :invalid_request
       validate :client,       error: :invalid_client
       validate :grant,        error: :invalid_grant
-      validate :redirect_uri, error: :invalid_redirect_uri
+      validate :redirect_uri, error: :invalid_grant
 
       attr_accessor :server, :grant, :client, :redirect_uri, :access_token
 

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -6,7 +6,7 @@ module Doorkeeper
       include OAuth::Helpers
 
       validate :client,         error: :invalid_client
-      validate :resource_owner, error: :invalid_resource_owner
+      validate :resource_owner, error: :invalid_grant
       validate :scopes,         error: :invalid_scope
 
       attr_accessor :server, :client, :resource_owner, :parameters,

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -59,7 +59,7 @@ module Doorkeeper::OAuth
     it "matches the redirect_uri with grant's one" do
       subject.redirect_uri = 'http://other.com'
       subject.validate
-      expect(subject.error).to eq(:invalid_redirect_uri)
+      expect(subject.error).to eq(:invalid_grant)
     end
 
     it "matches the client with grant's one" do

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -44,7 +44,7 @@ module Doorkeeper::OAuth
     it 'requires the owner' do
       subject.resource_owner = nil
       subject.validate
-      expect(subject.error).to eq(:invalid_resource_owner)
+      expect(subject.error).to eq(:invalid_grant)
     end
 
     it 'optionally accepts the client' do


### PR DESCRIPTION
`invalid_resource_owner` error is not in the spec. It should be `invalid_grant` when using Resource Owner Password Credentials Grant.

Reverts 0c8673d6c9350058a51e226e900a41a19b53e7c3

Thank you @hurty for your input on https://github.com/doorkeeper-gem/doorkeeper/pull/771#issuecomment-222471010:

> This has already been discussed and fixed in the past: #444 