### PR TITLE
Pessimistic Gemfile rspec-rails dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "rails", "~> #{ENV["rails"]}"
 
 if ENV['rails'].start_with?('5')
-  gem "rspec-rails", "3.5.2"
+  gem "rspec-rails", "~> 3.5"
 end
 
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby


### PR DESCRIPTION
No need to lock rspec-rails on some specific version (like "3.5.2") and update
it with every new release. Rspec follows Semantic Versioning so we can make
a pessimistic dependency for it (>= 3.5, < 4).