### PR TITLE
Fix comparing Scopes to non-enumerable instances

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#948] Make Scopes.<=> work with any "other" value.
 - [#970] Escape certain attributes in authorization forms.
 
 ## 4.2.5

--- a/lib/doorkeeper/oauth/scopes.rb
+++ b/lib/doorkeeper/oauth/scopes.rb
@@ -53,7 +53,11 @@ module Doorkeeper
       end
 
       def <=>(other)
-        map(&:to_s).sort <=> other.map(&:to_s).sort
+        if other.respond_to?(:map)
+          map(&:to_s).sort <=> other.map(&:to_s).sort
+        else
+          super
+        end
       end
 
       def &(other)

--- a/spec/lib/oauth/scopes_spec.rb
+++ b/spec/lib/oauth/scopes_spec.rb
@@ -89,6 +89,10 @@ module Doorkeeper::OAuth
       it 'differs from another set of scopes when scopes are not the same' do
         expect(Scopes.from_string('public write')).not_to eq(Scopes.from_string('write'))
       end
+
+      it "does not raise an error when compared to a non-enumerable object" do
+        expect { Scopes.from_string("public") == false }.not_to raise_error
+      end
     end
 
     describe '#has_scopes?' do


### PR DESCRIPTION
For example, `scopes == false` raises a `NoMethodError` that says `#map` is not defined for `false`.