### PR TITLE
Specify correct wikki pages from the way client credentials is config ured on doorkeeper initializer.

### DIFF
--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -60,13 +60,15 @@ Doorkeeper.configure do
   # Change the way client credentials are retrieved from the request object.
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
   # falls back to the `:client_id` and `:client_secret` params from the `params` object.
-  # Check out the wiki for more information on customization
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
   # client_credentials :from_basic, :from_params
 
   # Change the way access token is authenticated from the request object.
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
   # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
-  # Check out the wiki for more information on customization
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
   # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
 
   # Change the native redirect uri for client apps


### PR DESCRIPTION
Doorkeeper currently have 35 pages of wikis, directing to the right wikis will save time for user. I found it difficult to find corresponding wiki, hopefully this change will help people having the same problem as i do.

I didn't add to news as it is minor changes. Will add if it required.