### PR TITLE
Replace `destroy` with `delete_all` on app dependent tokens and grants

### DIFF
--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -7,8 +7,8 @@ module Doorkeeper
     include ActiveModel::MassAssignmentSecurity if defined?(::ProtectedAttributes)
 
     included do
-      has_many :access_grants, dependent: :destroy, class_name: 'Doorkeeper::AccessGrant'
-      has_many :access_tokens, dependent: :destroy, class_name: 'Doorkeeper::AccessToken'
+      has_many :access_grants, dependent: :delete_all, class_name: 'Doorkeeper::AccessGrant'
+      has_many :access_tokens, dependent: :delete_all, class_name: 'Doorkeeper::AccessToken'
 
       validates :name, :secret, :uid, presence: true
       validates :uid, uniqueness: true


### PR DESCRIPTION
Fixes #888 by specifying that access tokens and grants for an application are deleted using a single SQL query each rather than loading each one and running callbacks.

Re: Tests: The tests still pass but I'm not sure if it's reasonable to test that the number of queries executed during deletion is reduced. I'm happy to take advice on how best to handle this.