### PR TITLE
Added :after_successful_authorization callback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ User-visible changes worth mentioning.
   `optional_scopes`) for applications
 - [#1053] Support authorizing with query params in the request `redirect_uri` if explicitly present in app's `Application#redirect_uri`
 - [#1060] Ensure that the native redirect_uri parameter matches with redirect_uri of the client
+- [#1064] Add :before_successful_authorization and :after_successful_authorization hooks
 
 ## 4.3.1
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -22,10 +22,13 @@ module Doorkeeper
     private
 
     def render_success
+      before_successful_authorization
       if skip_authorization? || matching_token?
         auth = authorization.authorize
+        after_successful_authorization
         redirect_or_render auth
       elsif Doorkeeper.configuration.api_only
+        after_successful_authorization
         render json: pre_auth
       else
         render :new
@@ -78,6 +81,14 @@ module Doorkeeper
 
     def strategy
       @strategy ||= server.authorization_request pre_auth.response_type
+    end
+
+    def after_successful_authorization
+      Doorkeeper.configuration.after_successful_authorization.call(self)
+    end
+
+    def before_successful_authorization
+      Doorkeeper.configuration.before_successful_authorization.call(self)
     end
   end
 end

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -217,6 +217,8 @@ module Doorkeeper
              ::Rails.logger.warn(I18n.t('doorkeeper.errors.messages.credential_flow_not_configured'))
              nil
            end)
+    option :before_successful_authorization, default: ->(_context) {}
+    option :after_successful_authorization, default: ->(_context) {}
     option :before_successful_strategy_response, default: ->(_request) {}
     option :after_successful_strategy_response,
            default: ->(_request, _response) {}

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -352,4 +352,20 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
       expect(Doorkeeper::AccessToken.count).to eq 0
     end
   end
+
+  describe 'GET #new with callbacks' do
+    after do
+      allow(Doorkeeper.configuration).to receive(:skip_authorization).and_return(proc { true })
+      client.update_attribute :redirect_uri, 'urn:ietf:wg:oauth:2.0:oob'
+      get :new, client_id: client.uid, response_type: 'token', redirect_uri: client.redirect_uri
+    end
+
+    it 'should call :before_successful_authorization callback' do
+      expect(Doorkeeper.configuration).to receive_message_chain(:before_successful_authorization, :call).with(instance_of(described_class))
+    end
+
+    it 'should call :after_successful_authorization callback' do
+      expect(Doorkeeper.configuration).to receive_message_chain(:after_successful_authorization, :call).with(instance_of(described_class))
+    end
+  end
 end


### PR DESCRIPTION
### Summary

This PR adds an ability to run some code after successful authorization. TLDR: https://github.com/doorkeeper-gem/doorkeeper/issues/1062

Example:

```ruby
Doorkeeper.configure do
  after_successful_authorization do |controller|
    controller.session[:logout_urls] << 
      Doorkeeper::Application
      .find_by(controller.request.params.slice(:redirect_uri))
      .logout_uri
  end
end
```
