### PR TITLE
Fix NameError with confidential apps generator

### DIFF
--- a/lib/generators/doorkeeper/templates/add_confidential_to_applications.rb.erb
+++ b/lib/generators/doorkeeper/templates/add_confidential_to_applications.rb.erb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddConfidentialToApplication < ActiveRecord::Migration<%= migration_version %>
+class AddConfidentialToApplications < ActiveRecord::Migration<%= migration_version %>
   def change
     add_column(
       :oauth_applications,

--- a/spec/dummy/db/migrate/20180210183654_add_confidential_to_applications.rb
+++ b/spec/dummy/db/migrate/20180210183654_add_confidential_to_applications.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddConfidentialToApplication < ActiveRecord::Migration[5.1]
+class AddConfidentialToApplications < ActiveRecord::Migration[5.1]
   def change
     add_column(
       :oauth_applications,


### PR DESCRIPTION
### Summary

Fixes typo which caused migration to fail with new Confidential applications migration generator

### Other Information

Error was `NameError: uninitialized constant AddConfidentialToApplications`