### PR TITLE
Sort applications by created_at

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1029] Deprecate `order_method` and introduce `ordered_by`. Sort applications
+  by `created_at` in index action.
 - [#1033] Allow Doorkeeper configuration option #force_ssl_in_redirect_uri to be a callable object.
 - Fix Grape integration & add specs for it
 - [#913] Deferred ORM (ActiveRecord) models loading

--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -10,7 +10,10 @@ module Doorkeeper
       @applications = if applications.respond_to?(:ordered_by)
                         applications.ordered_by(:created_at)
                       else
-                        ActiveSupport::Deprecation.warn "#{Doorkeeper.configuration.orm} must implement #ordered_by method \that will be used by default in Doorkeeper 5."
+                        message = "#{Doorkeeper.configuration.orm} must \
+                          implement #ordered_by method that will be used by \
+                          default in Doorkeeper 5."
+                        ActiveSupport::Deprecation.warn(message)
                         applications
                       end
     end

--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -6,7 +6,13 @@ module Doorkeeper
     before_action :set_application, only: [:show, :edit, :update, :destroy]
 
     def index
-      @applications = Application.all
+      applications = Application.all
+      @applications = if applications.respond_to?(:ordered_by)
+                        applications.ordered_by(:created_at)
+                      else
+                        ActiveSupport::Deprecation.warn "#{Doorkeeper.configuration.orm} must implement #ordered_by method \that will be used by default in Doorkeeper 5."
+                        applications
+                      end
     end
 
     def show; end

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -168,7 +168,7 @@ module Doorkeeper
       #   nil if nothing was found
       #
       def last_authorized_token_for(application_id, resource_owner_id)
-        public_send(order_method, created_at_desc).
+        ordered_by(:created_at, :desc).
           find_by(application_id: application_id,
                   resource_owner_id: resource_owner_id,
                   revoked_at: nil)

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -5,6 +5,7 @@ module Doorkeeper
     module ActiveRecord
       def self.initialize_models!
         lazy_load do
+          require 'doorkeeper/orm/active_record/base_record'
           require 'doorkeeper/orm/active_record/access_grant'
           require 'doorkeeper/orm/active_record/access_token'
           require 'doorkeeper/orm/active_record/application'

--- a/lib/doorkeeper/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/access_grant.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
-  class AccessGrant < ActiveRecord::Base
+  class AccessGrant < BaseRecord
     self.table_name = "#{table_name_prefix}oauth_access_grants#{table_name_suffix}".to_sym
 
     include AccessGrantMixin

--- a/lib/doorkeeper/orm/active_record/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/access_token.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
-  class AccessToken < ActiveRecord::Base
+  class AccessToken < BaseRecord
     self.table_name = "#{table_name_prefix}oauth_access_tokens#{table_name_suffix}".to_sym
 
     include AccessTokenMixin
@@ -31,7 +31,7 @@ module Doorkeeper
 
     # ORM-specific order method.
     def self.order_method
-      :order
+      :ordered_by
     end
 
     def self.refresh_token_revoked_on_use?
@@ -40,7 +40,7 @@ module Doorkeeper
 
     # ORM-specific DESC order for `:created_at` column.
     def self.created_at_desc
-      'created_at desc'
+      :created_at
     end
   end
 end

--- a/lib/doorkeeper/orm/active_record/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/access_token.rb
@@ -29,18 +29,8 @@ module Doorkeeper
       where(resource_owner_id: resource_owner.id, revoked_at: nil)
     end
 
-    # ORM-specific order method.
-    def self.order_method
-      :ordered_by
-    end
-
     def self.refresh_token_revoked_on_use?
       column_names.include?('previous_refresh_token')
-    end
-
-    # ORM-specific DESC order for `:created_at` column.
-    def self.created_at_desc
-      :created_at
     end
   end
 end

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -1,5 +1,5 @@
 module Doorkeeper
-  class Application < ActiveRecord::Base
+  class Application < BaseRecord
     self.table_name = "#{table_name_prefix}oauth_applications#{table_name_suffix}".to_sym
 
     include ApplicationMixin

--- a/lib/doorkeeper/orm/active_record/base_record.rb
+++ b/lib/doorkeeper/orm/active_record/base_record.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  class BaseRecord < ActiveRecord::Base
+    self.abstract_class = true
+
+    def self.ordered_by(attribute, direction = :asc)
+      order(attribute => direction)
+    end
+  end
+end

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -24,8 +24,19 @@ module Doorkeeper
     end
 
     context 'when admin is authenticated' do
+      render_views
+
       before do
         allow(Doorkeeper.configuration).to receive(:authenticate_admin).and_return(->(*) { true })
+      end
+
+      it 'sorts applications by created_at' do
+        first_application = FactoryBot.create(:application)
+        second_application = FactoryBot.create(:application)
+        expect(Doorkeeper::Application).to receive(:ordered_by).and_call_original
+        get :index
+        expect(response.body).to have_selector("tbody tr:first-child#application_#{first_application.id}")
+        expect(response.body).to have_selector("tbody tr:last-child#application_#{second_application.id}")
       end
 
       it 'creates application' do

--- a/spec/models/doorkeeper/base_record_spec.rb
+++ b/spec/models/doorkeeper/base_record_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper_integration'
+
+module Doorkeeper
+  describe AccessToken do
+    describe '.ordered_by' do
+      let(:attribute) { 'name' }
+
+      context 'when a direction is not specifed' do
+        subject { described_class.ordered_by(attribute) }
+
+        it 'calls order with a default order of desc' do
+          expect(described_class).to receive(:order).with(attribute => :asc)
+          subject
+        end
+      end
+
+      context 'when a direction is specifed' do
+        subject { described_class.ordered_by(attribute, direction) }
+
+        let(:direction) { 'desc' }
+
+        it 'calls order with the specified direction' do
+          expect(described_class).to receive(:order).with(attribute => direction)
+          subject
+        end
+      end
+    end
+  end
+end

--- a/spec/models/doorkeeper/base_record_spec.rb
+++ b/spec/models/doorkeeper/base_record_spec.rb
@@ -10,7 +10,7 @@ module Doorkeeper
       context 'when a direction is not specifed' do
         subject { described_class.ordered_by(attribute) }
 
-        it 'calls order with a default order of desc' do
+        it 'calls order with a default order of asc' do
           expect(described_class).to receive(:order).with(attribute => :asc)
           subject
         end


### PR DESCRIPTION
### Summary

The impetus for this change is that the index page for applications doesn't apply any default ordering which can be a little disorienting.

This PR introduces a base AR model with an `ordered_by` method and removes the `order_method` + `public_send` implementation this is currently being used. It also adds a deprecation warning for this implementation in other ORMs. The idea is that a single `ordered_by` method that all ORMs implement will be a lot cleaner and more maintainable going forward.

Finally, this PR sorts applications by `created_at` in the index view.