### PR TITLE
Implement nonce tracking (WIP, open questions)

### DIFF
--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -26,6 +26,7 @@
       <%= hidden_field_tag :state, @pre_auth.state %>
       <%= hidden_field_tag :response_type, @pre_auth.response_type %>
       <%= hidden_field_tag :scope, @pre_auth.scope %>
+      <%= hidden_field_tag :nonce, @pre_auth.nonce %>
       <%= submit_tag t('doorkeeper.authorizations.buttons.authorize'), class: "btn btn-success btn-lg btn-block" %>
     <% end %>
     <%= form_tag oauth_authorization_path, method: :delete do %>
@@ -34,6 +35,7 @@
       <%= hidden_field_tag :state, @pre_auth.state %>
       <%= hidden_field_tag :response_type, @pre_auth.response_type %>
       <%= hidden_field_tag :scope, @pre_auth.scope %>
+      <%= hidden_field_tag :nonce, @pre_auth.nonce %>
       <%= submit_tag t('doorkeeper.authorizations.buttons.deny'), class: "btn btn-danger btn-lg btn-block" %>
     <% end %>
   </div>

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -15,7 +15,8 @@ module Doorkeeper
             resource_owner_id: resource_owner.id,
             expires_in: configuration.authorization_code_expires_in,
             redirect_uri: pre_auth.redirect_uri,
-            scopes: pre_auth.scopes.to_s
+            scopes: pre_auth.scopes.to_s,
+            nonce: pre_auth.nonce
           )
         end
 

--- a/lib/doorkeeper/oauth/client_credentials_request.rb
+++ b/lib/doorkeeper/oauth/client_credentials_request.rb
@@ -8,7 +8,7 @@ module Doorkeeper
       include Validations
       include OAuth::RequestConcern
 
-      attr_accessor :server, :client, :original_scopes
+      attr_accessor :server, :client, :original_scopes, :nonce
       attr_reader :response
       attr_writer :issuer
 
@@ -25,6 +25,7 @@ module Doorkeeper
         @server = server
         @response = nil
         @original_scopes = parameters[:scope]
+        @nonce = parameters[:nonce]
       end
 
       def access_token

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -10,7 +10,7 @@ module Doorkeeper
       validate :scopes,         error: :invalid_scope
 
       attr_accessor :server, :client, :resource_owner, :parameters,
-                    :access_token
+                    :access_token, :nonce
 
       def initialize(server, client, resource_owner, parameters = {})
         @server          = server
@@ -18,6 +18,7 @@ module Doorkeeper
         @client          = client
         @parameters      = parameters
         @original_scopes = parameters[:scope]
+        @nonce           = parameters[:nonce]
       end
 
       private

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -8,7 +8,7 @@ module Doorkeeper
       validate :scopes, error: :invalid_scope
       validate :redirect_uri, error: :invalid_redirect_uri
 
-      attr_accessor :server, :client, :response_type, :redirect_uri, :state
+      attr_accessor :server, :client, :response_type, :redirect_uri, :state, :nonce
       attr_writer   :scope
 
       def initialize(server, client, attrs = {})
@@ -18,6 +18,7 @@ module Doorkeeper
         @redirect_uri  = attrs[:redirect_uri]
         @scope         = attrs[:scope]
         @state         = attrs[:state]
+        @nonce         = attrs[:nonce]
       end
 
       def authorizable?


### PR DESCRIPTION
This is a proof-of-concept to store `nonce` parameters passed in the pre-authorization stage, to be able to return them later in the token response etc.

My motivation to add this feature is for `doorkeeper-openid_connect`, which requires nonce support for clients that use it, and returns the nonce value as part of the JWT-encoded ID token ([spec reference](http://openid.net/specs/openid-connect-core-1_0.html#NonceNotes))

I'm not entirely sure if it has any use outside of OpenID Connect, the OAuth 2.0 RFCs ([6749](https://tools.ietf.org/html/rfc6749), [6819](https://tools.ietf.org/html/rfc6819)) mention nonces only in passing without further references. If they only make sense for OpenID Connect I'll probably look for other ways to make Doorkeeper more extensible, so I can implement these changes in the OpenID Connect gem instead. The main reason I tried doing it in Doorkeeper first is because I can just add another column to the `access_grants` table to store the nonces, which would be trickier in an extension gem.

So my questions to you:
- Do you have any more information on nonce usage in OAuth2, especially how they should be returned?
- Do you think the current approach makes sense, or would you prefer to keep this functionality out of the main Doorkeeper code?

Some relevant PRs I found:
- [a previous experiment to add nonces](https://github.com/doorkeeper-gem/doorkeeper/pull/476)
- [making pre-authorization fields more dynamic](https://github.com/doorkeeper-gem/doorkeeper/pull/420)

Pending tasks:
- [ ] add specs
- [ ] add migration to add `nonce` column
- [ ] check all flows (I only tested the code flow for now)