### PR TITLE
Fix lookup for matching tokens when application has additional scopes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 - [#1032] Refactor BaseRequest callbacks into configurable lambdas
 - [#1040] Clear mixins from ActiveRecord DSL and save only overridable API. It
   allows to use this mixins in Doorkeeper ORM extensions with minimum code boilerplate.
+- [#907] Fix lookup for matching tokens in certain edge-cases
 
 ## 4.3.0
 

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -70,9 +70,12 @@ module Doorkeeper::OAuth
     end
 
     it 'skips token creation if there is a matching one' do
+      scopes = grant.scopes
+
       Doorkeeper.configure do
         orm DOORKEEPER_ORM
         reuse_access_token
+        default_scopes(*scopes)
       end
 
       FactoryBot.create(:access_token, application_id: client.id,

--- a/spec/lib/oauth/client_credentials/creator_spec.rb
+++ b/spec/lib/oauth/client_credentials/creator_spec.rb
@@ -5,6 +5,10 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
     let(:client) { FactoryBot.create :application }
     let(:scopes) { Doorkeeper::OAuth::Scopes.from_string('public') }
 
+    before do
+      default_scopes_exist :public
+    end
+
     it 'creates a new token' do
       expect do
         subject.call(client, scopes)

--- a/spec/requests/flows/skip_authorization_spec.rb
+++ b/spec/requests/flows/skip_authorization_spec.rb
@@ -15,13 +15,24 @@ feature 'Skip authorization form' do
     end
 
     scenario 'skips the authorization and return a new grant code' do
-      client_is_authorized(@client, @resource_owner, scopes: 'public')
-      visit authorization_endpoint_url(client: @client)
+      client_is_authorized(@client, @resource_owner, scopes: "public")
+      visit authorization_endpoint_url(client: @client, scope: "public")
 
-      i_should_not_see 'Authorize'
+      i_should_not_see "Authorize"
       client_should_be_authorized @client
       i_should_be_on_client_callback @client
-      url_should_have_param 'code', Doorkeeper::AccessGrant.first.token
+      url_should_have_param "code", Doorkeeper::AccessGrant.first.token
+    end
+
+    scenario "skips the authorization if other scopes are not requested" do
+      client_exists scopes: "public read write"
+      client_is_authorized(@client, @resource_owner, scopes: "public")
+      visit authorization_endpoint_url(client: @client, scope: "public")
+
+      i_should_not_see "Authorize"
+      client_should_be_authorized @client
+      i_should_be_on_client_callback @client
+      url_should_have_param "code", Doorkeeper::AccessGrant.first.token
     end
 
     scenario 'does not skip authorization when scopes differ (new request has fewer scopes)' do
@@ -41,12 +52,6 @@ feature 'Skip authorization form' do
       visit authorization_endpoint_url(client: @client, scope: 'public')
       click_on 'Authorize'
       access_grant_should_have_scopes :public
-    end
-
-    scenario 'doesn not skip authorization when scopes are greater' do
-      client_is_authorized(@client, @resource_owner, scopes: 'public')
-      visit authorization_endpoint_url(client: @client, scope: 'public write')
-      i_should_see 'Authorize'
     end
 
     scenario 'creates grant with new scope when scopes are greater' do


### PR DESCRIPTION
Follow-up to #906 

I traced the changes back to https://github.com/doorkeeper-gem/doorkeeper/commit/03008f5 and https://github.com/doorkeeper-gem/doorkeeper/pull/588, which made me realize that the existing token needs to match the requested scopes *exactly*, otherwise the user will end up with a token that has more permissions than requested. So `ScopeChecker#match?` seems to be correct, and the swapped order is already checked in `#valid?` as well. Sorry for the confusion, but I guess that can't be avoided when dealing with OAuth ;-)

Looking at `PreAuthorization#authorizable?` the scopes from the params are already verified to be present in the server/application scopes, so I think `AccessTokenMixin.matching_token_for` only needs to check if there is a token that matches the requested scopes. These changes try to accomplish that (as well as fixing the ambiguous spec descriptions), though I guess we're still abusing `ScopeChecker` a bit :)

One thing I'm still unsure about: currently only the last authorized token is checked, but what if there is a previously authorized, still-valid token matching the requested scopes? Shouldn't that also cause the authorization to be skipped? If yes I'll change the code to return the newest one matching the scopes.