### PR TITLE
Validate redirect_uri as the native URI when making authorization code requests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#907] Fix lookup for matching tokens in certain edge-cases
+- [#1045] Validate redirect_uri as the native URI when making authorization code requests
 
 ## 4.3.1
 

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -46,10 +46,11 @@ module Doorkeeper
       end
 
       def validate_redirect_uri
-        Helpers::URIChecker.valid_for_authorization?(
-          redirect_uri,
-          grant.redirect_uri
-        )
+        Helpers::URIChecker.native_uri?(redirect_uri) ||
+          Helpers::URIChecker.valid_for_authorization?(
+            redirect_uri,
+            grant.redirect_uri
+          )
       end
     end
   end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -107,5 +107,14 @@ module Doorkeeper::OAuth
         expect(subject.error).to eq(:invalid_grant)
       end
     end
+
+    context "when redirect_uri is the native one" do
+      let(:redirect_uri) { 'urn:ietf:wg:oauth:2.0:oob' }
+
+      it "compares redirect_uri with the configured redirect native URI" do
+        subject.validate
+        expect(subject.error).to eq(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary

[`AuthorizationCodeRequest#validate_redirect_uri`](https://github.com/doorkeeper-gem/doorkeeper/blob/8c337517cfde1237d5a1521b88e9bca364b210e1/lib/doorkeeper/oauth/authorization_code_request.rb#L48-L53) has started to use [`Helpers::URIChecker.valid_for_authorization?`](https://github.com/doorkeeper-gem/doorkeeper/blob/8c337517cfde1237d5a1521b88e9bca364b210e1/lib/doorkeeper/oauth/helpers/uri_checker.rb#L19-L21) since the change in #974. Although this change makes sense, this method does not care the native URI (default is `urn:ietf:wg:oauth:2.0:oob`). So, it seems that `POST /oauth/token` always returns a 401 error when using the native URI as a callback in authorization code flow since v4.3.0.

I think [`Helpers::URIChecker.native_uri?`](https://github.com/doorkeeper-gem/doorkeeper/blob/8c337517cfde1237d5a1521b88e9bca364b210e1/lib/doorkeeper/oauth/helpers/uri_checker.rb#L27-L29) is also needed in `AuthorizationCodeRequest#validate_redirect_uri` to validate as the native URI.
