### PR TITLE
Deprecate `Doorkeeper#configured?`, `Doorkeeper#database_installed?`,…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [] Deprecate `Doorkeeper#configured?`, `Doorkeeper#database_installed?`, and
+  `Doorkeeper#installed?`
 - [#909] Add `InvalidTokenResponse#reason` reader method to allow read the kind
   of invalid token error.
 - [#928] Test against more recent Ruby versions

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -49,16 +49,21 @@ require 'doorkeeper/rails/helpers'
 
 require 'doorkeeper/orm/active_record'
 
+require 'active_support/deprecation'
+
 module Doorkeeper
   def self.configured?
+    ActiveSupport::Deprecation.warn "Method `Doorkeeper#configured?` has been deprecated without replacement."
     @config.present?
   end
 
   def self.database_installed?
+    ActiveSupport::Deprecation.warn "Method `Doorkeeper#database_installed?` has been deprecated without replacement."
     [AccessToken, AccessGrant, Application].all?(&:table_exists?)
   end
 
   def self.installed?
+    ActiveSupport::Deprecation.warn "Method `Doorkeeper#installed?` has been deprecated without replacement."
     configured? && database_installed?
   end
 

--- a/spec/lib/doorkeeper_spec.rb
+++ b/spec/lib/doorkeeper_spec.rb
@@ -43,6 +43,13 @@ describe Doorkeeper do
         expect(Doorkeeper.configured?).to eq(false)
       end
     end
+
+    it "is deprecated" do
+      expect(ActiveSupport::Deprecation).to receive(:warn).
+        with("Method `Doorkeeper#configured?` has been deprecated without replacement.")
+
+      Doorkeeper.configured?
+    end
   end
 
   describe "#database_installed?" do
@@ -62,26 +69,44 @@ describe Doorkeeper do
     end
 
     context "all tables exist" do
-      it "returns true" do
+      before do
         klass = double table_exists?: true
 
         Doorkeeper.const_set(:AccessToken, klass)
         Doorkeeper.const_set(:AccessGrant, klass)
         Doorkeeper.const_set(:Application, klass)
+      end
 
+      it "returns true" do
         expect(Doorkeeper.database_installed?).to eq(true)
+      end
+
+      it "is deprecated" do
+        expect(ActiveSupport::Deprecation).to receive(:warn).
+          with("Method `Doorkeeper#database_installed?` has been deprecated without replacement.")
+
+        Doorkeeper.database_installed?
       end
     end
 
     context "all tables do not exist" do
-      it "returns false" do
+      before do
         klass = double table_exists?: false
 
         Doorkeeper.const_set(:AccessToken, klass)
         Doorkeeper.const_set(:AccessGrant, klass)
         Doorkeeper.const_set(:Application, klass)
+      end
 
+      it "returns false" do
         expect(Doorkeeper.database_installed?).to eq(false)
+      end
+
+      it "is deprecated" do
+        expect(ActiveSupport::Deprecation).to receive(:warn).
+          with("Method `Doorkeeper#database_installed?` has been deprecated without replacement.")
+
+        Doorkeeper.database_installed?
       end
     end
   end
@@ -107,6 +132,19 @@ describe Doorkeeper do
       it "returns false" do
         expect(Doorkeeper.installed?).to eq(false)
       end
+    end
+
+    it "is deprecated" do
+      expect(ActiveSupport::Deprecation).to receive(:warn).
+        with("Method `Doorkeeper#configured?` has been deprecated without replacement.")
+
+      expect(ActiveSupport::Deprecation).to receive(:warn).
+        with("Method `Doorkeeper#database_installed?` has been deprecated without replacement.")
+
+      expect(ActiveSupport::Deprecation).to receive(:warn).
+        with("Method `Doorkeeper#installed?` has been deprecated without replacement.")
+
+      Doorkeeper.installed?
     end
   end
 end


### PR DESCRIPTION
… and `Doorkeeper#installed?`

Are unused, so let's deprecate and get ready to remove them.