### PR TITLE
Make Scopes#+ and #& work against a non-Scopes object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#868] `Scopes#&` and `Scopes#+` now take an array or any other enumerable
+  object.
 - [#1019] Remove translation not in use: `invalid_resource_owner`.
 - Use Ruby 2 hash style syntax (min required Ruby version = 2.1)
 - [#948] Make Scopes.<=> work with any "other" value.

--- a/lib/doorkeeper/oauth/scopes.rb
+++ b/lib/doorkeeper/oauth/scopes.rb
@@ -45,11 +45,7 @@ module Doorkeeper
       end
 
       def +(other)
-        if other.is_a? Scopes
-          self.class.from_array(all + other.all)
-        else
-          super(other)
-        end
+        self.class.from_array(all + to_array(other))
       end
 
       def <=>(other)
@@ -61,8 +57,18 @@ module Doorkeeper
       end
 
       def &(other)
-        other_array = other.present? ? other.all : []
-        self.class.from_array(all & other_array)
+        self.class.from_array(all & to_array(other))
+      end
+
+      private
+
+      def to_array(other)
+        case other
+        when Scopes
+          other.all
+        else
+          other.to_a
+        end
       end
     end
   end

--- a/spec/lib/oauth/scopes_spec.rb
+++ b/spec/lib/oauth/scopes_spec.rb
@@ -70,10 +70,33 @@ module Doorkeeper::OAuth
         expect(origin.to_s).to eq('public')
       end
 
+      it 'can add an array to a scope object' do
+        scopes = Scopes.from_string('public') + ['admin']
+        expect(scopes.all).to eq(%w(public admin))
+      end
+
       it 'raises an error if cannot handle addition' do
         expect do
           Scopes.from_string('public') + 'admin'
         end.to raise_error(NoMethodError)
+      end
+    end
+
+    describe '#&' do
+      it 'can get intersection with another scope object' do
+        scopes = Scopes.from_string('public admin') & Scopes.from_string('write admin')
+        expect(scopes.all).to eq(%w(admin))
+      end
+
+      it 'does not change the existing object' do
+        origin = Scopes.from_string('public admin')
+        origin & Scopes.from_string('write admin')
+        expect(origin.to_s).to eq('public admin')
+      end
+
+      it 'can get intersection with an array' do
+        scopes = Scopes.from_string('public admin') & %w(write admin)
+        expect(scopes.all).to eq(%w(admin))
       end
     end
 


### PR DESCRIPTION
The intention of [`Scopes#+` calling super](https://github.com/doorkeeper-gem/doorkeeper/blob/711e072bd3af581bcbef42bd635e05e7828a0640/lib/doorkeeper/oauth/scopes.rb#L51) is unclear to me, but I believe it is useful for the operators like `+` and `&` to work against an array, or any object that is convertible to Array. 
