### PR TITLE
Change find_by to where/first to be mongoid friendly

### DIFF
--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -36,7 +36,7 @@ module Doorkeeper
       #   if there is no record with such token
       #
       def by_token(token)
-        find_by(token: token.to_s)
+        where(token: token.to_s).first
       end
     end
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -44,7 +44,7 @@ module Doorkeeper
       #   if there is no record with such token
       #
       def by_token(token)
-        find_by(token: token.to_s)
+        where(token: token.to_s).first
       end
 
       # Returns an instance of the Doorkeeper::AccessToken
@@ -57,7 +57,7 @@ module Doorkeeper
       #   if there is no record with such refresh token
       #
       def by_refresh_token(refresh_token)
-        find_by(refresh_token: refresh_token.to_s)
+        where(refresh_token: refresh_token.to_s).first
       end
 
       # Revokes AccessToken records that have not been revoked and associated
@@ -169,9 +169,9 @@ module Doorkeeper
       #
       def last_authorized_token_for(application_id, resource_owner_id)
         send(order_method, created_at_desc).
-          find_by(application_id: application_id,
-                  resource_owner_id: resource_owner_id,
-                  revoked_at: nil)
+          where(application_id: application_id,
+                resource_owner_id: resource_owner_id,
+                revoked_at: nil).first
       end
     end
 

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -28,7 +28,7 @@ module Doorkeeper
       #   if there is no record with such credentials
       #
       def by_uid_and_secret(uid, secret)
-        find_by(uid: uid.to_s, secret: secret.to_s)
+        where(uid: uid.to_s, secret: secret.to_s).first
       end
 
       # Returns an instance of the Doorkeeper::Application with specific UID.
@@ -39,7 +39,7 @@ module Doorkeeper
       #   if there is no record with such UID
       #
       def by_uid(uid)
-        find_by(uid: uid.to_s)
+        where(uid: uid.to_s).first
       end
     end
 


### PR DESCRIPTION
Using find_by introduces breaking behavior for applications using Mongoid5 with doorkeeper-mongodb without the `raise_if_not_found` configuration flag set.

Setting the `raise_if_not_found` configuration flag produces significant behavior changes in applications using Mongoid throughout the application including calls to `find` and `reload`