### PR TITLE
Specify Null option to timestamps

### DIFF
--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -6,7 +6,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       t.string  :secret,       null: false
       t.text    :redirect_uri, null: false
       t.string  :scopes,       null: false, default: ''
-      t.timestamps
+      t.timestamps             null: false
     end
 
     add_index :oauth_applications, :uid, unique: true

--- a/spec/dummy/db/migrate/20151223192035_create_doorkeeper_tables.rb
+++ b/spec/dummy/db/migrate/20151223192035_create_doorkeeper_tables.rb
@@ -6,7 +6,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration
       t.string  :secret,       null: false
       t.text    :redirect_uri, null: false
       t.string  :scopes,       null: false, default: ''
-      t.timestamps
+      t.timestamps             null: false
     end
 
     add_index :oauth_applications, :uid, unique: true


### PR DESCRIPTION
In Rails 5, default option of timestamps are changed to `null: false`.
If you do not specify the option deprecation messages are called.