### PR TITLE
Add test coverage tracking using Coveralls

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.1"
 
   s.add_development_dependency "capybara"
+  s.add_development_dependency "coveralls"
   s.add_development_dependency "database_cleaner", "~> 1.5.3"
   s.add_development_dependency "factory_girl", "~> 4.7.0"
   s.add_development_dependency "generator_spec", "~> 0.9.3"

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -1,3 +1,8 @@
+if ENV['TRAVIS']
+  require 'coveralls'
+  Coveralls.wear!('rails') { add_filter('/spec/') }
+end
+
 ENV['RAILS_ENV'] ||= 'test'
 TABLE_NAME_PREFIX = ENV['table_name_prefix'] || nil
 TABLE_NAME_SUFFIX = ENV['table_name_suffix'] || nil


### PR DESCRIPTION
As part of #926,

This change adds test coverage tracking using [Coveralls](https://coveralls.io). I originally tried to set it up using CodeClimate since this project already uses it, but they don't support reporting when using a build matrix.

I believe a maintainer will need to log in to Coveralls and add the project, but that should be all that's required!

Let me know if there's any changes necessary. Thanks!
