### PR TITLE
Rails API support

### DIFF
--- a/app/controllers/doorkeeper/application_controller.rb
+++ b/app/controllers/doorkeeper/application_controller.rb
@@ -4,8 +4,9 @@ module Doorkeeper
 
     include Helpers::Controller
 
-    protect_from_forgery with: :exception
-
-    helper 'doorkeeper/dashboard'
+    unless Doorkeeper.configuration.api_mode
+      protect_from_forgery with: :exception
+      helper 'doorkeeper/dashboard'
+    end
   end
 end

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -4,14 +4,9 @@ module Doorkeeper
 
     def new
       if pre_auth.authorizable?
-        if skip_authorization? || matching_token?
-          auth = authorization.authorize
-          redirect_to auth.redirect_uri
-        else
-          render :new
-        end
+        render_success
       else
-        render :error
+        render_error
       end
     end
 
@@ -26,6 +21,26 @@ module Doorkeeper
 
     private
 
+    def render_success
+      if skip_authorization? || matching_token?
+        auth = authorization.authorize
+        redirect_or_render auth
+      elsif Doorkeeper.configuration.api_mode
+        render json: @pre_auth
+      else
+        render :new
+      end
+    end
+
+    def render_error
+      if Doorkeeper.configuration.api_mode
+        render json: @pre_auth.error_response.body[:error_description],
+               status: :bad_request
+      else
+        render :error
+      end
+    end
+
     def matching_token?
       AccessToken.matching_token_for pre_auth.client,
                                      current_resource_owner.id,
@@ -33,7 +48,12 @@ module Doorkeeper
     end
 
     def redirect_or_render(auth)
-      if auth.redirectable?
+      if auth.redirectable? && Doorkeeper.configuration.api_mode
+        render(
+          json: { status: :redirect, redirect_uri: auth.redirect_uri },
+          status: auth.status
+        )
+      elsif auth.redirectable?
         redirect_to auth.redirect_uri
       else
         render json: auth.body, status: auth.status

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -114,6 +114,12 @@ doorkeeper.
       def reuse_access_token
         @config.instance_variable_set(:@reuse_access_token, true)
       end
+
+      # Use an API mode for applications generated with --api argument
+      # It will skip applications controller, disable forgery protection
+      def api_mode
+        @config.instance_variable_set("@api_mode", true)
+      end
     end
 
     module Option
@@ -251,6 +257,7 @@ doorkeeper.
            default: 'ActionController::Base'
 
     attr_reader :reuse_access_token
+    attr_reader :api_mode
 
     def refresh_token_enabled?
       @refresh_token_enabled ||= false

--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -4,7 +4,11 @@ module Doorkeeper
       include OAuth::Helpers
 
       def self.from_request(request, attributes = {})
-        new(attributes.merge(name: request.error, state: request.try(:state)))
+        new(attributes.merge(
+            name: request.error,
+            state: request.try(:state),
+            redirect_uri: request.try(:redirect_uri)
+        ))
       end
 
       delegate :name, :description, :state, to: :@error

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -36,6 +36,18 @@ module Doorkeeper
         OAuth::ErrorResponse.from_request(self)
       end
 
+      def as_json(_options)
+        {
+          client_id: client.uid,
+          redirect_uri: redirect_uri,
+          state: state,
+          response_type: response_type,
+          scope: scope,
+          client_name: client.name,
+          status: 'preauthorization'
+        }
+      end
+
       private
 
       def validate_response_type

--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -19,6 +19,9 @@ module Doorkeeper
       def initialize(routes, &block)
         @routes = routes
         @mapping = Mapper.new.map(&block)
+        if Doorkeeper.configuration.api_mode
+          @mapping.skips.push(:applications, :authorized_applications)
+        end
       end
 
       def generate_routes!(options)

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -70,6 +70,44 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     end
   end
 
