### PR TITLE
Call before/after_successful_authorization callbacks on create as well as new

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@ User-visible changes worth mentioning.
 - [#1068] Add rake task to cleanup databases that can become large over time
 - [#1072] AuthorizationsController: Memoize strategy.authorize_response result to enable
   subclasses to use the response object.
+- [#1075] Call `before_successful_authorization` and `after_successful_authorization` hooks
+  on `create` action as well as `new`
 
 ## 4.3.2
 


### PR DESCRIPTION
### Summary

The before/after_successful_authorization callbacks added in #1064 are only called on the `new` action. I think they should also be called on `create` to cover situations where the user must explicitly authorize the client.

### Other Information

I also found that the callbacks can be run when authorization is not successful. I added some more tests and modified the existing code a bit.

This PR has some conflicts with my other PR, #1072. I'll resolve them but wanted to put this up for review.

cc @nattfodd 