### PR TITLE
Make it possible to have composit strategy names.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 - [#913] Deferred ORM (ActiveRecord) models loading
 - [#943] Fix Access Token token generation when certain errors occur in custom token generators
 - [#1026] Implement RFC7662 - OAuth 2.0 Token Introspection
-- [#985] Generate valid migration files for Rails >= 5 
+- [#985] Generate valid migration files for Rails >= 5
 - [#972] Replace Struct subclassing with block-form initialization
 - [#1003] Use URL query param to pass through native redirect auth code so automated apps can find it.
 - [#868] `Scopes#&` and `Scopes#+` now take an array or any other enumerable
@@ -21,6 +21,7 @@ User-visible changes worth mentioning.
 - [#1023] Update Ruby versions and test against 2.5.0 on Travis CI.
 - [#1024] Migrate from FactoryGirl to FactoryBot.
 - [#1025] Improve documentation for adding foreign keys
+- [#1028] Make it possible to have composit strategy names.
 
 ## 4.2.5
 

--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -24,7 +24,7 @@ module Doorkeeper
     def get_strategy(grant_or_request_type, available)
       fail Errors::MissingRequestStrategy unless grant_or_request_type.present?
       fail NameError unless available.include?(grant_or_request_type.to_s)
-      "Doorkeeper::Request::#{grant_or_request_type.to_s.camelize}".constantize
+      strategy_class(grant_or_request_type)
     end
 
     def authorization_response_types
@@ -36,5 +36,11 @@ module Doorkeeper
       Doorkeeper.configuration.token_grant_types
     end
     private_class_method :token_grant_types
+
+    def strategy_class(grant_or_request_type)
+      strategy_class_name = grant_or_request_type.to_s.tr(' ', '_').camelize
+      "Doorkeeper::Request::#{strategy_class_name}".constantize
+    end
+    private_class_method :strategy_class
   end
 end

--- a/spec/lib/server_spec.rb
+++ b/spec/lib/server_spec.rb
@@ -45,5 +45,15 @@ describe Doorkeeper::Server do
       expect(fake_class).to receive(:new).with(subject)
       subject.authorization_request :code
     end
+
+    it 'builds the request with composit strategy name' do
+      allow(Doorkeeper.configuration).
+        to receive(:authorization_response_types).
+        and_return(['id_token token'])
+
+      stub_const 'Doorkeeper::Request::IdTokenToken', fake_class
+      expect(fake_class).to receive(:new).with(subject)
+      subject.authorization_request 'id_token token'
+    end
   end
 end


### PR DESCRIPTION
This fix is needed for https://github.com/doorkeeper-gem/doorkeeper-openid_connect since
it's possible to have "response_type=id_token token" that we need to translate to
`IdTokenToken` strategy class.
