### PR TITLE
Exposing InvalidTokenResponse reason.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 User-visible changes worth mentioning.
 
+- Add `InvalidTokenResponse#reason` reader method to allow read the kind of
+  invalid token error.
+
 ## master
 
 ## 4.2.0

--- a/lib/doorkeeper/oauth/invalid_token_response.rb
+++ b/lib/doorkeeper/oauth/invalid_token_response.rb
@@ -1,6 +1,8 @@
 module Doorkeeper
   module OAuth
     class InvalidTokenResponse < ErrorResponse
+      attr_reader :reason
+
       def self.from_access_token(access_token, attributes = {})
         reason = case
                  when access_token.try(:revoked?)

--- a/spec/lib/oauth/invalid_token_response_spec.rb
+++ b/spec/lib/oauth/invalid_token_response_spec.rb
@@ -5,49 +5,49 @@ require 'doorkeeper/oauth/invalid_token_response'
 
 module Doorkeeper::OAuth
   describe InvalidTokenResponse do
-    describe '#name' do
+    describe "#name" do
       it  { expect(subject.name).to eq(:invalid_token) }
     end
 
-    describe '#status' do
+    describe "#status" do
       it { expect(subject.status).to eq(:unauthorized) }
     end
 
     describe :from_access_token do
       let(:response) { InvalidTokenResponse.from_access_token(access_token) }
 
-      context 'revoked' do
+      context "revoked" do
         let(:access_token) { double(revoked?: true, expired?: true) }
 
-        it 'sets a description' do
-          expect(response.description).to include('revoked')
+        it "sets a description" do
+          expect(response.description).to include("revoked")
         end
 
-        it 'sets the reason' do
+        it "sets the reason" do
           expect(response.reason).to eq(:revoked)
         end
       end
 
-      context 'expired' do
+      context "expired" do
         let(:access_token) { double(revoked?: false, expired?: true) }
 
-        it 'sets a description' do
-          expect(response.description).to include('expired')
+        it "sets a description" do
+          expect(response.description).to include("expired")
         end
 
-        it 'sets the reason' do
+        it "sets the reason" do
           expect(response.reason).to eq(:expired)
         end
       end
 
-      context 'unkown' do
+      context "unkown" do
         let(:access_token) { double(revoked?: false, expired?: false) }
 
-        it 'sets a description' do
-          expect(response.description).to include('invalid')
+        it "sets a description" do
+          expect(response.description).to include("invalid")
         end
 
-        it 'sets the reason' do
+        it "sets the reason" do
           expect(response.reason).to eq(:unknown)
         end
       end

--- a/spec/lib/oauth/invalid_token_response_spec.rb
+++ b/spec/lib/oauth/invalid_token_response_spec.rb
@@ -14,14 +14,42 @@ module Doorkeeper::OAuth
     end
 
     describe :from_access_token do
-      it 'revoked' do
-        response = InvalidTokenResponse.from_access_token double(revoked?: true, expired?: true)
-        expect(response.description).to include('revoked')
+      let(:response) { InvalidTokenResponse.from_access_token(access_token) }
+
+      context 'revoked' do
+        let(:access_token) { double(revoked?: true, expired?: true) }
+
+        it 'sets a description' do
+          expect(response.description).to include('revoked')
+        end
+
+        it 'sets the reason' do
+          expect(response.reason).to eq(:revoked)
+        end
       end
 
-      it 'expired' do
-        response = InvalidTokenResponse.from_access_token double(revoked?: false, expired?: true)
-        expect(response.description).to include('expired')
+      context 'expired' do
+        let(:access_token) { double(revoked?: false, expired?: true) }
+
+        it 'sets a description' do
+          expect(response.description).to include('expired')
+        end
+
+        it 'sets the reason' do
+          expect(response.reason).to eq(:expired)
+        end
+      end
+
+      context 'unkown' do
+        let(:access_token) { double(revoked?: false, expired?: false) }
+
+        it 'sets a description' do
+          expect(response.description).to include('invalid')
+        end
+
+        it 'sets the reason' do
+          expect(response.reason).to eq(:unknown)
+        end
       end
     end
   end


### PR DESCRIPTION
This PR is for making it possible to read the reason of an `InvalidTokenResponse` error. 

**Motivation:**

When trying to render a custom unauthorized response using [customize the response body when unauthorized][1] I needed to fetch the type of error so that the consumer could handle the response differently based on the type.

For example, if the error is `expired` they could try to refresh the token, but if it's `revoked`, the process would be different.

When I was implementing the custom method, I needed to do some metaprogramming to fetch the error type, it would be nice to avoid doing this.

What I did:

```ruby
def doorkeeper_unauthorized_render_options(error: nil)
  {
    json: {
      error: {
        code: error.instance_variable_get(:@reason), # <<<<<<< here
        title: error.description
      }
    }
  }
end
```

**Solution**

So my idea with this pull request is to expose the `reason` variable within the `InvalidTokenResponse`class so that I can access the reason. This then allows me to do the following instead:

```ruby
def doorkeeper_unauthorized_render_options(error: nil)
  {
    json: {
      error: {
        code: error.reason, # <<<<<<< here
        title: error.description
      }
    }
  }
end
``` 

ps: I'll squash the commits, after the review. :)

What do you think?

[1]: https://github.com/doorkeeper-gem/doorkeeper/wiki/Customizing-the-response-body-when-unauthorized