### PR TITLE
Update doorkeeper to be used with grape >= 0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ You can pass any option `before_action` accepts, such as `if`, `only`,
 
 ### Protect your API with OAuth when using Grape
 
-As of [PR 567] doorkeeper has helpers for Grape. One of them is
+As of [PR 567] doorkeeper has helpers for Grape >= 0.10. One of them is
 `doorkeeper_authorize!` and can be used in a similar way as an example above.
 Note that you have to use `require 'doorkeeper/grape/helpers'` and
 `helpers Doorkeeper::Grape::Helpers`.
@@ -196,6 +196,11 @@ module API
 
       before do
         doorkeeper_authorize!
+      end
+
+      route_setting :scopes, ['user:email']
+      get :emails do
+        [{'email' => current_user.email}]
       end
 
       # ...

--- a/lib/doorkeeper/grape/helpers.rb
+++ b/lib/doorkeeper/grape/helpers.rb
@@ -3,12 +3,13 @@ require 'doorkeeper/grape/authorization_decorator'
 module Doorkeeper
   module Grape
     module Helpers
+      # These helpers are for grape >= 0.10
       extend ::Grape::API::Helpers
       include Doorkeeper::Rails::Helpers
 
       # endpoint specific scopes > parameter scopes > default scopes
       def doorkeeper_authorize!(*scopes)
-        endpoint_scopes = env['api.endpoint'].options[:route_options][:scopes]
+        endpoint_scopes = env["api.endpoint"].route_setting(:scopes)
         scopes = if endpoint_scopes
                    Doorkeeper::OAuth::Scopes.from_array(endpoint_scopes)
                  elsif scopes && !scopes.empty?


### PR DESCRIPTION
Grape has since long discouraged the use of options[:route_options] for custom additions. Since version 0.10 it cannot be used anymore like setup in the helpers in doorkeeper (grape is currently at 0.19.1).

This PR fixes the behaviour to properly work with grape, and describes a bit better in the example how you could actually use it and set it up (if you want I can elaborate more in the readme).

I think with this example and the change, most people should have enough with doorkeeper as is, and not need wine_bouncer at all.