### PR TITLE
Small `Doorkeeper::Rails::Routes` improvements

### DIFF
--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -3,7 +3,7 @@ require 'doorkeeper/rails/routes/mapper'
 
 module Doorkeeper
   module Rails
-    class Routes
+    class Routes # :nodoc:
       module Helper
         # TODO: options hash is not being used
         def use_doorkeeper(options = {}, &block)
@@ -15,15 +15,14 @@ module Doorkeeper
         ActionDispatch::Routing::Mapper.send :include, Doorkeeper::Rails::Routes::Helper
       end
 
-      attr_accessor :routes
+      attr_reader :routes
 
       def initialize(routes, &block)
         @routes = routes
-        @block = block
+        @mapping = Mapper.new.map(&block)
       end
 
       def generate_routes!(options)
-        @mapping = Mapper.new.map(&@block)
         routes.scope options[:scope] || 'oauth', as: 'oauth' do
           map_route(:authorizations, :authorization_routes)
           map_route(:tokens, :token_routes)

--- a/lib/doorkeeper/rails/routes/mapper.rb
+++ b/lib/doorkeeper/rails/routes/mapper.rb
@@ -1,9 +1,9 @@
 module Doorkeeper
   module Rails
-    class Routes
+    class Routes # :nodoc:
       class Mapper
-        def initialize(mapping = Mapping.new)
-          @mapping = mapping
+        def initialize
+          @mapping = Mapping.new
         end
 
         def map(&block)

--- a/lib/doorkeeper/rails/routes/mapping.rb
+++ b/lib/doorkeeper/rails/routes/mapping.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   module Rails
-    class Routes
+    class Routes # :nodoc:
       class Mapping
         attr_accessor :controllers, :as, :skips
 


### PR DESCRIPTION
- `nodoc`'ed all of the classes... not public API!
- Removed default of creating a new `Mapping.new`... we never pass one
  in... just create it within `initialize
- Generate `@mapping` earlier... remove `block` instance variable...
- Change `attr_accessor` to `attr_reader` for `routes`