### PR TITLE
Allow Application#redirect_uri= to handle array of URIs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#1036] Allow to forbid Application redirect URI's with specific rules. 
+- [#1035] Allow `Application#redirect_uri=` to handle array of URIs.
+- [#1036] Allow to forbid Application redirect URI's with specific rules.
 - [#1029] Deprecate `order_method` and introduce `ordered_by`. Sort applications
   by `created_at` in index action.
 - [#1033] Allow Doorkeeper configuration option #force_ssl_in_redirect_uri to be a callable object.

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -43,6 +43,15 @@ module Doorkeeper
       end
     end
 
+    # Set an application's valid redirect URIs.
+    #
+    # @param uris [String, Array] Newline-separated string or array the URI(s)
+    #
+    # @return [String] The redirect URI(s) seperated by newlines.
+    def redirect_uri=(uris)
+      super(uris.is_a?(Array) ? uris.join("\n") : uris)
+    end
+
     private
 
     def has_scopes?

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -154,6 +154,21 @@ module Doorkeeper
       end
     end
 
+    describe "#redirect_uri=" do
+      context "when array of valid redirect_uris" do
+        it "should join by newline" do
+          new_application.redirect_uri = ['http://localhost/callback1', 'http://localhost/callback2']
+          expect(new_application.redirect_uri).to eq("http://localhost/callback1\nhttp://localhost/callback2")
+        end
+      end
+      context "when string of valid redirect_uris" do
+        it "should store as-is" do
+          new_application.redirect_uri = "http://localhost/callback1\nhttp://localhost/callback2"
+          expect(new_application.redirect_uri).to eq("http://localhost/callback1\nhttp://localhost/callback2")
+        end
+      end
+    end
+
     describe :authorized_for do
       let(:resource_owner) { double(:resource_owner, id: 10) }
 


### PR DESCRIPTION
Just a little convenience to make the code more intuitive.

I think for the 5.0 milestone we should consider renaming the attribute to `Application#redirect_uris` and have it return an array of strings.