### PR TITLE
create configuration option to allow http callbacks to localhost uris

### DIFF
--- a/app/validators/redirect_uri_validator.rb
+++ b/app/validators/redirect_uri_validator.rb
@@ -29,6 +29,12 @@ class RedirectUriValidator < ActiveModel::EachValidator
 
   def invalid_ssl_uri?(uri)
     forces_ssl = Doorkeeper.configuration.force_ssl_in_redirect_uri
-    forces_ssl && uri.try(:scheme) == 'http'
+    allow_non_ssl_localhost = Doorkeeper.configuration.allow_non_secure_localhost_redirects
+    return false if allow_non_ssl_localhost && localhost_uri?(uri)
+    forces_ssl && uri.try(:scheme) == "http"
+  end
+
+  def localhost_uri?(uri)
+    uri.host == "localhost"
   end
 end

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -133,6 +133,14 @@ doorkeeper.
         @config.instance_variable_set("@force_ssl_in_redirect_uri", boolean)
       end
 
+      # Allows for non HTTPS localhost uris even when force ssl is set to true.
+      #
+      # @param [Boolean] boolean value for the parameter, false by default in
+      # non-development environment
+      def allow_non_secure_localhost_redirects(boolean)
+        @config.instance_variable_set("@allow_non_secure_localhost_redirects", boolean)
+      end
+
       # Use a custom class for generating the access token.
       # https://github.com/doorkeeper-gem/doorkeeper#custom-access-token-generator
       #
@@ -233,16 +241,17 @@ doorkeeper.
              nil
            end)
 
-    option :skip_authorization,             default: ->(_routes) {}
-    option :access_token_expires_in,        default: 7200
-    option :custom_access_token_expires_in, default: ->(_app) { nil }
-    option :authorization_code_expires_in,  default: 600
-    option :orm,                            default: :active_record
-    option :native_redirect_uri,            default: 'urn:ietf:wg:oauth:2.0:oob'
-    option :active_record_options,          default: {}
-    option :realm,                          default: 'Doorkeeper'
-    option :force_ssl_in_redirect_uri,      default: !Rails.env.development?
-    option :grant_flows,                    default: %w(authorization_code client_credentials)
+    option :skip_authorization,                   default: ->(_routes) {}
+    option :access_token_expires_in,              default: 7200
+    option :custom_access_token_expires_in,       default: ->(_app) { nil }
+    option :authorization_code_expires_in,        default: 600
+    option :orm,                                  default: :active_record
+    option :native_redirect_uri,                  default: 'urn:ietf:wg:oauth:2.0:oob'
+    option :active_record_options,                default: {}
+    option :realm,                                default: 'Doorkeeper'
+    option :force_ssl_in_redirect_uri,            default: !Rails.env.development?
+    option :allow_non_secure_localhost_redirects, default: Rails.env.development?
+    option :grant_flows,                          default: %w(authorization_code client_credentials)
     option :access_token_generator,
            default: 'Doorkeeper::OAuth::Helpers::UniqueToken'
     option :base_controller,

--- a/spec/validators/redirect_uri_validator_spec.rb
+++ b/spec/validators/redirect_uri_validator_spec.rb
@@ -68,6 +68,22 @@ describe RedirectUriValidator do
       expect(subject).to be_valid
     end
 
+    it 'accepts non secure localhost redirect when allow non ssl localhost is enabled' do
+      subject.redirect_uri = "http://localhost"
+      allow(Doorkeeper.configuration).to receive(
+        :allow_non_secure_localhost_redirects
+      ).and_return(true)
+      expect(subject).to be_valid
+    end
+
+    it 'does not accept non secure localhost redirects when allow non ssl localhost is diabled'  do
+      subject.redirect_uri = "http://localhost"
+      allow(Doorkeeper.configuration).to receive(
+        :allow_non_secure_localhost_redirects
+      ).and_return(false)
+      expect(subject).not_to be_valid
+    end
+
     it 'invalidates the uri when the uri does not use a secure protocol' do
       subject.redirect_uri = 'http://example.com/callback'
       expect(subject).not_to be_valid


### PR DESCRIPTION
Hey! 

We love Doorkeeper at the company I work at now.

We have an interesting use case that other people might have.

We would like to use the `force_ssl`configuration option, but we'd also like to allow http access to localhost callback URIs.

This PR creates the option `allow_non_secure_localhost_redirects` which allows doorkeeper users to allow http localhost uris while still forcing all other uris to be ssl. 