### PR TITLE
Add a rake task to cleanup stale database records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@ User-visible changes worth mentioning.
 - [#1060] Ensure that the native redirect_uri parameter matches with redirect_uri of the client
 - [#1064] Add :before_successful_authorization and :after_successful_authorization hooks
 - [#1069] Upgrade Bootstrap to 4 for Admin
+- [#1068] Add rake task to cleanup databases that can become large over time
 
 ## 4.3.2
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ https://github.com/doorkeeper-gem/doorkeeper/releases
   - [Routes](#routes)
   - [Authenticating](#authenticating)
   - [Internationalization (I18n)](#internationalization-i18n)
+  - [Rake Tasks](#rake-tasks)
 - [Protecting resources with OAuth (a.k.a your API endpoint)](#protecting-resources-with-oauth-aka-your-api-endpoint)
   - [Ruby on Rails controllers](#ruby-on-rails-controllers)
   - [Grape endpoints](#grape-endpoints)
@@ -106,7 +107,7 @@ for each table that includes a `resource_owner_id` column:
 add_foreign_key :table_name, :users, column: :resource_owner_id
 ```
 
-If you want to enable [PKCE flow] for mobile apps, you need to generate another 
+If you want to enable [PKCE flow] for mobile apps, you need to generate another
 migration:
 
 [PKCE flow]: https://tools.ietf.org/html/rfc7636
@@ -115,7 +116,7 @@ migration:
     rails generate doorkeeper:pkce
 ```
 
-If you want to allow PKCE flow without secrets, you can configure doorkeeper to 
+If you want to allow PKCE flow without secrets, you can configure doorkeeper to
 allow this:
 
 ```ruby
@@ -242,6 +243,34 @@ You may want to check other ways of authentication
 
 Doorkeeper support multiple languages. See language files in
 [the I18n repository](https://github.com/doorkeeper-gem/doorkeeper-i18n).
+
+### Rake Tasks
+
+If you are using `rake`, you can load rake tasks provided by this gem, by adding
+the following line to your `Rakefile`:
+
+```ruby
+Doorkeeper::Rake.load_tasks
+```
+
+#### Cleaning up
+
+By default Doorkeeper is retaining expired and revoked access tokens and grants.
+This allows to keep an audit log of those records, but it also leads to the
+corresponding tables to grow large over the lifetime of your application.
+
+If you are concerned about those tables growing too large,
+you can regularly run the following rake task to remove stale entries
+from the database:
+
+```rake
+rake doorkeeper:db:cleanup
+```
+
+Note that this will remove tokens that are expired according to the configured TTL
+in `Doorkeeper.configuration.access_token_expires_in`. The specific `expires_in`
+value of each access token **is not considered**. The same is true for access
+grants.
 
 ## Protecting resources with OAuth (a.k.a your API endpoint)
 
@@ -471,7 +500,7 @@ Doorkeeper 4.3.0 it uses [ActiveSupport lazy loading hooks](http://api.rubyonrai
 to load models. There are [known issue](https://github.com/doorkeeper-gem/doorkeeper/issues/1043)
 with the `factory_bot_rails` gem (it executes factories building before `ActiveRecord::Base`
 is initialized using hooks in gem railtie, so you can catch a `uninitialized constant` error).
-It is recommended to use pure `factory_bot` gem to solve this problem. 
+It is recommended to use pure `factory_bot` gem to solve this problem.
 
 ## Upgrading
 

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -50,6 +50,8 @@ require 'doorkeeper/helpers/controller'
 require 'doorkeeper/rails/routes'
 require 'doorkeeper/rails/helpers'
 
+require 'doorkeeper/rake'
+
 require 'doorkeeper/orm/active_record'
 
 module Doorkeeper

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -1,5 +1,7 @@
 require 'active_support/lazy_load_hooks'
 
+require 'doorkeeper/orm/active_record/stale_records_cleaner'
+
 module Doorkeeper
   module Orm
     module ActiveRecord

--- a/lib/doorkeeper/orm/active_record/stale_records_cleaner.rb
+++ b/lib/doorkeeper/orm/active_record/stale_records_cleaner.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Orm
+    module ActiveRecord
+      class StaleRecordsCleaner
+        def initialize(model)
+          @model = model
+        end
+
+        def clean_revoked
+          table = @model.arel_table
+          @model.where.not(revoked_at: nil)
+                .where(table[:revoked_at].lt(Time.current))
+                .delete_all
+        end
+
+        def clean_expired(ttl)
+          table = @model.arel_table
+          @model.where(table[:created_at].lt(Time.current - ttl))
+                .delete_all
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/rake.rb
+++ b/lib/doorkeeper/rake.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Rake
+    class << self
+      def load_tasks
+        glob = File.join(File.absolute_path(__dir__), 'rake', '*.rake')
+        Dir[glob].each do |rake_file|
+          load rake_file
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/rake/db.rake
+++ b/lib/doorkeeper/rake/db.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+namespace :doorkeeper do
+  namespace :db do
+    desc 'Removes stale data from doorkeeper related database tables'
+    task cleanup: [
+      'doorkeeper:db:cleanup:revoked_tokens',
+      'doorkeeper:db:cleanup:expired_tokens',
+      'doorkeeper:db:cleanup:revoked_grants',
+      'doorkeeper:db:cleanup:expired_grants'
+    ]
+
+    namespace :cleanup do
+      desc 'Removes stale access tokens'
+      task revoked_tokens: 'doorkeeper:setup' do
+        cleaner = Doorkeeper::Orm::ActiveRecord::StaleRecordsCleaner.new(Doorkeeper::AccessToken)
+        cleaner.clean_revoked
+      end
+
+      desc 'Removes expired (TTL passed) access tokens'
+      task expired_tokens: 'doorkeeper:setup' do
+        cleaner = Doorkeeper::Orm::ActiveRecord::StaleRecordsCleaner.new(Doorkeeper::AccessToken)
+        cleaner.clean_expired(Doorkeeper.configuration.access_token_expires_in)
+      end
+
+      desc 'Removes stale access grants'
+      task revoked_grants: 'doorkeeper:setup' do
+        cleaner = Doorkeeper::Orm::ActiveRecord::StaleRecordsCleaner.new(Doorkeeper::AccessGrant)
+        cleaner.clean_revoked
+      end
+
+      desc 'Removes expired (TTL passed) access grants'
+      task expired_grants: 'doorkeeper:setup' do
+        cleaner = Doorkeeper::Orm::ActiveRecord::StaleRecordsCleaner.new(Doorkeeper::AccessGrant)
+        cleaner.clean_expired(Doorkeeper.configuration.authorization_code_expires_in)
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/rake/setup.rake
+++ b/lib/doorkeeper/rake/setup.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+namespace :doorkeeper do
+  task setup: :environment do
+  end
+end

--- a/spec/lib/models/expirable_spec.rb
+++ b/spec/lib/models/expirable_spec.rb
@@ -45,6 +45,5 @@ describe 'Expirable' do
       allow(subject).to receive(:expires_in).and_return(nil)
       expect(subject.expires_in_seconds).to be_nil
     end
-
   end
 end

--- a/spec/lib/orm/active_record/stale_records_cleaner_spec.rb
+++ b/spec/lib/orm/active_record/stale_records_cleaner_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Doorkeeper::Orm::ActiveRecord::StaleRecordsCleaner do
+  let(:cleaner) { described_class.new(model) }
+  let(:models_by_name) do
+    {
+      access_token: Doorkeeper::AccessToken,
+      access_grant: Doorkeeper::AccessGrant
+    }
+  end
+
+  %i[access_token access_grant].each do |model_name|
+    context "(#{model_name})" do
+      let(:model) { models_by_name.fetch(model_name) }
+
+      describe '#clean_revoked' do
+        subject { cleaner.clean_revoked }
+
+        context 'with revoked record' do
+          before do
+            FactoryBot.create model_name, revoked_at: Time.current - 1.minute
+          end
+
+          it 'removes the record' do
+            expect { subject }.to change { model.count }.to(0)
+          end
+        end
+
+        context 'with record revoked in the future' do
+          before do
+            FactoryBot.create model_name, revoked_at: Time.current + 1.minute
+          end
+
+          it 'keeps the record' do
+            expect { subject }.not_to change { model.count }
+          end
+        end
+
+        context 'with unrevoked record' do
+          before do
+            FactoryBot.create model_name, revoked_at: nil
+          end
+
+          it 'keeps the record' do
+            expect { subject }.not_to change { model.count }
+          end
+        end
+      end
+
+      describe '#clean_expired' do
+        subject { cleaner.clean_expired(ttl) }
+        let(:ttl) { 500 }
+        let(:expiry_border) { ttl.seconds.ago }
+
+        context 'with record that is expired' do
+          before do
+            FactoryBot.create model_name, created_at: expiry_border - 1.minute
+          end
+
+          it 'removes the record' do
+            expect { subject }.to change { model.count }.to(0)
+          end
+        end
+
+        context 'with record that is not expired' do
+          before do
+            FactoryBot.create model_name, created_at: expiry_border + 1.minute
+          end
+
+          it 'keeps the record' do
+            expect { subject }.not_to change { model.count }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Based on discussions in https://github.com/doorkeeper-gem/doorkeeper/issues/536,
this merge request wraps "safe to execute" maintenance tasks
in a rake task.

For now this is basically the one-liner provided by @tute, but I assume that there is more
data that we can safely remove during such a cleanup.

My main motivation is that migrations on the `oauth_access_tokens` table tend to take quite a long
time, when that table has grown rather large.