### PR TITLE
Make native redirect code a query param

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1003] Use URL query param to pass through native redirect auth code so automated apps can find it.
 - [#868] `Scopes#&` and `Scopes#+` now take an array or any other enumerable
   object.
 - [#1019] Remove translation not in use: `invalid_resource_owner`.

--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -49,7 +49,7 @@ module Doorkeeper
           as: mapping[:as],
           controller: mapping[:controllers]
         ) do
-          routes.get '/:code', action: :show, on: :member
+          routes.get '/native', action: :show, on: :member
           routes.get '/', action: :new, on: :member
         end
       end

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -154,7 +154,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
 
     it 'should redirect immediately' do
       expect(response).to be_redirect
-      expect(response.location).to match(/oauth\/authorize\//)
+      expect(response.location).to match(/oauth\/authorize\/native\?code=#{Doorkeeper::AccessGrant.first.token}/)
     end
 
     it 'should issue a grant' do

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -29,6 +29,7 @@ feature 'Authorization Code Flow' do
 
     access_grant_should_exist_for(@client, @resource_owner)
 
+    url_should_have_param('code', Doorkeeper::AccessGrant.first.token)
     i_should_see 'Authorization code:'
     i_should_see Doorkeeper::AccessGrant.first.token
   end


### PR DESCRIPTION
Using native redirect, instead of redirecting to

```oauth/authorize/abc123abc123```

it redirects to

```oauth/authorize/native?code=abc123abc123```

This allows for automated flows to detect that an Authorization code was granted in much the same way as a normal redirect. This is used by e.g. Mac Paw (and possibly Postman) to detect whether a code was given or not. I'm not sure if this was intentional or not, but adding the code as an actual param would make sense to mimic the non-oob flow as much as possible, gaining support by any software that works with non-oob flow.

Before:

![](http://d.pr/i/QcTIgb.gif)

After:

![](http://d.pr/i/UlxwIo.gif)

### Related
- https://stackoverflow.com/questions/46834280/oauth-2-0-authentication-flow-with-paw-and-funky-redirect-uri/47563884#47563884