### PR TITLE
Remove the dead code for legacy Rails

### DIFF
--- a/app/controllers/doorkeeper/application_controller.rb
+++ b/app/controllers/doorkeeper/application_controller.rb
@@ -4,11 +4,7 @@ module Doorkeeper
 
     include Helpers::Controller
 
-    if ::Rails.version.to_i < 4
-      protect_from_forgery
-    else
-      protect_from_forgery with: :exception
-    end
+    protect_from_forgery with: :exception
 
     helper 'doorkeeper/dashboard'
   end


### PR DESCRIPTION
The Rails 3.x support is dropped since 02949f96.