### PR TITLE
Ensure that the native redirect_uri parameter matches with redirect_uri of the client.  

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ User-visible changes worth mentioning.
 - [#1010] Add configuration to enforce configured scopes (`default_scopes` and
   `optional_scopes`) for applications
 - [#1053] Support authorizing with query params in the request `redirect_uri` if explicitly present in app's `Application#redirect_uri`
+- [#1060] Ensure that the native redirect_uri parameter matches with redirect_uri of the client
 
 ## 4.3.1
 

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -63,11 +63,10 @@ module Doorkeeper
       end
 
       def validate_redirect_uri
-        Helpers::URIChecker.native_uri?(redirect_uri) ||
-          Helpers::URIChecker.valid_for_authorization?(
-            redirect_uri,
-            grant.redirect_uri
-          )
+        Helpers::URIChecker.valid_for_authorization?(
+          redirect_uri,
+          grant.redirect_uri
+        )
       end
 
       # if either side (server or client) request pkce, check the verifier

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -3,6 +3,7 @@ module Doorkeeper
     module Helpers
       module URIChecker
         def self.valid?(url)
+          return true if native_uri?(url)
           uri = as_uri(url)
           uri.fragment.nil? && !uri.host.nil? && !uri.scheme.nil?
         rescue URI::InvalidURIError

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -72,12 +72,13 @@ module Doorkeeper
         )
       end
 
-      # TODO: test uri should be matched against the client's one
       def validate_redirect_uri
         return false if redirect_uri.blank?
 
-        Helpers::URIChecker.native_uri?(redirect_uri) ||
-          Helpers::URIChecker.valid_for_authorization?(redirect_uri, client.redirect_uri)
+        Helpers::URIChecker.valid_for_authorization?(
+          redirect_uri,
+          client.redirect_uri
+        )
       end
 
       def validate_code_challenge_method

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -113,7 +113,13 @@ module Doorkeeper::OAuth
     context "when redirect_uri is the native one" do
       let(:redirect_uri) { 'urn:ietf:wg:oauth:2.0:oob' }
 
-      it "compares redirect_uri with the configured redirect native URI" do
+      it "invalidates when redirect_uri of the grant is not native" do
+        subject.validate
+        expect(subject.error).to eq(:invalid_grant)
+      end
+
+      it "validates when redirect_uri of the grant is also native" do
+        allow(grant).to receive(:redirect_uri) { redirect_uri }
         subject.validate
         expect(subject.error).to eq(nil)
       end

--- a/spec/lib/oauth/helpers/uri_checker_spec.rb
+++ b/spec/lib/oauth/helpers/uri_checker_spec.rb
@@ -44,6 +44,11 @@ module Doorkeeper::OAuth::Helpers
         uri = '   '
         expect(URIChecker.valid?(uri)).to be_falsey
       end
+
+      it 'is valid for native uris' do
+        uri = 'urn:ietf:wg:oauth:2.0:oob'
+        expect(URIChecker.valid?(uri)).to be_truthy
+      end
     end
 
     describe '.matches?' do

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -123,9 +123,19 @@ module Doorkeeper::OAuth
       expect(subject.scopes).to eq(Scopes.from_string('default'))
     end
 
-    it 'accepts test uri' do
-      subject.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
-      expect(subject).to be_authorizable
+    context 'with native redirect uri' do
+      let(:native_redirect_uri) { 'urn:ietf:wg:oauth:2.0:oob' }
+
+      it 'accepts redirect_uri when it matches with the client' do
+        subject.redirect_uri = native_redirect_uri
+        allow(subject.client).to receive(:redirect_uri) { native_redirect_uri }
+        expect(subject).to be_authorizable
+      end
+
+      it 'invalidates redirect_uri when it does\'n match with the client' do
+        subject.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
+        expect(subject).not_to be_authorizable
+      end
     end
 
     it 'matches the redirect uri against client\'s one' do


### PR DESCRIPTION
### Summary

Even though #1045 fixes the issue with broken native redirect URLs, it bypasses
`Doorkeeper::OAuth::Helpers::URIChecker::valid_for_authorization?` check for
authorization_code grants. This enables `Doorkeeper::
OAuth::AuthorizationCodeRequest#validate_redirect_uri` to return `true` if the
`redirect_uri` parameter is a native URI.

This fix tries to fix this anomaly by changing the behaviour of
`Doorkeeper::OAuth::Helpers::URIChecker::valid?` to return `true` whenever the
`redirect_uri` parameter is a native URI. I think this makes more sense because
this is a logic that is common to all grant types.

### Other Information

When `Doorkeeper::OAuth::Helpers::URIChecker::valid?` returns `true` for native
URLs, `Doorkeeper::OAuth::Helpers::URIChecker::valid_for_authorization?` makes
sure that the given two urls match before returning `true` to the respective
`validate_redirect_uri` methods of different grant types.

Also gets rid of a #TODO from `Doorkeeper::OAuth::PreAuthorization`.