### PR TITLE
Explicitly add controller actions

### DIFF
--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -9,6 +9,8 @@ module Doorkeeper
       @applications = Application.all
     end
 
+    def show; end
+
     def new
       @application = Application.new
     end
@@ -22,6 +24,8 @@ module Doorkeeper
         render :new
       end
     end
+
+    def edit; end
 
     def update
       if @application.update_attributes(application_params)


### PR DESCRIPTION
In https://github.com/doorkeeper-gem/doorkeeper/wiki/Customizing-routes, it is encouraged in some circumstances to inherit from `Doorkeeper::ApplicationsController`. In some cases, it works well to add some code to all the actions (in my case, authorization).

If I do this, it looks something like:

```ruby
def index
  authorize! :index, :oauth_application
  super
end
```

However, this doesn't work for the edit or show actions, as they rely on implicit logic from Rails. This patch allows super to be called for them, which makes it more robust in case you ever add logic to those methods.

Thanks!