### PR TITLE
Move two helper methods to respective classes

### DIFF
--- a/lib/doorkeeper/request/authorization_code.rb
+++ b/lib/doorkeeper/request/authorization_code.rb
@@ -3,7 +3,7 @@ require 'doorkeeper/request/strategy'
 module Doorkeeper
   module Request
     class AuthorizationCode < Strategy
-      delegate :grant, :client, :parameters, to: :server
+      delegate :client, :parameters, to: :server
 
       def request
         @request ||= OAuth::AuthorizationCodeRequest.new(
@@ -13,6 +13,12 @@ module Doorkeeper
           parameters
         )
       end
+
+      private
+
+        def grant
+          AccessGrant.by_token(parameters[:code])
+        end
     end
   end
 end

--- a/lib/doorkeeper/request/authorization_code.rb
+++ b/lib/doorkeeper/request/authorization_code.rb
@@ -16,9 +16,9 @@ module Doorkeeper
 
       private
 
-        def grant
-          AccessGrant.by_token(parameters[:code])
-        end
+      def grant
+        AccessGrant.by_token(parameters[:code])
+      end
     end
   end
 end

--- a/lib/doorkeeper/request/refresh_token.rb
+++ b/lib/doorkeeper/request/refresh_token.rb
@@ -6,7 +6,7 @@ module Doorkeeper
       delegate :credentials, :parameters, to: :server
 
       def refresh_token
-        server.current_refresh_token
+        AccessToken.by_refresh_token(parameters[:refresh_token])
       end
 
       def request

--- a/lib/doorkeeper/server.rb
+++ b/lib/doorkeeper/server.rb
@@ -33,14 +33,6 @@ module Doorkeeper
       context.send :current_resource_owner
     end
 
-    def current_refresh_token
-      AccessToken.by_refresh_token(parameters[:refresh_token])
-    end
-
-    def grant
-      AccessGrant.by_token(parameters[:code])
-    end
-
     # TODO: Use configuration and evaluate proper context on block
     def resource_owner
       context.send :resource_owner_from_credentials


### PR DESCRIPTION
These two methods are only used once. Moved them to their respective
classes, to keep `Doorkeeper::Server` more generic.