### PR TITLE
Fix #913: Deferred ORM (ActiveRecord) models loading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#913] Deferred ORM (ActiveRecord) models loading
 - [#943] Fix Access Token token generation when certain errors occur in custom token generators
 - [#1026] Implement RFC7662 - OAuth 2.0 Token Introspection
 - [#985] Generate valid migration files for Rails >= 5 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Dependency Status](https://gemnasium.com/doorkeeper-gem/doorkeeper.svg?travis)](https://gemnasium.com/doorkeeper-gem/doorkeeper)
 [![Code Climate](https://codeclimate.com/github/doorkeeper-gem/doorkeeper.svg)](https://codeclimate.com/github/doorkeeper-gem/doorkeeper)
 [![Gem Version](https://badge.fury.io/rb/doorkeeper.svg)](https://rubygems.org/gems/doorkeeper)
+[![Coverage Status](https://coveralls.io/repos/github/doorkeeper-gem/doorkeeper/badge.svg?branch=master)](https://coveralls.io/github/doorkeeper-gem/doorkeeper?branch=master)
 [![Security](https://hakiri.io/github/doorkeeper-gem/doorkeeper/master.svg)](https://hakiri.io/github/doorkeeper-gem/doorkeeper/master)
 
 Doorkeeper is a gem that makes it easy to introduce OAuth 2 provider

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -4,7 +4,7 @@ require "doorkeeper/version"
 
 Gem::Specification.new do |s|
   s.name        = "doorkeeper"
-  s.version     = Doorkeeper::VERSION
+  s.version     = Doorkeeper.gem_version
   s.authors     = ["Felipe Elias Philipp", "Tute Costa", "Jon Moss"]
   s.email       = %w(me@jonathanmoss.me)
   s.homepage    = "https://github.com/doorkeeper-gem/doorkeeper"

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -1,22 +1,33 @@
+require 'active_support/lazy_load_hooks'
+
 module Doorkeeper
   module Orm
     module ActiveRecord
       def self.initialize_models!
-        require 'doorkeeper/orm/active_record/access_grant'
-        require 'doorkeeper/orm/active_record/access_token'
-        require 'doorkeeper/orm/active_record/application'
+        lazy_load do
+          require 'doorkeeper/orm/active_record/access_grant'
+          require 'doorkeeper/orm/active_record/access_token'
+          require 'doorkeeper/orm/active_record/application'
 
-        if Doorkeeper.configuration.active_record_options[:establish_connection]
-          [Doorkeeper::AccessGrant, Doorkeeper::AccessToken, Doorkeeper::Application].each do |c|
-            c.send :establish_connection, Doorkeeper.configuration.active_record_options[:establish_connection]
+          if Doorkeeper.configuration.active_record_options[:establish_connection]
+            [Doorkeeper::AccessGrant, Doorkeeper::AccessToken, Doorkeeper::Application].each do |c|
+              options = Doorkeeper.configuration.active_record_options[:establish_connection]
+              c.send :establish_connection, options
+            end
           end
         end
       end
 
       def self.initialize_application_owner!
-        require 'doorkeeper/models/concerns/ownership'
+        lazy_load do
+          require 'doorkeeper/models/concerns/ownership'
 
-        Doorkeeper::Application.send :include, Doorkeeper::Models::Ownership
+          Doorkeeper::Application.send :include, Doorkeeper::Models::Ownership
+        end
+      end
+
+      def self.lazy_load(&block)
+        ActiveSupport.on_load(:active_record, {}, &block)
       end
     end
   end

--- a/lib/doorkeeper/version.rb
+++ b/lib/doorkeeper/version.rb
@@ -1,3 +1,15 @@
 module Doorkeeper
-  VERSION = "4.2.6".freeze
+  def self.gem_version
+    Gem::Version.new VERSION::STRING
+  end
+
+  module VERSION
+    # Semantic versioning
+    MAJOR = 4
+    MINOR = 2
+    TINY = 6
+
+    # Full version number
+    STRING = [MAJOR, MINOR, TINY].compact.join('.')
+  end
 end

--- a/spec/dummy/config/initializers/new_framework_defaults.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults.rb
@@ -1,6 +1,6 @@
 # Require `belongs_to` associations by default. This is a new Rails 5.0
 # default, so it is introduced as a configuration option to ensure that apps
 # made on earlier versions of Rails are not affected when upgrading.
-if Rails.version.to_i >= 5
+if Rails::VERSION::MAJOR >= 5
   Rails.application.config.active_record.belongs_to_required_by_default = true
 end

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -1,6 +1,11 @@
 if ENV['TRAVIS']
   require 'coveralls'
-  Coveralls.wear!('rails') { add_filter('/spec/') }
+
+  Coveralls.wear!('rails') do
+    add_filter('/spec/')
+    add_filter('/lib/generators/doorkeeper/templates/')
+    add_filter('/lib/version')
+  end
 end
 
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
### Summary

Lazy load ActiveRecord models with ActiveSupport `on_load` hook in order to allow initializers to be loaded before Doorkeeper models.

Close #913