### PR TITLE
fix issue with per_form csrf token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ if ENV['rails'].start_with?('5')
 end
 
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
-gem "sqlite3", platform: [:ruby, :mswin, :mingw]
-
+gem "sqlite3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 gemspec

--- a/app/views/doorkeeper/applications/_delete_form.html.erb
+++ b/app/views/doorkeeper/applications/_delete_form.html.erb
@@ -1,5 +1,4 @@
 <%- submit_btn_css ||= 'btn btn-link' %>
-<%= form_tag oauth_application_path(application) do %>
-  <input type="hidden" name="_method" value="delete">
+<%= form_tag oauth_application_path(application), method: :delete do %>
   <%= submit_tag t('doorkeeper.applications.buttons.destroy'), onclick: "return confirm('#{ t('doorkeeper.applications.confirmations.destroy') }')", class: submit_btn_css %>
 <% end %>

--- a/app/views/doorkeeper/authorized_applications/_delete_form.html.erb
+++ b/app/views/doorkeeper/authorized_applications/_delete_form.html.erb
@@ -1,5 +1,4 @@
 <%- submit_btn_css ||= 'btn btn-link' %>
-<%= form_tag oauth_authorized_application_path(application) do %>
-  <input type="hidden" name="_method" value="delete">
+<%= form_tag oauth_authorized_application_path(application), method: :delete do %>
   <%= submit_tag t('doorkeeper.authorized_applications.buttons.revoke'), onclick: "return confirm('#{ t('doorkeeper.authorized_applications.confirmations.revoke') }')", class: submit_btn_css %>
 <% end %>


### PR DESCRIPTION
### Issue

The "destroy" button for application fails with `ActionController::InvalidAuthenticityToken`
### Explanation

Rails may check authenticity token with a 'per form' policy. When doing so, the authenticity token is generated with the form_tag and depends on the url and the method.
The form to delete application is not build with a simple call form_tag but also uses an <input> field for the method. This prevents rails from generating a suitable authenticity token.
### Fix

replace 

```
<%= form_tag target %>
<input type="hidden" name="_method" value="delete">
...
<% end %>
```

with 

```
<%= form_tag target, method: :delete %>
...
<% end %>
```
