### PR TITLE
Have strategy requests all invoke BaseRequest's callbacks

### DIFF
--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -28,6 +28,7 @@ module Doorkeeper
                                       grant.scopes,
                                       server)
         end
+        super
       end
 
       def validate_attributes

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -22,6 +22,7 @@ module Doorkeeper
 
       def before_successful_response
         find_or_create_access_token(client, resource_owner.id, scopes, server)
+        super
       end
 
       def validate_scopes

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -35,6 +35,7 @@ module Doorkeeper
           refresh_token.revoke unless refresh_token_revoked_on_use?
           create_access_token
         end
+        super
       end
 
       def refresh_token_revoked_on_use?

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -80,6 +80,12 @@ module Doorkeeper::OAuth
       end.to_not change { Doorkeeper::AccessToken.count }
     end
 
+    it 'calls BaseRequest callback methods' do
+      expect_any_instance_of(BaseRequest).to receive(:before_successful_response).once
+      expect_any_instance_of(BaseRequest).to receive(:after_successful_response).once
+      subject.authorize
+    end
+
     context "when redirect_uri contains some query params" do
       let(:redirect_uri) { client.redirect_uri + "?query=q" }
 

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -80,7 +80,7 @@ module Doorkeeper::OAuth
       end.to_not change { Doorkeeper::AccessToken.count }
     end
 
-    it 'calls BaseRequest callback methods' do
+    it "calls BaseRequest callback methods" do
       expect_any_instance_of(BaseRequest).to receive(:before_successful_response).once
       expect_any_instance_of(BaseRequest).to receive(:after_successful_response).once
       subject.authorize

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -67,6 +67,12 @@ module Doorkeeper::OAuth
       end.to_not change { Doorkeeper::AccessToken.count }
     end
 
+    it 'calls BaseRequest callback methods' do
+      expect_any_instance_of(BaseRequest).to receive(:before_successful_response).once
+      expect_any_instance_of(BaseRequest).to receive(:after_successful_response).once
+      subject.authorize
+    end
+
     describe 'with scopes' do
       subject do
         PasswordAccessTokenRequest.new(server, client, owner, scope: 'public')

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -67,7 +67,7 @@ module Doorkeeper::OAuth
       end.to_not change { Doorkeeper::AccessToken.count }
     end
 
-    it 'calls BaseRequest callback methods' do
+    it "calls BaseRequest callback methods" do
       expect_any_instance_of(BaseRequest).to receive(:before_successful_response).once
       expect_any_instance_of(BaseRequest).to receive(:after_successful_response).once
       subject.authorize

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -44,6 +44,12 @@ module Doorkeeper::OAuth
       expect { subject.authorize }.to change { refresh_token.revoked? }.from(false).to(true)
     end
 
+    it 'calls BaseRequest callback methods' do
+      expect_any_instance_of(BaseRequest).to receive(:before_successful_response).once
+      expect_any_instance_of(BaseRequest).to receive(:after_successful_response).once
+      subject.authorize
+    end
+
     it 'requires the refresh token' do
       subject.refresh_token = nil
       subject.validate

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -44,7 +44,7 @@ module Doorkeeper::OAuth
       expect { subject.authorize }.to change { refresh_token.revoked? }.from(false).to(true)
     end
 
-    it 'calls BaseRequest callback methods' do
+    it "calls BaseRequest callback methods" do
       expect_any_instance_of(BaseRequest).to receive(:before_successful_response).once
       expect_any_instance_of(BaseRequest).to receive(:after_successful_response).once
       subject.authorize


### PR DESCRIPTION
There are some limitations to the current way the strategy request callback methods are implemented. Each specific strategy subclass does not call `super`, leaving a developer like myself who wants to generally hook into all requests, to hook into 3 particular strategies in addition to the BaseRequest parent class.

This PR makes the `BaseRequest#before_successful_response` and `BaseRequest#after_successful_response` generally available. 

## Example

If a developer wanted to hook into, say, `before_successful_response` callback for all request strategies in their Rails application:

### Before this PR

```ruby
# /config/initializers/enrich_strategy_requests.rb
require 'doorkeeper'

module Doorkeeper
  module OAuth
    class BaseRequest
      private

      def before_successful_response
        do_work()
      end
    end

    class RefreshTokenRequest
      private

      def before_successful_response
        refresh_token.transaction do
          refresh_token.lock!
          raise Errors::InvalidTokenReuse if refresh_token.revoked?

          refresh_token.revoke unless refresh_token_revoked_on_use?
          create_access_token
        end
        do_work()
      end
    end

    class AuthorizationCodeRequest
      private

      def before_successful_response
        grant.transaction do
          grant.lock!
          raise Errors::InvalidGrantReuse if grant.revoked?

          grant.revoke
          find_or_create_access_token(grant.application,
                                      grant.resource_owner_id,
                                      grant.scopes,
                                      server)
        end
        do_work()
      end
    end

    class PasswordAccessTokenRequest
      private

      def before_successful_response
        find_or_create_access_token(client, resource_owner.id, scopes, server)
        do_work()
      end
    end
  end
end
```

### After this PR

```ruby
# /config/initializers/enrich_strategy_requests.rb
require 'doorkeeper'

module Doorkeeper
  module OAuth
    class BaseRequest

      private

      def before_successful_response
        do_work()
      end
    end
  end
end
```

* * *

Also, an aside, I'm not the best Ruby developer in the world when it comes to extending and modifying gems within a Rails app. For me to make use of these callbacks, is redefining some aspects of the classes in initializers as illustrated above the correct way to go?