### PR TITLE
Properly generate migrations for Rails 5.0+

### DIFF
--- a/lib/generators/doorkeeper/migration_generator.rb
+++ b/lib/generators/doorkeeper/migration_generator.rb
@@ -6,10 +6,20 @@ class Doorkeeper::MigrationGenerator < ::Rails::Generators::Base
   desc 'Installs Doorkeeper migration file.'
 
   def install
-    migration_template 'migration.rb', 'db/migrate/create_doorkeeper_tables.rb'
+    migration_template(
+      'migration.rb',
+      'db/migrate/create_doorkeeper_tables.rb',
+      migration_version: migration_version
+    )
   end
 
   def self.next_migration_number(dirname)
     ActiveRecord::Generators::Base.next_migration_number(dirname)
+  end
+
+  def migration_version
+    if Rails.version >= "5.0.0"
+      "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+    end
   end
 end

--- a/lib/generators/doorkeeper/templates/migration.rb
+++ b/lib/generators/doorkeeper/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperTables < ActiveRecord::Migration
+class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :oauth_applications do |t|
       t.string  :name,         null: false

--- a/spec/generators/migration_generator_spec.rb
+++ b/spec/generators/migration_generator_spec.rb
@@ -10,11 +10,34 @@ describe 'Doorkeeper::MigrationGenerator' do
   describe 'after running the generator' do
     before :each do
       prepare_destination
-      run_generator
     end
 
-    it 'creates a migration' do
-      assert_migration 'db/migrate/create_doorkeeper_tables.rb'
+    context 'pre Rails 5.0.0' do
+      it 'creates a migration with no version specifier' do
+        expect(Rails).to receive(:version).at_least(:once).and_return '4.2.0'
+        stub_const("Rails::VERSION::MAJOR", 4)
+        stub_const("Rails::VERSION::MINOR", 2)
+
+        run_generator
+
+        assert_migration 'db/migrate/create_doorkeeper_tables.rb' do |migration|
+          assert migration.include?("ActiveRecord::Migration\n")
+        end
+      end
+    end
+
+    context 'post Rails 5.0.0' do
+      it 'creates a migration with a version specifier' do
+        expect(Rails).to receive(:version).at_least(:once).and_return '5.0.0'
+        stub_const("Rails::VERSION::MAJOR", 5)
+        stub_const("Rails::VERSION::MINOR", 0)
+
+        run_generator
+
+        assert_migration 'db/migrate/create_doorkeeper_tables.rb' do |migration|
+          assert migration.include?("ActiveRecord::Migration[5.0]\n")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Requires a migration version number to be specified in the constant.