### PR TITLE
Fix testing Rails 5.1 version

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -8,7 +8,6 @@ appraise "rails-5-0" do
 end
 
 appraise "rails-5-1" do
-  gem "rails", github: "rails/rails"
-  gem "arel", github: "rails/arel"
+  gem "rails", "~> 5.1.0"
   gem "rspec-rails", "~> 3.5"
 end

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.1"
+gem "rails", "~> 5.1.0"
 gem "appraisal"
 gem "activerecord-jdbcsqlite3-adapter", :platform => :jruby
 gem "sqlite3", :platform => [:ruby, :mswin, :mingw, :x64_mingw]


### PR DESCRIPTION
The version specification '~> 5.1' means '5.x'.
When Rails 5.2 is released, rails version will be updated to 5.2.0.