### PR TITLE
AccessToken.matching_token_for returns wrong results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ User-visible changes worth mentioning.
 - Small refactorings within the codebase
 - [#921] Switch to Appraisal, and test against Rails master
 - [#892] Add minimum Ruby version requirement
+- [#957] AccessToken.matching_token_for return wrong values for empty string
 
 ## 4.2.0
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -95,7 +95,7 @@ module Doorkeeper
                               resource_owner_or_id
                             end
         token = last_authorized_token_for(application.try(:id), resource_owner_id)
-        if token && scopes_match?(token.scopes, scopes, application.try(:scopes))
+        if token && scopes_match_exactly?(token.scopes, scopes, application.try(:scopes))
           token
         end
       end
@@ -116,6 +116,28 @@ module Doorkeeper
       def scopes_match?(token_scopes, param_scopes, app_scopes)
         (!token_scopes.present? && !param_scopes.present?) ||
           Doorkeeper::OAuth::Helpers::ScopeChecker.match?(
+            token_scopes.to_s,
+            param_scopes,
+            app_scopes
+          )
+      end
+
+      # Checks whether the token scopes match exactly the scopes from the parameters or
+      # Application scopes (if present).
+      #
+      # @param token_scopes [#to_s]
+      #   set of scopes (any object that responds to `#to_s`)
+      # @param param_scopes [String]
+      #   scopes from params
+      # @param app_scopes [String]
+      #   Application scopes
+      #
+      # @return [Boolean] true if all scopes are blank or exact matches
+      #   and false in other cases
+      #
+      def scopes_match_exactly?(token_scopes, param_scopes, app_scopes)
+        (!token_scopes.present? && !param_scopes.present?) ||
+          Doorkeeper::OAuth::Helpers::ScopeChecker.match_exactly?(
             token_scopes.to_s,
             param_scopes,
             app_scopes

--- a/lib/doorkeeper/oauth/helpers/scope_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/scope_checker.rb
@@ -8,6 +8,7 @@ module Doorkeeper
           def initialize(scope_str, server_scopes, application_scopes)
             @parsed_scopes = OAuth::Scopes.from_string(scope_str)
             @scope_str = scope_str
+            @server_scopes = server_scopes
             @valid_scopes = valid_scopes(server_scopes, application_scopes)
           end
 
@@ -19,6 +20,11 @@ module Doorkeeper
 
           def match?
             valid? && parsed_scopes.has_scopes?(@valid_scopes)
+          end
+
+          def match_exactly?
+            server_scopes_array = @server_scopes.to_a.uniq.sort
+            match? && (server_scopes_array == parsed_scopes.to_a.sort)
           end
 
           private
@@ -38,6 +44,10 @@ module Doorkeeper
 
         def self.match?(scope_str, server_scopes, application_scopes = nil)
           Validator.new(scope_str, server_scopes, application_scopes).match?
+        end
+
+        def self.match_exactly?(scope_str, server_scopes, application_scopes = nil)
+          Validator.new(scope_str, server_scopes, application_scopes).match_exactly?
         end
       end
     end

--- a/spec/lib/oauth/helpers/scope_checker_spec.rb
+++ b/spec/lib/oauth/helpers/scope_checker_spec.rb
@@ -4,6 +4,114 @@ require 'doorkeeper/oauth/helpers/scope_checker'
 require 'doorkeeper/oauth/scopes'
 
 module Doorkeeper::OAuth::Helpers
+  describe ScopeChecker, ".match_exactly?" do
+    let(:token_scopes) { Doorkeeper::OAuth::Scopes.new }
+    let(:server_scopes) { Doorkeeper::OAuth::Scopes.new }
+    let(:application_scopes) { Doorkeeper::OAuth::Scopes.new }
+
+    context "with application scopes" do
+      before do
+        token_scopes.add :scope
+        application_scopes.add :scope
+      end
+
+      it "returns true if scopes are the same" do
+        server_scopes.add :scope
+        expect(
+          ScopeChecker.match_exactly?(
+            token_scopes.to_s,
+            server_scopes,
+            application_scopes
+          )
+        ).to be_truthy
+      end
+
+      it "returns false if params contain extra scopes" do
+        server_scopes.add :scope, :other_scope
+        expect(
+          ScopeChecker.match_exactly?(
+            token_scopes.to_s,
+            server_scopes,
+            application_scopes
+          )
+        ).to be_falsey
+      end
+
+      it "false for empty string" do
+        expect(
+          ScopeChecker.match_exactly?(
+            token_scopes.to_s,
+            server_scopes,
+            application_scopes
+          )
+        ).to be_falsey
+      end
+
+      it "returns true if scopes are in different order" do
+        token_scopes.add :other_scope
+        application_scopes.add :other_scope
+        server_scopes.add :other_scope, :scope
+        expect(
+          ScopeChecker.match_exactly?(
+            token_scopes.to_s,
+            server_scopes,
+            application_scopes
+          )
+        ).to be_truthy
+      end
+    end
+
+    context "with only token scopes" do
+      before do
+        token_scopes.add :scope
+      end
+
+      it "returns true if scopes are the same" do
+        server_scopes.add :scope
+        expect(
+          ScopeChecker.match_exactly?(
+            token_scopes.to_s,
+            server_scopes,
+            application_scopes
+          )
+        ).to be_truthy
+      end
+
+      it "returns false if params contain extra scopes" do
+        server_scopes.add :scope, :other_scope
+        expect(
+          ScopeChecker.match_exactly?(
+            token_scopes.to_s,
+            server_scopes,
+            application_scopes
+          )
+        ).to be_falsey
+      end
+
+      it "false for empty string" do
+        expect(
+          ScopeChecker.match_exactly?(
+            token_scopes.to_s,
+            server_scopes,
+            application_scopes
+          )
+        ).to be_falsey
+      end
+
+      it "returns true if scopes are in different order" do
+        token_scopes.add :other_scope
+        server_scopes.add :other_scope, :scope
+        expect(
+          ScopeChecker.match_exactly?(
+            token_scopes.to_s,
+            server_scopes,
+            application_scopes
+          )
+        ).to be_truthy
+      end
+    end
+  end
+
   describe ScopeChecker, '.valid?' do
     let(:server_scopes) { Doorkeeper::OAuth::Scopes.new }
 

--- a/spec/lib/oauth/token_request_spec.rb
+++ b/spec/lib/oauth/token_request_spec.rb
@@ -75,6 +75,7 @@ module Doorkeeper::OAuth
 
       it 'creates a new token if scopes do not match' do
         allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
+        allow(application.scopes).to receive(:to_a).and_return(["public"])
         FactoryGirl.create(:access_token, application_id: pre_auth.client.id,
                            resource_owner_id: owner.id, scopes: '')
         expect do
@@ -86,6 +87,7 @@ module Doorkeeper::OAuth
         allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
         allow(application.scopes).to receive(:has_scopes?).and_return(true)
         allow(application.scopes).to receive(:all?).and_return(true)
+        allow(application.scopes).to receive(:to_a).and_return(["public"])
         FactoryGirl.create(:access_token, application_id: pre_auth.client.id,
                            resource_owner_id: owner.id, scopes: 'public')
 

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -370,6 +370,30 @@ module Doorkeeper
         expect(last_token).to be_nil
       end
 
+      it "does not match token if empty scope requested and token/app scopes present" do
+        application = FactoryGirl.create :application, scopes: "sample:scope"
+        app_params = {
+          application_id: application.id, scopes: "sample:scope",
+          resource_owner_id: 100
+        }
+        FactoryGirl.create :access_token, app_params
+        empty_scopes = Doorkeeper::OAuth::Scopes.from_string("")
+        last_token = AccessToken.matching_token_for(application, 100, empty_scopes)
+        expect(last_token).to be_nil
+      end
+
+      it "does not match token if scope requested contains extra scopes" do
+        application = FactoryGirl.create :application, scopes: "sample:scope"
+        app_params = {
+          application_id: application.id, scopes: "sample:scope",
+          resource_owner_id: 100
+        }
+        FactoryGirl.create :access_token, app_params
+        empty_scopes = Doorkeeper::OAuth::Scopes.from_string("sample:scope other:scope")
+        last_token = AccessToken.matching_token_for(application, 100, empty_scopes)
+        expect(last_token).to be_nil
+      end
+
       it 'returns the last created token' do
         FactoryGirl.create :access_token, default_attributes.merge(created_at: 1.day.ago)
         token = FactoryGirl.create :access_token, default_attributes


### PR DESCRIPTION
**Description**

If there is access_token and application already saved in database with matching scopes,
access_token_for returns first token, completely ignoring ‘scopes’ argument.

This happens, because in ’Doorkeeper::OAuth::ScopeChecker’ the ‘match?’ method
compares token scopes against application scopes if application scopes are present.

**Expected behaviour:**

If there is no token with scopes requested in ‘mathing_token_for’, ‘nil should be returned,
so new token could be created.

This affects custom authentication methods based on scope checking
and it is potential security problem.

**Resolves** #957