### PR TITLE
Make mixins & models more independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ sudo: false
 
 rvm:
   - 2.1
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
 
 before_install:
   - gem update --system # Need for Ruby 2.5.0. https://github.com/travis-ci/travis-ci/issues/8978
@@ -30,5 +30,9 @@ matrix:
       rvm: 2.1
     - gemfile: gemfiles/rails_master.gemfile
       rvm: 2.1
+    - gemfile: gemfiles/rails_master.gemfile
+      rvm: 2.2
+    - gemfile: gemfiles/rails_master.gemfile
+      rvm: 2.3
   allow_failures:
     - gemfile: gemfiles/rails_master.gemfile

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1040] Clear mixins from ActiveRecord DSL and save only overridable API. It
+  allows to use this mixins in Doorkeeper ORM extensions with minimum code boilerplate.
+
+## 4.3.0
+
 - [#976] Fix to invalidate the second redirect URI when the first URI is the native URI
 - [#1035] Allow `Application#redirect_uri=` to handle array of URIs.
 - [#1036] Allow to forbid Application redirect URI's with specific rules.

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -7,24 +7,6 @@ module Doorkeeper
     include Models::Revocable
     include Models::Accessible
     include Models::Scopes
-    include ActiveModel::MassAssignmentSecurity if defined?(::ProtectedAttributes)
-
-    included do
-      belongs_to_options = {
-        class_name: 'Doorkeeper::Application',
-        inverse_of: :access_grants
-      }
-      if defined?(ActiveRecord::Base) && ActiveRecord::VERSION::MAJOR >= 5
-        belongs_to_options[:optional] = true
-      end
-
-      belongs_to :application, belongs_to_options
-
-      validates :resource_owner_id, :application_id, :token, :expires_in, :redirect_uri, presence: true
-      validates :token, uniqueness: true
-
-      before_validation :generate_token, on: :create
-    end
 
     module ClassMethods
       # Searches for Doorkeeper::AccessGrant record with the
@@ -38,16 +20,6 @@ module Doorkeeper
       def by_token(token)
         find_by(token: token.to_s)
       end
-    end
-
-    private
-
-    # Generates token value with UniqueToken class.
-    #
-    # @return [String] token value
-    #
-    def generate_token
-      self.token = UniqueToken.generate
     end
   end
 end

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -7,31 +7,6 @@ module Doorkeeper
     include Models::Revocable
     include Models::Accessible
     include Models::Scopes
-    include ActiveModel::MassAssignmentSecurity if defined?(::ProtectedAttributes)
-
-    included do
-      belongs_to_options = {
-        class_name: 'Doorkeeper::Application',
-        inverse_of: :access_tokens
-      }
-      if defined?(ActiveRecord::Base) && ActiveRecord::VERSION::MAJOR >= 5
-        belongs_to_options[:optional] = true
-      end
-
-      belongs_to :application, belongs_to_options
-
-      validates :token, presence: true, uniqueness: true
-      validates :refresh_token, uniqueness: true, if: :use_refresh_token?
-
-      # @attr_writer [Boolean, nil] use_refresh_token
-      #   indicates the possibility of using refresh token
-      attr_writer :use_refresh_token
-
-      before_validation :generate_token, on: :create
-      before_validation :generate_refresh_token,
-                        on: :create,
-                        if: :use_refresh_token?
-    end
 
     module ClassMethods
       # Returns an instance of the Doorkeeper::AccessToken with
@@ -231,7 +206,7 @@ module Doorkeeper
     # @return [String] refresh token value
     #
     def generate_refresh_token
-      write_attribute :refresh_token, UniqueToken.generate
+      self.refresh_token = UniqueToken.generate
     end
 
     # Generates and sets the token value with the
@@ -247,12 +222,7 @@ module Doorkeeper
     def generate_token
       self.created_at ||= Time.now.utc
 
-      generator = token_generator
-      unless generator.respond_to?(:generate)
-        raise Errors::UnableToGenerateToken, "#{generator} does not respond to `.generate`."
-      end
-
-      self.token = generator.generate(
+      self.token = token_generator.generate(
         resource_owner_id: resource_owner_id,
         scopes: scopes,
         application: application,
@@ -263,7 +233,11 @@ module Doorkeeper
 
     def token_generator
       generator_name = Doorkeeper.configuration.access_token_generator
-      generator_name.constantize
+      generator = generator_name.constantize
+
+      return generator if generator.respond_to?(:generate)
+
+      raise Errors::UnableToGenerateToken, "#{generator} does not respond to `.generate`."
     rescue NameError
       raise Errors::TokenGeneratorNotFound, "#{generator_name} not found"
     end

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -4,18 +4,6 @@ module Doorkeeper
 
     include OAuth::Helpers
     include Models::Scopes
-    include ActiveModel::MassAssignmentSecurity if defined?(::ProtectedAttributes)
-
-    included do
-      has_many :access_grants, dependent: :delete_all, class_name: 'Doorkeeper::AccessGrant'
-      has_many :access_tokens, dependent: :delete_all, class_name: 'Doorkeeper::AccessToken'
-
-      validates :name, :secret, :uid, presence: true
-      validates :uid, uniqueness: true
-      validates :redirect_uri, redirect_uri: true
-
-      before_validation :generate_uid, :generate_secret, on: :create
-    end
 
     module ClassMethods
       # Returns an instance of the Doorkeeper::Application with
@@ -50,21 +38,6 @@ module Doorkeeper
     # @return [String] The redirect URI(s) seperated by newlines.
     def redirect_uri=(uris)
       super(uris.is_a?(Array) ? uris.join("\n") : uris)
-    end
-
-    private
-
-    def has_scopes?
-      Doorkeeper.configuration.orm != :active_record ||
-        Doorkeeper::Application.column_names.include?("scopes")
-    end
-
-    def generate_uid
-      self.uid = UniqueToken.generate if uid.blank?
-    end
-
-    def generate_secret
-      self.secret = UniqueToken.generate if secret.blank?
     end
   end
 end

--- a/lib/doorkeeper/oauth/invalid_token_response.rb
+++ b/lib/doorkeeper/oauth/invalid_token_response.rb
@@ -21,7 +21,7 @@ module Doorkeeper
       end
 
       def description
-        scope = { scope: [:doorkeeper, :errors, :messages, :invalid_token] }
+        scope = { scope: %i[doorkeeper errors messages invalid_token] }
         @description ||= I18n.translate @reason, scope
       end
     end

--- a/lib/doorkeeper/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/access_grant.rb
@@ -3,5 +3,32 @@ module Doorkeeper
     self.table_name = "#{table_name_prefix}oauth_access_grants#{table_name_suffix}".to_sym
 
     include AccessGrantMixin
+    include ActiveModel::MassAssignmentSecurity if defined?(::ProtectedAttributes)
+
+    belongs_to_options = {
+      class_name: 'Doorkeeper::Application',
+      inverse_of: :access_grants
+    }
+
+    if defined?(ActiveRecord::Base) && ActiveRecord::VERSION::MAJOR >= 5
+      belongs_to_options[:optional] = true
+    end
+
+    belongs_to :application, belongs_to_options
+
+    validates :resource_owner_id, :application_id, :token, :expires_in, :redirect_uri, presence: true
+    validates :token, uniqueness: true
+
+    before_validation :generate_token, on: :create
+
+    private
+
+    # Generates token value with UniqueToken class.
+    #
+    # @return [String] token value
+    #
+    def generate_token
+      self.token = UniqueToken.generate
+    end
   end
 end

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -3,6 +3,16 @@ module Doorkeeper
     self.table_name = "#{table_name_prefix}oauth_applications#{table_name_suffix}".to_sym
 
     include ApplicationMixin
+    include ActiveModel::MassAssignmentSecurity if defined?(::ProtectedAttributes)
+
+    has_many :access_grants, dependent: :delete_all, class_name: 'Doorkeeper::AccessGrant'
+    has_many :access_tokens, dependent: :delete_all, class_name: 'Doorkeeper::AccessToken'
+
+    validates :name, :secret, :uid, presence: true
+    validates :uid, uniqueness: true
+    validates :redirect_uri, redirect_uri: true
+
+    before_validation :generate_uid, :generate_secret, on: :create
 
     has_many :authorized_tokens, -> { where(revoked_at: nil) }, class_name: 'AccessToken'
     has_many :authorized_applications, through: :authorized_tokens, source: :application
@@ -19,6 +29,16 @@ module Doorkeeper
     def self.authorized_for(resource_owner)
       resource_access_tokens = AccessToken.active_for(resource_owner)
       where(id: resource_access_tokens.select(:application_id).distinct)
+    end
+
+    private
+
+    def generate_uid
+      self.uid = UniqueToken.generate if uid.blank?
+    end
+
+    def generate_secret
+      self.secret = UniqueToken.generate if secret.blank?
     end
   end
 end

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -24,7 +24,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
   end
 
   def translated_error_message(key)
-    I18n.translate key, scope: [:doorkeeper, :errors, :messages]
+    I18n.translate key, scope: %i[doorkeeper errors messages]
   end
 
   let(:client)        { FactoryBot.create :application }

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -36,7 +36,7 @@ describe Doorkeeper::TokensController do
       allow(I18n).to receive(:translate).
         with(
           custom_message,
-          hash_including(scope: [:doorkeeper, :errors, :messages]),
+          hash_including(scope: %i[doorkeeper errors messages]),
         ).
         and_return('Authorization custom message')
 

--- a/spec/lib/oauth/base_request_spec.rb
+++ b/spec/lib/oauth/base_request_spec.rb
@@ -69,7 +69,7 @@ module Doorkeeper::OAuth
         it "returns an ErrorResponse object" do
           error_description = I18n.translate(
             "server_error",
-            scope: [:doorkeeper, :errors, :messages]
+            scope: %i[doorkeeper errors messages]
           )
 
           result = subject.authorize

--- a/spec/lib/oauth/error_spec.rb
+++ b/spec/lib/oauth/error_spec.rb
@@ -13,7 +13,7 @@ module Doorkeeper::OAuth
       it 'is translated from translation messages' do
         expect(I18n).to receive(:translate).with(
           :some_error,
-          scope: [:doorkeeper, :errors, :messages],
+          scope: %i[doorkeeper errors messages],
           default: :server_error
         )
         error.description

--- a/spec/support/helpers/request_spec_helper.rb
+++ b/spec/support/helpers/request_spec_helper.rb
@@ -77,7 +77,7 @@ module RequestSpecHelper
   end
 
   def translated_error_message(key)
-    I18n.translate key, scope: [:doorkeeper, :errors, :messages]
+    I18n.translate key, scope: %i[doorkeeper errors messages]
   end
 
   def response_status_should_be(status)


### PR DESCRIPTION
Clear mixins from ActiveRecord DSL and save only overridable API. It allows to use this mixins in Doorkeeper ORM extensions with minimum code boilerplate (only real ORM-dependent methods like associations, callbacks, validations, etc). Fix Travis build for Rails master.