### PR TITLE
Remove unnecessarily extended ActiveSupport::Concern

### DIFF
--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -3,8 +3,6 @@
 module Doorkeeper
   module Helpers
     module Controller
-      extend ActiveSupport::Concern
-
       private
 
       def authenticate_resource_owner!

--- a/lib/doorkeeper/rails/helpers.rb
+++ b/lib/doorkeeper/rails/helpers.rb
@@ -1,8 +1,6 @@
 module Doorkeeper
   module Rails
     module Helpers
-      extend ActiveSupport::Concern
-
       def doorkeeper_authorize!(*scopes)
         @_doorkeeper_scopes = scopes.presence || Doorkeeper.configuration.default_scopes
 


### PR DESCRIPTION
These modules do not use `included` nor `ClassMethods`, so they don't have to extend ActiveSupport::Concern. 