+  describe "POST #create in API mode" do
+    before do
+      allow(Doorkeeper.configuration).to receive(:api_mode).and_return(true)
+      post :create, client_id: client.uid, response_type: "token", redirect_uri: client.redirect_uri
+    end
+
+    let(:response_json_body) { JSON.parse(response.body) }
+    let(:redirect_uri) { response_json_body["redirect_uri"] }
+
+    it "renders success after authorization" do
+      expect(response).to be_success
+    end
+
+    it "renders correct redirect uri" do
+      expect(redirect_uri).to match(/^#{client.redirect_uri}/)
+    end
+
+    it "includes access token in fragment" do
+      expect(redirect_uri.match(/access_token=([a-f0-9]+)&?/)[1]).to eq(Doorkeeper::AccessToken.first.token)
+    end
+
+    it "includes token type in fragment" do
+      expect(redirect_uri.match(/token_type=(\w+)&?/)[1]).to eq "bearer"
+    end
+
+    it "includes token expiration in fragment" do
+      expect(redirect_uri.match(/expires_in=(\d+)&?/)[1].to_i).to eq 2.hours
+    end
+
+    it "issues the token for the current client" do
+      expect(Doorkeeper::AccessToken.first.application_id).to eq(client.id)
+    end
+
+    it "issues the token for the current resource owner" do
+      expect(Doorkeeper::AccessToken.first.resource_owner_id).to eq(user.id)
+    end
+  end
+
   describe 'POST #create with errors' do
     before do
       default_scopes_exist :public
@@ -81,7 +119,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     end
 
     it 'redirects to client redirect uri' do
-      expect(response.location).to match(%r{^#{client.redirect_uri}})
+      expect(response.location).to match(/^#{client.redirect_uri}/)
     end
 
     it 'does not include access token in fragment' do
@@ -94,6 +132,40 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
 
     it 'includes error description in fragment' do
       expect(response.query_params['error_description']).to eq(translated_error_message(:invalid_scope))
+    end
+
+    it 'does not issue any access token' do
+      expect(Doorkeeper::AccessToken.all).to be_empty
+    end
+  end
+
+  describe 'POST #create in API mode with errors' do
+    before do
+      allow(Doorkeeper.configuration).to receive(:api_mode).and_return(true)
+      default_scopes_exist :public
+      post :create, client_id: client.uid, response_type: 'token', scope: 'invalid', redirect_uri: client.redirect_uri
+    end
+    let(:response_json_body) { JSON.parse(response.body) }
+    let(:redirect_uri) { response_json_body['redirect_uri'] }
+
+    it 'renders 400 error' do
+      expect(response.status).to eq 401
+    end
+
+    it 'includes correct redirect URI' do
+      expect(redirect_uri).to match(/^#{client.redirect_uri}/)
+    end
+
+    it 'does not include access token in fragment' do
+      expect(redirect_uri.match(/access_token=([a-f0-9]+)&?/)).to be_nil
+    end
+
+    it 'includes error in redirect uri' do
+      expect(redirect_uri.match(/error=([a-z_]+)&?/)[1]).to eq 'invalid_scope'
+    end
+
+    it 'includes error description in redirect uri' do
+      expect(redirect_uri.match(/error_description=(.+)&?/)[1]).to_not be_nil
     end
 
     it 'does not issue any access token' do
@@ -196,6 +268,46 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     end
 
     it 'issues the token for the current resource owner' do
+      expect(Doorkeeper::AccessToken.first.resource_owner_id).to eq(user.id)
+    end
+  end
+
+  describe 'GET #new in API mode with skip_authorization true' do
+    before do
+      allow(Doorkeeper.configuration).to receive(:skip_authorization).and_return(proc do
+        true
+      end)
+      allow(Doorkeeper.configuration).to receive(:api_mode).and_return(true)
+      get :new, client_id: client.uid, response_type: 'token', redirect_uri: client.redirect_uri
+    end
+
+    it 'should render success' do
+      expect(response).to be_success
+    end
+
+    it 'should issue a token' do
+      expect(Doorkeeper::AccessToken.count).to be 1
+    end
+
+    it "sets status to redirect" do
+      expect(JSON.parse(response.body)["status"]).to eq("redirect")
+    end
+
+    it "sets redirect_uri to correct value" do
+      redirect_uri = JSON.parse(response.body)["redirect_uri"]
+      expect(redirect_uri).to_not be_nil
+      expect(redirect_uri.match(/token_type=(\w+)&?/)[1]).to eq "bearer"
+      expect(redirect_uri.match(/expires_in=(\d+)&?/)[1].to_i).to eq 2.hours
+      expect(
+        redirect_uri.match(/access_token=([a-f0-9]+)&?/)[1]
+      ).to eq Doorkeeper::AccessToken.first.token
+    end
+
+    it "issues the token for the current client" do
+      expect(Doorkeeper::AccessToken.first.application_id).to eq(client.id)
+    end
+
+    it "issues the token for the current resource owner" do
       expect(Doorkeeper::AccessToken.first.resource_owner_id).to eq(user.id)
     end
   end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -434,4 +434,18 @@ describe Doorkeeper, 'configuration' do
       end
     end
   end
+
+  describe "api_mode" do
+    it "is false by default" do
+      expect(subject.api_mode).to be_falsey
+    end
+
+    it "can change the value" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        api_mode
+      end
+      expect(subject.api_mode).to be_truthy
+    end
+  end
 end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -151,5 +151,25 @@ module Doorkeeper::OAuth
       subject.redirect_uri = nil
       expect(subject).not_to be_authorizable
     end
+
+    describe "as_json" do
+      let(:client_id) { "client_uid_123" }
+      let(:client_name) { "Acme Co." }
+      before do
+        allow(client).to receive(:uid).and_return client_id
+        allow(client).to receive(:name).and_return client_name
+      end
+      let(:json) { subject.as_json({}) }
+      it { is_expected.to respond_to :as_json }
+      it "returns correct values" do
+        expect(json[:client_id]).to eq client_id
+        expect(json[:redirect_uri]).to eq subject.redirect_uri
+        expect(json[:state]).to eq subject.state
+        expect(json[:response_type]).to eq subject.response_type
+        expect(json[:scope]).to eq subject.scope
+        expect(json[:client_name]).to eq client_name
+        expect(json[:status]).to eq "preauthorization"
+      end
+    end
   end
 end


### PR DESCRIPTION
This was influenced by #893, but I took a bit different approach and extended functionality to other areas. It is still WIP, but I just wanted to share what is done already, and I'll be glad to get some advices.

The main premise for this PR is that usually Rails APIs and frontend apps are running on different domains, so we cannot easily identity users by cookies or something like that (e.g. in our project we use [devise_token_auth](https://github.com/lynndylanhurley/devise_token_auth) and authenticate users by tokens).

Switching on `api_mode` configuration will:
- disable request forgery protection, since we assume user is not authenticated by cookies - if he is, there's no much sense in turning `api_mode` on
- remove helpers since we don't rely on HTML views
- render JSON with `status: redirect` and `redirect_uri` instead of directly redirecting user
- disable applications and authorized_applications controller (maybe I will update it to support JSON as well and enable them back - not sure if it's needed though)

As a side effects, this PR:
- makes `Doorkeeper::Oauth::PreAuthorization` serializable by as_json method which will provide all information needed to show preauthorization page
- *(I need more information on this one from someone more familiar with project)* sets redirect_uri on `Doorkeeper::Oauth::ErrorResponse` - for some reason, it was not set before. If we render ErrorResponse with api_mode, it will render the same `status: redirect` and `redirect_uri` with error message

Anyone who will use `api_mode`, will also need some oauth page (which can be easily implemented as a small SPA and that will be running on the same domain as main frontend application). They can make main frontend app do this job, but I assume it is not worth loading the whole app just to show a single dialogue message with Allow/Deny buttons. It will have to be responsible for:
- logging users in
- making pre-auth requests which will return client name, and other information
- sending POST `oauth/authorize`
- redirecting user whenever they get `status: redirect` to `redirect_uri` provided in response

Please let me know your thoughts about it.