### PR TITLE
Add passing specs for default scopes in password grant

### DIFF
--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -22,6 +22,7 @@ describe 'Client Credentials Request' do
     context 'with scopes' do
       before do
         optional_scopes_exist :write
+        default_scopes_exist :public
       end
 
       it 'adds the scope to the token an returns in the response' do
@@ -32,6 +33,33 @@ describe 'Client Credentials Request' do
 
         should_have_json 'access_token', Doorkeeper::AccessToken.first.token
         should_have_json 'scope', 'write'
+      end
+
+      context 'that are default' do
+        it 'adds the scope to the token an returns in the response' do
+          headers = authorization client.uid, client.secret
+          params  = { grant_type: 'client_credentials', scope: 'public' }
+
+          post '/oauth/token', params, headers
+
+          should_have_json 'access_token', Doorkeeper::AccessToken.first.token
+          should_have_json 'scope', 'public'
+        end
+      end
+
+      context 'that are invalid' do
+        it 'does not authorize the client and returns the error' do
+          headers = authorization client.uid, client.secret
+          params  = { grant_type: 'client_credentials', scope: 'random' }
+
+          post '/oauth/token', params, headers
+
+          should_have_json 'error', 'invalid_scope'
+          should_have_json 'error_description', translated_error_message(:invalid_scope)
+          should_not_have_json 'access_token'
+
+          expect(response.status).to eq(401)
+        end
       end
     end
   end

--- a/spec/support/helpers/url_helper.rb
+++ b/spec/support/helpers/url_helper.rb
@@ -17,6 +17,7 @@ module UrlHelper
       client_secret: options[:client_secret] || (options[:client] ? options[:client].secret : nil),
       username: options[:resource_owner_username] || (options[:resource_owner] ? options[:resource_owner].name : nil),
       password: options[:resource_owner_password] || (options[:resource_owner] ? options[:resource_owner].password : nil),
+      scope: options[:scope],
       grant_type: 'password'
     }
     "/oauth/token?#{build_query(parameters)}"


### PR DESCRIPTION
This was in reference to #1002 where I could not get a failing spec for the description provided.