### PR TITLE
Rename user factory to doorkeeper_testing_user

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#871] Allow downstream users to better utilize doorkeeper spec factories by
+  eliminating name conflict on `:user` factory.
+
 ## 4.1.0
 
 - [#845] Allow customising the `Doorkeeper::ApplicationController` base

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,5 +22,7 @@ FactoryGirl.define do
     redirect_uri 'https://app.com/callback'
   end
 
-  factory :user
+  # do not name this factory :user, otherwise it will conflict with factories
+  # from applications that use doorkeeper factories in their own tests
+  factory :doorkeeper_testing_user, class: :user
 end

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -30,7 +30,7 @@ module Doorkeeper
       context 'application owner is required' do
         before(:each) do
           require_owner
-          @owner = FactoryGirl.build_stubbed(:user)
+          @owner = FactoryGirl.build_stubbed(:doorkeeper_testing_user)
         end
 
         it 'is invalid without an owner' do


### PR DESCRIPTION
Developers of Rails applications love to include the factories from the doorkeeper gem into their applications because the factories make it easy to do feature testing of the API, stubbing out the relevant doorkeeper models.

However, there is a name conflict on the user factory (which is a global namespace), so that developers cannot include `<path_to_doorkeeper>/spec/factories.rb` if their own factories.rb includes a :user factory (which most do).

This change simply renames the internal factory (which is only used in 1 test anyways) to a scoped name that is much less likely to conflict.  It does not change which class the factory is modeled off of (still the user.rb in the dummy spec app).