### PR TITLE
Replace Struct subclassing with block-form initialization

### DIFF
--- a/lib/doorkeeper/oauth/client/credentials.rb
+++ b/lib/doorkeeper/oauth/client/credentials.rb
@@ -1,7 +1,7 @@
 module Doorkeeper
   module OAuth
     class Client
-      class Credentials < Struct.new(:uid, :secret)
+      Credentials = Struct.new(:uid, :secret) do
         class << self
           def from_request(request, *credentials_methods)
             credentials_methods.inject(nil) do |credentials, method|

--- a/lib/doorkeeper/oauth/error.rb
+++ b/lib/doorkeeper/oauth/error.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   module OAuth
-    class Error < Struct.new(:name, :state)
+    Error = Struct.new(:name, :state) do
       def description
         I18n.translate(
           name,


### PR DESCRIPTION
Replace the Struct subclassing with block-form initialization.  According to the [the docs](https://ruby-doc.org/core-2.2.0/Struct.html), "This is the recommended way to customize a struct. Subclassing an anonymous struct creates an extra anonymous class that will never be used."

This fixes an issue we're seeing downstream in our rails project when using doorkeeper with Spring/Bootsnap.  The subclassing pattern results in differing class hierarchies when the code is loaded:

/usr/local/opt/rbenv/versions/2.3.4/gemsets/app/gems/doorkeeper-4.2.0/lib/doorkeeper/oauth/client/credentials.rb:4:in `<class:Client>': superclass mismatch for class Credentials (TypeError)