### PR TITLE
Add hooks for ApplicationMetalController

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 User-visible changes worth mentioning.
 
 ## master
-
+- [#873] Add hooks to Doorkeeper::ApplicationMetalController
 - [#871] Allow downstream users to better utilize doorkeeper spec factories by
   eliminating name conflict on `:user` factory.
 

--- a/app/controllers/doorkeeper/application_metal_controller.rb
+++ b/app/controllers/doorkeeper/application_metal_controller.rb
@@ -11,5 +11,7 @@ module Doorkeeper
     MODULES.each do |mod|
       include mod
     end
+
+    ActiveSupport.run_load_hooks(:doorkeeper_metal_controller, self)
   end
 end

--- a/spec/controllers/application_metal_controller.rb
+++ b/spec/controllers/application_metal_controller.rb
@@ -1,0 +1,10 @@
+require 'spec_helper_integration'
+
+describe Doorkeeper::ApplicationMetalController do
+  it 'lazy run hooks' do
+    i = 0
+    ActiveSupport.on_load(:doorkeeper_metal_controller) { i += 1 }
+
+    expect(i).to eq 1
+  end
+end

--- a/spec/controllers/application_metal_controller.rb
+++ b/spec/controllers/application_metal_controller.rb
@@ -1,7 +1,7 @@
-require 'spec_helper_integration'
+require "spec_helper_integration"
 
 describe Doorkeeper::ApplicationMetalController do
-  it 'lazy run hooks' do
+  it "lazy run hooks" do
     i = 0
     ActiveSupport.on_load(:doorkeeper_metal_controller) { i += 1 }
 


### PR DESCRIPTION
Add the feature in [issue 472](https://github.com/doorkeeper-gem/doorkeeper/issues/472)

Example: https://github.com/hongxingshi/doorkeeper_hooks_example

