### PR TITLE
AuthorizationsController: Memoize strategy.authorize result

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@ User-visible changes worth mentioning.
 - [#1064] Add :before_successful_authorization and :after_successful_authorization hooks
 - [#1069] Upgrade Bootstrap to 4 for Admin
 - [#1068] Add rake task to cleanup databases that can become large over time
+- [#1072] AuthorizationsController: Memoize strategy.authorize_response result to enable
+  subclasses to use the response object.
 
 ## 4.3.2
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -12,7 +12,7 @@ module Doorkeeper
 
     # TODO: Handle raise invalid authorization
     def create
-      redirect_or_render authorization.authorize
+      redirect_or_render authorize_response
     end
 
     def destroy
@@ -24,7 +24,7 @@ module Doorkeeper
     def render_success
       before_successful_authorization
       if skip_authorization? || matching_token?
-        auth = authorization.authorize
+        auth = authorize_response
         after_successful_authorization
         redirect_or_render auth
       elsif Doorkeeper.configuration.api_only
@@ -81,6 +81,10 @@ module Doorkeeper
 
     def strategy
       @strategy ||= server.authorization_request pre_auth.response_type
+    end
+
+    def authorize_response
+      @authorize_response ||= strategy.authorize
     end
 
     def after_successful_authorization

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -368,4 +368,18 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
       expect(Doorkeeper.configuration).to receive_message_chain(:after_successful_authorization, :call).with(instance_of(described_class))
     end
   end
+
+  describe 'authorize response memoization' do
+    it 'memoizes the result of the authorization' do
+      strategy = double(:strategy, authorize: true)
+      expect(strategy).to receive(:authorize).once
+      allow(controller).to receive(:strategy) { strategy }
+      allow(controller).to receive(:create) do
+        2.times { controller.send :authorize_response }
+        controller.render json: {}, status: :ok
+      end
+
+      post :create
+    end
+  end
 end

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -74,7 +74,8 @@ describe Doorkeeper::TokensController do
       expect(strategy).to receive(:authorize).once
       allow(controller).to receive(:strategy) { strategy }
       allow(controller).to receive(:create) do
-        controller.send :authorize_response
+        2.times { controller.send :authorize_response }
+        controller.render json: {}, status: :ok
       end
 
       post :create


### PR DESCRIPTION
This allows easy access to the authorize response in a subclass of Doorkeeper::AuthorizationsController. It's equivalent to #568, which made the same change to TokensController.