### PR TITLE
Remove translation not in use: invalid_resource_owner 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1019] Remove translation not in use: `invalid_resource_owner`.
 - Use Ruby 2 hash style syntax (min required Ruby version = 2.1)
 - [#948] Make Scopes.<=> work with any "other" value.
 - [#970] Escape certain attributes in authorization forms.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,9 +94,6 @@ en:
         invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
         unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
 
-        # Password Access token errors
-        invalid_resource_owner: 'The provided resource owner credentials are not valid, or resource owner cannot be found'
-
         invalid_token:
           revoked: "The access token was revoked"
           expired: "The access token expired"


### PR DESCRIPTION
The key was removed from use in #843 (discussed in #771 and formerly #444) and I think it is better removed to prevent confusion.