### PR TITLE
Migrate from FactoryGirl to FactoryBot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 - [#970] Escape certain attributes in authorization forms.
 - [#974] Redirect URI is checked without query params within AuthorizationCodeRequest.
 - [#1023] Update Ruby versions and test against 2.5.0 on Travis CI.
+- [#1024] Migrate from FactoryGirl to FactoryBot.
 
 ## 4.2.5
 

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara"
   s.add_development_dependency "coveralls"
   s.add_development_dependency "database_cleaner", "~> 1.6"
-  s.add_development_dependency "factory_girl", "~> 4.9"
+  s.add_development_dependency "factory_bot", "~> 4.8"
   s.add_development_dependency "generator_spec", "~> 0.9.3"
   s.add_development_dependency "rake", ">= 11.3.0"
   s.add_development_dependency "rspec-rails"

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -38,7 +38,7 @@ module Doorkeeper
       end
 
       it 'does not allow mass assignment of uid or secret' do
-        application = FactoryGirl.create(:application)
+        application = FactoryBot.create(:application)
         put :update, id: application.id, doorkeeper_application: {
           uid: '1A2B3C4D',
           secret: '1A2B3C4D' }
@@ -47,7 +47,7 @@ module Doorkeeper
       end
 
       it 'updates application' do
-        application = FactoryGirl.create(:application)
+        application = FactoryBot.create(:application)
         put :update, id: application.id, doorkeeper_application: {
           name: 'Example',
           redirect_uri: 'https://example.com' }

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -27,9 +27,9 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     I18n.translate key, scope: [:doorkeeper, :errors, :messages]
   end
 
-  let(:client)        { FactoryGirl.create :application }
+  let(:client)        { FactoryBot.create :application }
   let(:user)          { User.create!(name: 'Joe', password: 'sekret') }
-  let(:access_token)  { FactoryGirl.build :access_token, resource_owner_id: user.id, application_id: client.id }
+  let(:access_token)  { FactoryBot.build :access_token, resource_owner_id: user.id, application_id: client.id }
 
   before do
     allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(["implicit"])

--- a/spec/controllers/token_info_controller_spec.rb
+++ b/spec/controllers/token_info_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_integration'
 
 describe Doorkeeper::TokenInfoController do
   describe 'when requesting tokeninfo with valid token' do
-    let(:doorkeeper_token) { FactoryGirl.create(:access_token) }
+    let(:doorkeeper_token) { FactoryBot.create(:access_token) }
 
     before(:each) do
       allow(controller).to receive(:doorkeeper_token) { doorkeeper_token }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :access_grant, class: Doorkeeper::AccessGrant do
     sequence(:resource_owner_id) { |n| n }
     application

--- a/spec/lib/models/revocable_spec.rb
+++ b/spec/lib/models/revocable_spec.rb
@@ -38,11 +38,11 @@ describe 'Revocable' do
   describe :revoke_previous_refresh_token! do
     it "revokes the previous token if existing, and resets the
       `previous_refresh_token` attribute" do
-      previous_token = FactoryGirl.create(
+      previous_token = FactoryBot.create(
         :access_token,
         refresh_token: "refresh_token"
       )
-      current_token = FactoryGirl.create(
+      current_token = FactoryBot.create(
         :access_token,
         previous_refresh_token: previous_token.refresh_token
       )

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -8,7 +8,7 @@ module Doorkeeper::OAuth
              refresh_token_enabled?: false,
              custom_access_token_expires_in: ->(_app) { nil }
     end
-    let(:grant)  { FactoryGirl.create :access_grant }
+    let(:grant)  { FactoryBot.create :access_grant }
     let(:client) { grant.application }
     let(:redirect_uri) { client.redirect_uri }
     let(:params) { { redirect_uri: redirect_uri } }
@@ -65,14 +65,14 @@ module Doorkeeper::OAuth
     end
 
     it "matches the client with grant's one" do
-      subject.client = FactoryGirl.create :application
+      subject.client = FactoryBot.create :application
       subject.validate
       expect(subject.error).to eq(:invalid_grant)
     end
 
     it 'skips token creation if there is a matching one' do
       allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
-      FactoryGirl.create(:access_token, application_id: client.id,
+      FactoryBot.create(:access_token, application_id: client.id,
         resource_owner_id: grant.resource_owner_id, scopes: grant.scopes.to_s)
       expect do
         subject.authorize

--- a/spec/lib/oauth/client_credentials/creator_spec.rb
+++ b/spec/lib/oauth/client_credentials/creator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_integration'
 
 class Doorkeeper::OAuth::ClientCredentialsRequest
   describe Creator do
-    let(:client) { FactoryGirl.create :application }
+    let(:client) { FactoryBot.create :application }
     let(:scopes) { Doorkeeper::OAuth::Scopes.from_string('public') }
 
     it 'creates a new token' do

--- a/spec/lib/oauth/client_credentials_integration_spec.rb
+++ b/spec/lib/oauth/client_credentials_integration_spec.rb
@@ -5,7 +5,7 @@ module Doorkeeper::OAuth
     let(:server) { Doorkeeper.configuration }
 
     context 'with a valid request' do
-      let(:client) { FactoryGirl.create :application }
+      let(:client) { FactoryBot.create :application }
 
       it 'issues an access token' do
         request = ClientCredentialsRequest.new(server, client, {})

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -11,7 +11,7 @@ module Doorkeeper::OAuth
         custom_access_token_expires_in: ->(_app) { nil }
       )
     end
-    let(:client) { FactoryGirl.create(:application) }
+    let(:client) { FactoryBot.create(:application) }
     let(:owner)  { double :owner, id: 99 }
 
     subject do
@@ -53,7 +53,7 @@ module Doorkeeper::OAuth
     end
 
     it 'creates token even when there is already one (default)' do
-      FactoryGirl.create(:access_token, application_id: client.id, resource_owner_id: owner.id)
+      FactoryBot.create(:access_token, application_id: client.id, resource_owner_id: owner.id)
       expect do
         subject.authorize
       end.to change { Doorkeeper::AccessToken.count }.by(1)
@@ -61,7 +61,7 @@ module Doorkeeper::OAuth
 
     it 'skips token creation if there is already one' do
       allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
-      FactoryGirl.create(:access_token, application_id: client.id, resource_owner_id: owner.id)
+      FactoryBot.create(:access_token, application_id: client.id, resource_owner_id: owner.id)
       expect do
         subject.authorize
       end.to_not change { Doorkeeper::AccessToken.count }

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -11,7 +11,7 @@ module Doorkeeper::OAuth
              custom_access_token_expires_in: -> (_oauth_client) { nil }
     end
     let(:refresh_token) do
-      FactoryGirl.create(:access_token, use_refresh_token: true)
+      FactoryBot.create(:access_token, use_refresh_token: true)
     end
     let(:client) { refresh_token.application }
     let(:credentials) { Client::Credentials.new(client.uid, client.secret) }
@@ -52,7 +52,7 @@ module Doorkeeper::OAuth
     end
 
     it "requires the token's client and current client to match" do
-      subject.client = FactoryGirl.create(:application)
+      subject.client = FactoryBot.create(:application)
       subject.validate
       expect(subject.error).to eq(:invalid_grant)
     end
@@ -99,7 +99,7 @@ module Doorkeeper::OAuth
     end
 
     context 'clientless access tokens' do
-      let!(:refresh_token) { FactoryGirl.create(:clientless_access_token, use_refresh_token: true) }
+      let!(:refresh_token) { FactoryBot.create(:clientless_access_token, use_refresh_token: true) }
 
       subject { RefreshTokenRequest.new server, refresh_token, nil }
 
@@ -110,7 +110,7 @@ module Doorkeeper::OAuth
 
     context 'with scopes' do
       let(:refresh_token) do
-        FactoryGirl.create :access_token,
+        FactoryBot.create :access_token,
                            use_refresh_token: true,
                            scopes: 'public write'
       end

--- a/spec/lib/oauth/token_request_spec.rb
+++ b/spec/lib/oauth/token_request_spec.rb
@@ -75,7 +75,7 @@ module Doorkeeper::OAuth
 
       it 'creates a new token if scopes do not match' do
         allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
-        FactoryGirl.create(:access_token, application_id: pre_auth.client.id,
+        FactoryBot.create(:access_token, application_id: pre_auth.client.id,
                            resource_owner_id: owner.id, scopes: '')
         expect do
           subject.authorize
@@ -86,7 +86,7 @@ module Doorkeeper::OAuth
         allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
         allow(application.scopes).to receive(:has_scopes?).and_return(true)
         allow(application.scopes).to receive(:all?).and_return(true)
-        FactoryGirl.create(:access_token, application_id: pre_auth.client.id,
+        FactoryBot.create(:access_token, application_id: pre_auth.client.id,
                            resource_owner_id: owner.id, scopes: 'public')
 
         expect do

--- a/spec/models/doorkeeper/access_grant_spec.rb
+++ b/spec/models/doorkeeper/access_grant_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_integration'
 
 describe Doorkeeper::AccessGrant do
-  subject { FactoryGirl.build(:access_grant) }
+  subject { FactoryBot.build(:access_grant) }
 
   it { expect(subject).to be_valid }
 

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_integration'
 
 module Doorkeeper
   describe AccessToken do
-    subject { FactoryGirl.build(:access_token) }
+    subject { FactoryBot.build(:access_token) }
 
     it { expect(subject).to be_valid }
 
@@ -19,9 +19,9 @@ module Doorkeeper
 
     describe :generate_token do
       it 'generates a token using the default method' do
-        FactoryGirl.create :access_token
+        FactoryBot.create :access_token
 
-        token = FactoryGirl.create :access_token
+        token = FactoryBot.create :access_token
         expect(token.token).to be_a(String)
       end
 
@@ -41,7 +41,7 @@ module Doorkeeper
           access_token_generator "Doorkeeper::CustomGeneratorArgs"
         end
 
-        token = FactoryGirl.create :access_token
+        token = FactoryBot.create :access_token
         expect(token.token).to match(%r{custom_generator_token_\d+})
       end
 
@@ -61,7 +61,7 @@ module Doorkeeper
           access_token_generator "Doorkeeper::CustomGeneratorArgs"
         end
 
-        token = FactoryGirl.create :access_token
+        token = FactoryBot.create :access_token
         expect(token.token).to match(%r{custom_generator_token_Application \d+})
       end
 
@@ -81,7 +81,7 @@ module Doorkeeper
           access_token_generator "Doorkeeper::CustomGeneratorArgs"
         end
 
-        token = FactoryGirl.create :access_token, scopes: 'public write'
+        token = FactoryBot.create :access_token, scopes: 'public write'
 
         expect(token.token).to eq 'custom_generator_token_2_public write'
       end
@@ -102,7 +102,7 @@ module Doorkeeper
           access_token_generator "Doorkeeper::CustomGeneratorArgs"
         end
 
-        token = FactoryGirl.create :access_token
+        token = FactoryBot.create :access_token
         expect(token.token).to eq 'custom_generator_token_7200'
       end
 
@@ -118,7 +118,7 @@ module Doorkeeper
           access_token_generator "Doorkeeper::CustomGeneratorArgs"
         end
 
-        token = FactoryGirl.create :access_token
+        token = FactoryBot.create :access_token
         created_at = token.created_at
         expect(token.token).to eq "custom_generator_token_#{created_at.to_i}"
       end
@@ -132,7 +132,7 @@ module Doorkeeper
           access_token_generator "Doorkeeper::NoGenerate"
         end
 
-        expect { FactoryGirl.create :access_token }.to(
+        expect { FactoryBot.create :access_token }.to(
           raise_error(Doorkeeper::Errors::UnableToGenerateToken))
       end
 
@@ -142,32 +142,32 @@ module Doorkeeper
           access_token_generator "Doorkeeper::NotReal"
         end
 
-        expect { FactoryGirl.create :access_token }.to(
+        expect { FactoryBot.create :access_token }.to(
           raise_error(Doorkeeper::Errors::TokenGeneratorNotFound))
       end
     end
 
     describe :refresh_token do
       it 'has empty refresh token if it was not required' do
-        token = FactoryGirl.create :access_token
+        token = FactoryBot.create :access_token
         expect(token.refresh_token).to be_nil
       end
 
       it 'generates a refresh token if it was requested' do
-        token = FactoryGirl.create :access_token, use_refresh_token: true
+        token = FactoryBot.create :access_token, use_refresh_token: true
         expect(token.refresh_token).not_to be_nil
       end
 
       it 'is not valid if token exists' do
-        token1 = FactoryGirl.create :access_token, use_refresh_token: true
-        token2 = FactoryGirl.create :access_token, use_refresh_token: true
+        token1 = FactoryBot.create :access_token, use_refresh_token: true
+        token2 = FactoryBot.create :access_token, use_refresh_token: true
         token2.refresh_token = token1.refresh_token
         expect(token2).not_to be_valid
       end
 
       it 'expects database to raise an error if refresh tokens are the same' do
-        token1 = FactoryGirl.create :access_token, use_refresh_token: true
-        token2 = FactoryGirl.create :access_token, use_refresh_token: true
+        token1 = FactoryBot.create :access_token, use_refresh_token: true
+        token2 = FactoryBot.create :access_token, use_refresh_token: true
         expect do
           token2.refresh_token = token1.refresh_token
           token2.save(validate: false)
@@ -194,22 +194,22 @@ module Doorkeeper
       context 'with default parameters' do
 
         let(:resource_owner_id) { 100 }
-        let(:application)    { FactoryGirl.create :application }
+        let(:application)    { FactoryBot.create :application }
         let(:default_attributes) do
           { application: application, resource_owner_id: resource_owner_id }
         end
-        let(:access_token1) { FactoryGirl.create :access_token, default_attributes }
+        let(:access_token1) { FactoryBot.create :access_token, default_attributes }
 
         context 'the second token has the same owner and same app' do
-          let(:access_token2) { FactoryGirl.create :access_token, default_attributes }
+          let(:access_token2) { FactoryBot.create :access_token, default_attributes }
           it 'success' do
             expect(access_token1.same_credential?(access_token2)).to be_truthy
           end
         end
 
         context 'the second token has same owner and different app' do
-          let(:other_application) { FactoryGirl.create :application }
-          let(:access_token2) { FactoryGirl.create :access_token, application: other_application, resource_owner_id: resource_owner_id }
+          let(:other_application) { FactoryBot.create :application }
+          let(:access_token2) { FactoryBot.create :access_token, application: other_application, resource_owner_id: resource_owner_id }
 
           it 'fail' do
             expect(access_token1.same_credential?(access_token2)).to be_falsey
@@ -218,8 +218,8 @@ module Doorkeeper
 
         context 'the second token has different owner and different app' do
 
-          let(:other_application) { FactoryGirl.create :application }
-          let(:access_token2) { FactoryGirl.create :access_token, application: other_application, resource_owner_id: 42 }
+          let(:other_application) { FactoryBot.create :application }
+          let(:access_token2) { FactoryBot.create :access_token, application: other_application, resource_owner_id: 42 }
 
           it 'fail' do
             expect(access_token1.same_credential?(access_token2)).to be_falsey
@@ -227,7 +227,7 @@ module Doorkeeper
         end
 
         context 'the second token has different owner and same app' do
-          let(:access_token2) { FactoryGirl.create :access_token, application: application, resource_owner_id: 42 }
+          let(:access_token2) { FactoryBot.create :access_token, application: application, resource_owner_id: 42 }
 
           it 'fail' do
             expect(access_token1.same_credential?(access_token2)).to be_falsey
@@ -238,7 +238,7 @@ module Doorkeeper
 
     describe '#acceptable?' do
       context 'a token that is not accessible' do
-        let(:token) { FactoryGirl.create(:access_token, created_at: 6.hours.ago) }
+        let(:token) { FactoryBot.create(:access_token, created_at: 6.hours.ago) }
 
         it 'should return false' do
           expect(token.acceptable?(nil)).to be false
@@ -246,7 +246,7 @@ module Doorkeeper
       end
 
       context 'a token that has the incorrect scopes' do
-        let(:token) { FactoryGirl.create(:access_token) }
+        let(:token) { FactoryBot.create(:access_token) }
 
         it 'should return false' do
           expect(token.acceptable?(['public'])).to be false
@@ -255,7 +255,7 @@ module Doorkeeper
 
       context 'a token is acceptable with the correct scopes' do
         let(:token) do
-          token = FactoryGirl.create(:access_token)
+          token = FactoryBot.create(:access_token)
           token[:scopes] = 'public'
           token
         end
@@ -268,13 +268,13 @@ module Doorkeeper
 
     describe '.revoke_all_for' do
       let(:resource_owner) { double(id: 100) }
-      let(:application)    { FactoryGirl.create :application }
+      let(:application)    { FactoryBot.create :application }
       let(:default_attributes) do
         { application: application, resource_owner_id: resource_owner.id }
       end
 
       it 'revokes all tokens for given application and resource owner' do
-        FactoryGirl.create :access_token, default_attributes
+        FactoryBot.create :access_token, default_attributes
         AccessToken.revoke_all_for application.id, resource_owner
         AccessToken.all.each do |token|
           expect(token).to be_revoked
@@ -282,13 +282,13 @@ module Doorkeeper
       end
 
       it 'matches application' do
-        FactoryGirl.create :access_token, default_attributes.merge(application: FactoryGirl.create(:application))
+        FactoryBot.create :access_token, default_attributes.merge(application: FactoryBot.create(:application))
         AccessToken.revoke_all_for application.id, resource_owner
         expect(AccessToken.all).not_to be_empty
       end
 
       it 'matches resource owner' do
-        FactoryGirl.create :access_token, default_attributes.merge(resource_owner_id: 90)
+        FactoryBot.create :access_token, default_attributes.merge(resource_owner_id: 90)
         AccessToken.revoke_all_for application.id, resource_owner
         expect(AccessToken.all).not_to be_empty
       end
@@ -296,7 +296,7 @@ module Doorkeeper
 
     describe '.matching_token_for' do
       let(:resource_owner_id) { 100 }
-      let(:application)       { FactoryGirl.create :application }
+      let(:application)       { FactoryBot.create :application }
       let(:scopes) { Doorkeeper::OAuth::Scopes.from_string('public write') }
       let(:default_attributes) do
         {
@@ -307,63 +307,63 @@ module Doorkeeper
       end
 
       it 'returns only one token' do
-        token = FactoryGirl.create :access_token, default_attributes
+        token = FactoryBot.create :access_token, default_attributes
         last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
         expect(last_token).to eq(token)
       end
 
       it 'accepts resource owner as object' do
         resource_owner = double(to_key: true, id: 100)
-        token = FactoryGirl.create :access_token, default_attributes
+        token = FactoryBot.create :access_token, default_attributes
         last_token = AccessToken.matching_token_for(application, resource_owner, scopes)
         expect(last_token).to eq(token)
       end
 
       it 'accepts nil as resource owner' do
-        token = FactoryGirl.create :access_token, default_attributes.merge(resource_owner_id: nil)
+        token = FactoryBot.create :access_token, default_attributes.merge(resource_owner_id: nil)
         last_token = AccessToken.matching_token_for(application, nil, scopes)
         expect(last_token).to eq(token)
       end
 
       it 'excludes revoked tokens' do
-        FactoryGirl.create :access_token, default_attributes.merge(revoked_at: 1.day.ago)
+        FactoryBot.create :access_token, default_attributes.merge(revoked_at: 1.day.ago)
         last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
         expect(last_token).to be_nil
       end
 
       it 'matches the application' do
-        FactoryGirl.create :access_token, default_attributes.merge(application: FactoryGirl.create(:application))
+        FactoryBot.create :access_token, default_attributes.merge(application: FactoryBot.create(:application))
         last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
         expect(last_token).to be_nil
       end
 
       it 'matches the resource owner' do
-        FactoryGirl.create :access_token, default_attributes.merge(resource_owner_id: 2)
+        FactoryBot.create :access_token, default_attributes.merge(resource_owner_id: 2)
         last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
         expect(last_token).to be_nil
       end
 
       it 'matches token with fewer scopes' do
-        FactoryGirl.create :access_token, default_attributes.merge(scopes: 'public')
+        FactoryBot.create :access_token, default_attributes.merge(scopes: 'public')
         last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
         expect(last_token).to be_nil
       end
 
       it 'matches token with different scopes' do
-        FactoryGirl.create :access_token, default_attributes.merge(scopes: 'public email')
+        FactoryBot.create :access_token, default_attributes.merge(scopes: 'public email')
         last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
         expect(last_token).to be_nil
       end
 
       it 'matches token with more scopes' do
-        FactoryGirl.create :access_token, default_attributes.merge(scopes: 'public write email')
+        FactoryBot.create :access_token, default_attributes.merge(scopes: 'public write email')
         last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
         expect(last_token).to be_nil
       end
 
       it 'matches application scopes' do
-        application = FactoryGirl.create :application, scopes: "private read"
-        FactoryGirl.create :access_token, default_attributes.merge(
+        application = FactoryBot.create :application, scopes: "private read"
+        FactoryBot.create :access_token, default_attributes.merge(
           application: application
         )
         last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
@@ -371,14 +371,14 @@ module Doorkeeper
       end
 
       it 'returns the last created token' do
-        FactoryGirl.create :access_token, default_attributes.merge(created_at: 1.day.ago)
-        token = FactoryGirl.create :access_token, default_attributes
+        FactoryBot.create :access_token, default_attributes.merge(created_at: 1.day.ago)
+        token = FactoryBot.create :access_token, default_attributes
         last_token = AccessToken.matching_token_for(application, resource_owner_id, scopes)
         expect(last_token).to eq(token)
       end
 
       it 'returns as_json hash' do
-        token = FactoryGirl.create :access_token, default_attributes
+        token = FactoryBot.create :access_token, default_attributes
         token_hash = {
           resource_owner_id:  token.resource_owner_id,
           scopes:             token.scopes,

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -4,7 +4,7 @@ module Doorkeeper
   describe Application do
     let(:require_owner) { Doorkeeper.configuration.instance_variable_set('@confirm_application_owner', true) }
     let(:unset_require_owner) { Doorkeeper.configuration.instance_variable_set('@confirm_application_owner', false) }
-    let(:new_application) { FactoryGirl.build(:application) }
+    let(:new_application) { FactoryBot.build(:application) }
 
     let(:uid) { SecureRandom.hex(8) }
     let(:secret) { SecureRandom.hex(8) }
@@ -30,7 +30,7 @@ module Doorkeeper
       context 'application owner is required' do
         before(:each) do
           require_owner
-          @owner = FactoryGirl.build_stubbed(:doorkeeper_testing_user)
+          @owner = FactoryBot.build_stubbed(:doorkeeper_testing_user)
         end
 
         it 'is invalid without an owner' do
@@ -80,15 +80,15 @@ module Doorkeeper
     end
 
     it 'checks uniqueness of uid' do
-      app1 = FactoryGirl.create(:application)
-      app2 = FactoryGirl.create(:application)
+      app1 = FactoryBot.create(:application)
+      app2 = FactoryBot.create(:application)
       app2.uid = app1.uid
       expect(app2).not_to be_valid
     end
 
     it 'expects database to throw an error when uids are the same' do
-      app1 = FactoryGirl.create(:application)
-      app2 = FactoryGirl.create(:application)
+      app1 = FactoryBot.create(:application)
+      app2 = FactoryBot.create(:application)
       app2.uid = app1.uid
       expect { app2.save!(validate: false) }.to raise_error(uniqueness_error)
     end
@@ -123,13 +123,13 @@ module Doorkeeper
       end
 
       it 'should destroy its access grants' do
-        FactoryGirl.create(:access_grant, application: new_application)
+        FactoryBot.create(:access_grant, application: new_application)
         expect { new_application.destroy }.to change { Doorkeeper::AccessGrant.count }.by(-1)
       end
 
       it 'should destroy its access tokens' do
-        FactoryGirl.create(:access_token, application: new_application)
-        FactoryGirl.create(:access_token, application: new_application, revoked_at: Time.now.utc)
+        FactoryBot.create(:access_token, application: new_application)
+        FactoryBot.create(:access_token, application: new_application, revoked_at: Time.now.utc)
         expect do
           new_application.destroy
         end.to change { Doorkeeper::AccessToken.count }.by(-2)
@@ -144,33 +144,33 @@ module Doorkeeper
       end
 
       it 'returns only application for a specific resource owner' do
-        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.id + 1)
-        token = FactoryGirl.create(:access_token, resource_owner_id: resource_owner.id)
+        FactoryBot.create(:access_token, resource_owner_id: resource_owner.id + 1)
+        token = FactoryBot.create(:access_token, resource_owner_id: resource_owner.id)
         expect(Application.authorized_for(resource_owner)).to eq([token.application])
       end
 
       it 'excludes revoked tokens' do
-        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.id, revoked_at: 2.days.ago)
+        FactoryBot.create(:access_token, resource_owner_id: resource_owner.id, revoked_at: 2.days.ago)
         expect(Application.authorized_for(resource_owner)).to be_empty
       end
 
       it 'returns all applications that have been authorized' do
-        token1 = FactoryGirl.create(:access_token, resource_owner_id: resource_owner.id)
-        token2 = FactoryGirl.create(:access_token, resource_owner_id: resource_owner.id)
+        token1 = FactoryBot.create(:access_token, resource_owner_id: resource_owner.id)
+        token2 = FactoryBot.create(:access_token, resource_owner_id: resource_owner.id)
         expect(Application.authorized_for(resource_owner)).to eq([token1.application, token2.application])
       end
 
       it 'returns only one application even if it has been authorized twice' do
-        application = FactoryGirl.create(:application)
-        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.id, application: application)
-        FactoryGirl.create(:access_token, resource_owner_id: resource_owner.id, application: application)
+        application = FactoryBot.create(:application)
+        FactoryBot.create(:access_token, resource_owner_id: resource_owner.id, application: application)
+        FactoryBot.create(:access_token, resource_owner_id: resource_owner.id, application: application)
         expect(Application.authorized_for(resource_owner)).to eq([application])
       end
     end
 
     describe :authenticate do
       it 'finds the application via uid/secret' do
-        app = FactoryGirl.create :application
+        app = FactoryBot.create :application
         authenticated = Application.by_uid_and_secret(app.uid, app.secret)
         expect(authenticated).to eq(app)
       end

--- a/spec/requests/applications/applications_request_spec.rb
+++ b/spec/requests/applications/applications_request_spec.rb
@@ -25,8 +25,8 @@ end
 
 feature 'Listing applications' do
   background do
-    FactoryGirl.create :application, name: 'Oauth Dude'
-    FactoryGirl.create :application, name: 'Awesome App'
+    FactoryBot.create :application, name: 'Oauth Dude'
+    FactoryBot.create :application, name: 'Awesome App'
   end
 
   scenario 'application list' do
@@ -38,7 +38,7 @@ end
 
 feature 'Show application' do
   given :app do
-    FactoryGirl.create :application, name: 'Just another oauth app'
+    FactoryBot.create :application, name: 'Just another oauth app'
   end
 
   scenario 'visiting application page' do
@@ -49,7 +49,7 @@ end
 
 feature 'Edit application' do
   let :app do
-    FactoryGirl.create :application, name: 'OMG my app'
+    FactoryBot.create :application, name: 'OMG my app'
   end
 
   background do
@@ -73,7 +73,7 @@ end
 
 feature 'Remove application' do
   background do
-    @app = FactoryGirl.create :application
+    @app = FactoryBot.create :application
   end
 
   scenario 'deleting an application from list' do

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_integration'
 
 describe 'Client Credentials Request' do
-  let(:client) { FactoryGirl.create :application }
+  let(:client) { FactoryBot.create :application }
 
   context 'a valid request' do
     it 'authorizes the client and returns the token response' do

--- a/spec/requests/flows/refresh_token_spec.rb
+++ b/spec/requests/flows/refresh_token_spec.rb
@@ -37,7 +37,7 @@ describe 'Refresh Token Flow' do
 
   context 'refreshing the token' do
     before do
-      @token = FactoryGirl.create(
+      @token = FactoryBot.create(
         :access_token,
         application: @client,
         resource_owner_id: 1,
@@ -130,7 +130,7 @@ describe 'Refresh Token Flow' do
       )
       last_token.update_attribute :created_at, 5.seconds.ago
 
-      @token = FactoryGirl.create(
+      @token = FactoryBot.create(
         :access_token,
         application: @client,
         resource_owner_id: @resource_owner.id,

--- a/spec/requests/flows/revoke_token_spec.rb
+++ b/spec/requests/flows/revoke_token_spec.rb
@@ -6,10 +6,10 @@ describe 'Revoke Token Flow' do
   end
 
   context 'with default parameters' do
-    let(:client_application) { FactoryGirl.create :application }
+    let(:client_application) { FactoryBot.create :application }
     let(:resource_owner) { User.create!(name: 'John', password: 'sekret') }
     let(:access_token) do
-      FactoryGirl.create(:access_token,
+      FactoryBot.create(:access_token,
                          application: client_application,
                          resource_owner_id: resource_owner.id,
                          use_refresh_token: true)
@@ -81,7 +81,7 @@ describe 'Revoke Token Flow' do
       end
 
       context 'with valid token for another client application' do
-        let(:other_client_application) { FactoryGirl.create :application }
+        let(:other_client_application) { FactoryBot.create :application }
         let(:headers) do
           client_id = other_client_application.uid
           client_secret = other_client_application.secret
@@ -102,7 +102,7 @@ describe 'Revoke Token Flow' do
 
     context 'with public OAuth 2.0 client/application' do
       let(:access_token) do
-        FactoryGirl.create(:access_token,
+        FactoryBot.create(:access_token,
                            application: nil,
                            resource_owner_id: resource_owner.id,
                            use_refresh_token: true)
@@ -128,7 +128,7 @@ describe 'Revoke Token Flow' do
 
       context 'with a valid token issued for a confidential client' do
         let(:access_token) do
-          FactoryGirl.create(:access_token,
+          FactoryBot.create(:access_token,
                              application: client_application,
                              resource_owner_id: resource_owner.id,
                              use_refresh_token: true)

--- a/spec/requests/protected_resources/metal_spec.rb
+++ b/spec/requests/protected_resources/metal_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_integration'
 
 describe 'ActionController::Metal API' do
   before do
-    @client   = FactoryGirl.create(:application)
+    @client   = FactoryBot.create(:application)
     @resource = User.create!(name: 'Joe', password: 'sekret')
     @token    = client_is_authorized(@client, @resource)
   end

--- a/spec/requests/protected_resources/private_api_spec.rb
+++ b/spec/requests/protected_resources/private_api_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_integration'
 
 feature 'Private API' do
   background do
-    @client   = FactoryGirl.create(:application)
+    @client   = FactoryBot.create(:application)
     @resource = User.create!(name: 'Joe', password: 'sekret')
     @token    = client_is_authorized(@client, @resource)
   end

--- a/spec/support/dependencies/factory_girl.rb
+++ b/spec/support/dependencies/factory_girl.rb
@@ -1,2 +1,2 @@
-require 'factory_girl'
-FactoryGirl.find_definitions
+require 'factory_bot'
+FactoryBot.find_definitions

--- a/spec/support/helpers/access_token_request_helper.rb
+++ b/spec/support/helpers/access_token_request_helper.rb
@@ -4,7 +4,7 @@ module AccessTokenRequestHelper
       application: client,
       resource_owner_id: resource_owner.id
     }.merge(access_token_attributes)
-    FactoryGirl.create(:access_token, attributes)
+    FactoryBot.create(:access_token, attributes)
   end
 end
 

--- a/spec/support/helpers/model_helper.rb
+++ b/spec/support/helpers/model_helper.rb
@@ -1,6 +1,6 @@
 module ModelHelper
   def client_exists(client_attributes = {})
-    @client = FactoryGirl.create(:application, client_attributes)
+    @client = FactoryBot.create(:application, client_attributes)
   end
 
   def create_resource_owner
@@ -8,7 +8,7 @@ module ModelHelper
   end
 
   def authorization_code_exists(options = {})
-    @authorization = FactoryGirl.create(:access_grant, options)
+    @authorization = FactoryBot.create(:access_grant, options)
   end
 
   def access_grant_should_exist_for(client, resource_owner)

--- a/spec/support/shared/models_shared_examples.rb
+++ b/spec/support/shared/models_shared_examples.rb
@@ -34,15 +34,15 @@ shared_examples 'a unique token' do
     end
 
     it 'is not valid if token exists' do
-      token1 = FactoryGirl.create factory_name
-      token2 = FactoryGirl.create factory_name
+      token1 = FactoryBot.create factory_name
+      token2 = FactoryBot.create factory_name
       token2.token = token1.token
       expect(token2).not_to be_valid
     end
 
     it 'expects database to throw an error when tokens are the same' do
-      token1 = FactoryGirl.create factory_name
-      token2 = FactoryGirl.create factory_name
+      token1 = FactoryBot.create factory_name
+      token2 = FactoryBot.create factory_name
       token2.token = token1.token
       expect do
         token2.save!(validate: false)

--- a/spec/validators/redirect_uri_validator_spec.rb
+++ b/spec/validators/redirect_uri_validator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper_integration'
 
 describe RedirectUriValidator do
   subject do
-    FactoryGirl.create(:application)
+    FactoryBot.create(:application)
   end
 
   it 'is valid when the uri is a uri' do


### PR DESCRIPTION
FactoryGirl has been renamed as FactoryBot.
Ref: https://robots.thoughtbot.com/factory_bot

This commit fixes the following warning message:
```
DEPRECATION WARNING: The factory_girl gem is deprecated. Please upgrade to factory_bot.
See https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md for further instructions.
```