### PR TITLE
Change to allow optional scopes in the authorization code request

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ User-visible changes worth mentioning.
 
 ## master
 
+- Change to allow optional scopes in the authorization code request
+
 ## 4.2.5
 
 - [#936] Deprecate `Doorkeeper#configured?`, `Doorkeeper#database_installed?`, and

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -13,6 +13,7 @@ module Doorkeeper
         @client = client
         @grant  = grant
         @redirect_uri = parameters[:redirect_uri]
+        @original_scopes = parameters[:scope]
       end
 
       private


### PR DESCRIPTION
As with Password Access Token Request, this is a change to make the optional scope available for authorization code request.

I cannot know the reason why this is limited to the default scopes.
If I should not make this change, please let me know why.