### PR TITLE
Allow customising the Doorkeeper::ApplicationController base controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,16 @@ end
 JWT token support is available with
 [Doorkeeper-JWT](https://github.com/chriswarren/doorkeeper-jwt).
 
+### Custom Base Controller
+
+By default Doorkeeper's main controller `Doorkeeper::ApplicationController` inherits from `ActionController::Base`.
+You may want to use your own controller to inherit from, to keep Doorkeeper controllers in the same context than the rest your app:
+
+```ruby
+Doorkeeper.configure do
+  base_controller 'ApplicationController'
+end
+```
 
 ### Authenticated resource owner
 

--- a/app/controllers/doorkeeper/application_controller.rb
+++ b/app/controllers/doorkeeper/application_controller.rb
@@ -1,5 +1,7 @@
 module Doorkeeper
-  class ApplicationController < Doorkeeper.configuration.base_controller.constantize
+  class ApplicationController <
+    Doorkeeper.configuration.base_controller.constantize
+
     include Helpers::Controller
 
     if ::Rails.version.to_i < 4

--- a/app/controllers/doorkeeper/application_controller.rb
+++ b/app/controllers/doorkeeper/application_controller.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
-  class ApplicationController < ActionController::Base
+  class ApplicationController < Doorkeeper.configuration.base_controller.constantize
     include Helpers::Controller
 
     if ::Rails.version.to_i < 4

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -89,7 +89,9 @@ doorkeeper.
       end
 
       def access_token_generator(access_token_generator)
-        @config.instance_variable_set('@access_token_generator', access_token_generator)
+        @config.instance_variable_set(
+          '@access_token_generator', access_token_generator
+        )
       end
 
       def base_controller(base_controller)
@@ -186,8 +188,10 @@ doorkeeper.
     option :realm,                          default: 'Doorkeeper'
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
-    option :access_token_generator,         default: 'Doorkeeper::OAuth::Helpers::UniqueToken'
-    option :base_controller,                default: 'ActionController::Base'
+    option :access_token_generator,
+           default: 'Doorkeeper::OAuth::Helpers::UniqueToken'
+    option :base_controller,
+           default: 'ActionController::Base'
 
     attr_reader :reuse_access_token
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -89,9 +89,11 @@ doorkeeper.
       end
 
       def access_token_generator(access_token_generator)
-        @config.instance_variable_set(
-          '@access_token_generator', access_token_generator
-        )
+        @config.instance_variable_set('@access_token_generator', access_token_generator)
+      end
+
+      def base_controller(base_controller)
+        @config.instance_variable_set('@base_controller', base_controller)
       end
     end
 
@@ -184,7 +186,8 @@ doorkeeper.
     option :realm,                          default: 'Doorkeeper'
     option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
     option :grant_flows,                    default: %w(authorization_code client_credentials)
-    option :access_token_generator,         default: "Doorkeeper::OAuth::Helpers::UniqueToken"
+    option :access_token_generator,         default: 'Doorkeeper::OAuth::Helpers::UniqueToken'
+    option :base_controller,                default: 'ActionController::Base'
 
     attr_reader :reuse_access_token
 

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -31,7 +31,12 @@ Doorkeeper.configure do
 
   # Use a custom class for generating the access token.
   # https://github.com/doorkeeper-gem/doorkeeper#custom-access-token-generator
-  # access_token_generator "::Doorkeeper::JWT"
+  # access_token_generator '::Doorkeeper::JWT'
+
+  # The controller Doorkeeper::ApplicationController inherits from.
+  # Defaults to ActionController::Base.
+  # https://github.com/doorkeeper-gem/doorkeeper#custom-base-controller
+  # base_controller 'ApplicationController'
 
   # Reuse access token for the same resource owner within an application (disabled by default)
   # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -314,4 +314,21 @@ describe Doorkeeper, 'configuration' do
       expect(subject.access_token_generator).to eq('Example')
     end
   end
+
+  describe 'base_controller' do
+    context 'default' do
+      it { expect(Doorkeeper.configuration.base_controller).to eq('ActionController::Base') }
+    end
+
+    context 'custom' do
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          base_controller 'ApplicationController'
+        end
+      end
+
+      it { expect(Doorkeeper.configuration.base_controller).to eq('ApplicationController') }
+    end
+  end
 end


### PR DESCRIPTION
Related to https://github.com/doorkeeper-gem/doorkeeper/issues/465.

Usefull to keep Doorkeeper controllers in the same context than the rest of your app.