### PR TITLE
Fix AssetNotPrecompiled error with Sprockets 4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#834] Fix AssetNotPrecompiled error with Sprockets 4
+
 ## 4.0.0.rc4
 
 - [#777] Add support for public client in password grant flow

--- a/lib/doorkeeper/engine.rb
+++ b/lib/doorkeeper/engine.rb
@@ -14,5 +14,14 @@ module Doorkeeper
         include Doorkeeper::Rails::Helpers
       end
     end
+
+    if defined?(Sprockets) && Sprockets::VERSION.chr.to_i >= 4
+      initializer 'doorkeeper.assets.precompile' do |app|
+        app.config.assets.precompile += %w(
+          doorkeeper/application.css
+          doorkeeper/admin/application.css
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #834: precompile assets when using Sprockets 4 to remove Sprockets::Rails::Helper::AssetNotPrecompiled rubyrubyerror.