### PR TITLE
Only clean expired access tokens without a refresh token

### DIFF
--- a/lib/doorkeeper/orm/active_record/stale_records_cleaner.rb
+++ b/lib/doorkeeper/orm/active_record/stale_records_cleaner.rb
@@ -4,21 +4,21 @@ module Doorkeeper
   module Orm
     module ActiveRecord
       class StaleRecordsCleaner
-        def initialize(model)
-          @model = model
+        def initialize(base_scope)
+          @base_scope = base_scope
         end
 
         def clean_revoked
-          table = @model.arel_table
-          @model.where.not(revoked_at: nil)
-                .where(table[:revoked_at].lt(Time.current))
-                .delete_all
+          table = @base_scope.arel_table
+          @base_scope.where.not(revoked_at: nil)
+                     .where(table[:revoked_at].lt(Time.current))
+                     .delete_all
         end
 
         def clean_expired(ttl)
-          table = @model.arel_table
-          @model.where(table[:created_at].lt(Time.current - ttl))
-                .delete_all
+          table = @base_scope.arel_table
+          @base_scope.where(table[:created_at].lt(Time.current - ttl))
+                     .delete_all
         end
       end
     end

--- a/lib/doorkeeper/rake/db.rake
+++ b/lib/doorkeeper/rake/db.rake
@@ -19,7 +19,8 @@ namespace :doorkeeper do
 
       desc 'Removes expired (TTL passed) access tokens'
       task expired_tokens: 'doorkeeper:setup' do
-        cleaner = Doorkeeper::Orm::ActiveRecord::StaleRecordsCleaner.new(Doorkeeper::AccessToken)
+        expirable_tokens = Doorkeeper::AccessToken.where(refresh_token: nil)
+        cleaner = Doorkeeper::Orm::ActiveRecord::StaleRecordsCleaner.new(expirable_tokens)
         cleaner.clean_expired(Doorkeeper.configuration.access_token_expires_in)
       end
 


### PR DESCRIPTION
The refresh token is usable even after the initial access token expired.
Therefore as soon as a refresh_token is present, we can't automatically
delete corresponding access tokens.

This does not affect revoked access tokens, their refresh_tokens are
supposed to be invalid, too.