### PR TITLE
Compare redirect_uri and grant uri without query

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ User-visible changes worth mentioning.
 
 ## master
 
+- Redirect URI is checked without query params within AuthorizationCodeRequest.
+
 ## 4.2.5
 
 - [#936] Deprecate `Doorkeeper#configured?`, `Doorkeeper#database_installed?`, and

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -44,7 +44,7 @@ module Doorkeeper
       end
 
       def validate_redirect_uri
-        grant.redirect_uri == redirect_uri
+        Helpers::URIChecker.valid_for_authorization?(redirect_uri, grant.redirect_uri)
       end
     end
   end

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -44,7 +44,10 @@ module Doorkeeper
       end
 
       def validate_redirect_uri
-        Helpers::URIChecker.valid_for_authorization?(redirect_uri, grant.redirect_uri)
+        Helpers::URIChecker.valid_for_authorization?(
+          redirect_uri,
+          grant.redirect_uri
+        )
       end
     end
   end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -10,9 +10,11 @@ module Doorkeeper::OAuth
     end
     let(:grant)  { FactoryGirl.create :access_grant }
     let(:client) { grant.application }
+    let(:redirect_uri) { client.redirect_uri }
+    let(:params) { { redirect_uri: redirect_uri } }
 
     subject do
-      AuthorizationCodeRequest.new server, grant, client, redirect_uri: client.redirect_uri
+      AuthorizationCodeRequest.new server, grant, client, params
     end
 
     it 'issues a new token for the client' do
@@ -75,6 +77,15 @@ module Doorkeeper::OAuth
       expect do
         subject.authorize
       end.to_not change { Doorkeeper::AccessToken.count }
+    end
+
+    context "when redirect_uri contains some query params" do
+      let(:redirect_uri) { client.redirect_uri + "?query=q" }
+
+      it "compares only host part with grant's redirect_uri" do
+        subject.validate
+        expect(subject.error).to eq(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
when doing checks from authorization code request

Related to: https://github.com/doorkeeper-gem/doorkeeper/issues/949