### PR TITLE
Handle random newlines in the grant_type param

### DIFF
--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -71,7 +71,7 @@ module Doorkeeper
     end
 
     def strategy
-      @strategy ||= server.token_request (params[:grant_type] && params[:grant_type].chomp)
+      @strategy ||= server.token_request params[:grant_type].try(:chomp)
     end
 
     def authorize_response

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -71,7 +71,7 @@ module Doorkeeper
     end
 
     def strategy
-      @strategy ||= server.token_request params[:grant_type].chomp
+      @strategy ||= server.token_request (params[:grant_type] && params[:grant_type].chomp)
     end
 
     def authorize_response

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -71,7 +71,7 @@ module Doorkeeper
     end
 
     def strategy
-      @strategy ||= server.token_request params[:grant_type]
+      @strategy ||= server.token_request params[:grant_type].chomp
     end
 
     def authorize_response

--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -16,7 +16,7 @@ module Doorkeeper
     end
 
     def token_strategy(grant_type)
-      get_strategy grant_type, token_grant_types
+      get_strategy grant_type.chomp, token_grant_types
     rescue NameError
       raise Errors::InvalidTokenStrategy
     end

--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -16,7 +16,7 @@ module Doorkeeper
     end
 
     def token_strategy(grant_type)
-      get_strategy grant_type.chomp, token_grant_types
+      get_strategy grant_type, token_grant_types
     rescue NameError
       raise Errors::InvalidTokenStrategy
     end


### PR DESCRIPTION
When x-www-form-encoded data is posted to /oauth/token, the possibility of an invisible newline at the end can suck away more development time than one might want to spend on a Saturday morning.

Tests still pass. 

I don't know if this is the right place to handle it, but in lieu of more descriptive error messages (at least in development), this obviates the problem.