### PR TITLE
Removing unnecessary <th>

### DIFF
--- a/app/views/doorkeeper/authorized_applications/index.html.erb
+++ b/app/views/doorkeeper/authorized_applications/index.html.erb
@@ -9,7 +9,6 @@
       <th><%= t('doorkeeper.authorized_applications.index.application') %></th>
       <th><%= t('doorkeeper.authorized_applications.index.created_at') %></th>
       <th></th>
-      <th></th>
     </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
There are only three columns in the table - we don't need four headers