### PR TITLE
Fix to invalidate the second redirect URI when the first URI is the native URI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#976] Fix to invalidate the second redirect URI when the first URI is the native URI
 - [#1035] Allow `Application#redirect_uri=` to handle array of URIs.
 - [#1036] Allow to forbid Application redirect URI's with specific rules.
 - [#1029] Deprecate `order_method` and introduce `ordered_by`. Sort applications

--- a/app/validators/redirect_uri_validator.rb
+++ b/app/validators/redirect_uri_validator.rb
@@ -11,7 +11,7 @@ class RedirectUriValidator < ActiveModel::EachValidator
     else
       value.split.each do |val|
         uri = ::URI.parse(val)
-        break if native_redirect_uri?(uri)
+        next if native_redirect_uri?(uri)
         record.errors.add(attribute, :forbidden_uri) if forbidden_uri?(uri)
         record.errors.add(attribute, :fragment_present) unless uri.fragment.nil?
         record.errors.add(attribute, :relative_uri) if uri.scheme.nil? || uri.host.nil?

--- a/spec/validators/redirect_uri_validator_spec.rb
+++ b/spec/validators/redirect_uri_validator_spec.rb
@@ -113,4 +113,11 @@ describe RedirectUriValidator do
       expect(error).to eq('must be an HTTPS/SSL URI.')
     end
   end
+
+  context 'multiple redirect uri' do
+    it 'invalidates the second uri when the first uri is native uri' do
+      subject.redirect_uri = "urn:ietf:wg:oauth:2.0:oob\nexample.com/callback"
+      expect(subject).to be_invalid
+    end
+  end
 end


### PR DESCRIPTION
This PR should fix to invalidates the second (or further) redirect URI when multiple redirect URIs are entered and the first URI is native URI like `urn:ietf:wg:oauth:2.0:oob`.