### PR TITLE
Use factory bot to save application rather than using a double

### DIFF
--- a/spec/lib/oauth/client_credentials_request_spec.rb
+++ b/spec/lib/oauth/client_credentials_request_spec.rb
@@ -13,7 +13,7 @@ module Doorkeeper::OAuth
       )
     end
 
-    let(:application)   { double :application, scopes: Scopes.from_string('') }
+    let(:application)   { FactoryBot.create(:application, scopes: '') }
     let(:client)        { double :client, application: application }
     let(:token_creator) { double :issuer, create: true, token: double }
 

--- a/spec/lib/oauth/token_request_spec.rb
+++ b/spec/lib/oauth/token_request_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper_integration'
 module Doorkeeper::OAuth
   describe TokenRequest do
     let :application do
-      scopes = double(all: ['public'])
-      double(:application, id: 9990, scopes: scopes)
+      FactoryBot.create(:application, scopes: "public")
     end
 
     let :pre_auth do


### PR DESCRIPTION
### Summary

Everywhere else in the doorkeeper specs FactoryBot is used to create applications. This change follows that consistency.  

### Other Information

This change came about while building a custom orm that proxys to our main application's database for application data. There is no nice way of handling application doubles in our mock, so this small change would help us greatly.
