### PR TITLE
Fix #916: use configured routes for responses

### DIFF
--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -47,7 +47,7 @@ module Doorkeeper
 
         def native_redirect
           {
-            controller: 'doorkeeper/token_info',
+            controller: controller,
             action: :show,
             access_token: token.token
           }
@@ -57,6 +57,13 @@ module Doorkeeper
 
         def configuration
           Doorkeeper.configuration
+        end
+
+        def controller
+          @controller ||= begin
+            mapping = Doorkeeper::Rails::Routes.mapping[:token_info] || {}
+            mapping[:controllers] || 'doorkeeper/token_info'
+          end
         end
       end
     end

--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -4,6 +4,10 @@ require 'doorkeeper/rails/routes/mapper'
 module Doorkeeper
   module Rails
     class Routes # :nodoc:
+      mattr_reader :mapping do
+        {}
+      end
+
       module Helper
         def use_doorkeeper(options = {}, &block)
           Doorkeeper::Rails::Routes.new(self, &block).generate_routes!(options)
@@ -40,7 +44,11 @@ module Doorkeeper
       private
 
       def map_route(name, method)
-        send(method, @mapping[name]) unless @mapping.skipped?(name)
+       unless @mapping.skipped?(name)
+         send(method, @mapping[name])
+
+         mapping[name] = @mapping[name]
+       end
       end
 
       def authorization_routes(mapping)

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,52 +1,13 @@
 Rails.application.routes.draw do
   use_doorkeeper
-  use_doorkeeper scope: 'scope'
 
-  scope 'inner_space' do
-    use_doorkeeper scope: 'scope' do
-      controllers authorizations: 'custom_authorizations',
-                  tokens: 'custom_authorizations',
-                  applications: 'custom_authorizations',
-                  token_info: 'custom_authorizations'
-
-      as authorizations: 'custom_auth',
-         tokens: 'custom_token',
-         token_info: 'custom_token_info'
-    end
-  end
-
-  scope 'space' do
-    use_doorkeeper do
-      controllers authorizations: 'custom_authorizations',
-                  tokens: 'custom_authorizations',
-                  applications: 'custom_authorizations',
-                  token_info: 'custom_authorizations'
-
-      as authorizations: 'custom_auth',
-         tokens: 'custom_token',
-         token_info: 'custom_token_info'
-    end
-  end
-
-  scope 'outer_space' do
-    use_doorkeeper do
-      controllers authorizations: 'custom_authorizations',
-                  tokens: 'custom_authorizations',
-                  token_info: 'custom_authorizations'
-
-      as authorizations: 'custom_auth',
-         tokens: 'custom_token',
-         token_info: 'custom_token_info'
-
-      skip_controllers :tokens, :applications, :token_info
-    end
-  end
+  resources :semi_protected_resources
+  resources :full_protected_resources
 
   get 'metal.json' => 'metal#index'
 
   get '/callback', to: 'home#callback'
   get '/sign_in',  to: 'home#sign_in'
-  resources :semi_protected_resources
-  resources :full_protected_resources
+
   root to: 'home#index'
 end

--- a/spec/routing/custom_controller_routes_spec.rb
+++ b/spec/routing/custom_controller_routes_spec.rb
@@ -1,27 +1,79 @@
 require 'spec_helper'
 
 describe 'Custom controller for routes' do
-  it 'GET /space/scope/authorize routes to custom authorizations controller' do
+  before :all do
+    Rails.application.routes.disable_clear_and_finalize = true
+
+    Rails.application.routes.draw do
+      scope 'inner_space' do
+        use_doorkeeper scope: 'scope' do
+          controllers authorizations: 'custom_authorizations',
+                      tokens: 'custom_authorizations',
+                      applications: 'custom_authorizations',
+                      token_info: 'custom_authorizations'
+
+          as authorizations: 'custom_auth',
+             tokens: 'custom_token',
+             token_info: 'custom_token_info'
+        end
+      end
+
+      scope 'space' do
+        use_doorkeeper do
+          controllers authorizations: 'custom_authorizations',
+                      tokens: 'custom_authorizations',
+                      applications: 'custom_authorizations',
+                      token_info: 'custom_authorizations'
+
+          as authorizations: 'custom_auth',
+             tokens: 'custom_token',
+             token_info: 'custom_token_info'
+        end
+      end
+
+      scope 'outer_space' do
+        use_doorkeeper do
+          controllers authorizations: 'custom_authorizations',
+                      tokens: 'custom_authorizations',
+                      token_info: 'custom_authorizations'
+
+          as authorizations: 'custom_auth',
+             tokens: 'custom_token',
+             token_info: 'custom_token_info'
+
+          skip_controllers :tokens, :applications, :token_info
+        end
+      end
+    end
+  end
+
+  after :all do
+    Rails.application.routes.clear!
+
+    load File.expand_path('../dummy/config/routes.rb', __dir__)
+  end
+
+  it 'GET /inner_space/scope/authorize routes to custom authorizations controller' do
     expect(get('/inner_space/scope/authorize')).to route_to('custom_authorizations#new')
   end
 
-  it 'POST /space/scope/authorize routes to custom authorizations controller' do
+  it 'POST /inner_space/scope/authorize routes to custom authorizations controller' do
     expect(post('/inner_space/scope/authorize')).to route_to('custom_authorizations#create')
   end
 
-  it 'DELETE /space/scope/authorize routes to custom authorizations controller' do
+  it 'DELETE /inner_space/scope/authorize routes to custom authorizations controller' do
     expect(delete('/inner_space/scope/authorize')).to route_to('custom_authorizations#destroy')
   end
 
-  it 'POST /space/scope/token routes to tokens controller' do
+  it 'POST /inner_space/scope/token routes to tokens controller' do
     expect(post('/inner_space/scope/token')).to route_to('custom_authorizations#create')
   end
 
-  it 'GET /space/scope/applications routes to applications controller' do
+  it 'GET /inner_space/scope/applications routes to applications controller' do
     expect(get('/inner_space/scope/applications')).to route_to('custom_authorizations#index')
   end
 
-  it 'GET /space/scope/token/info routes to the token_info controller' do
+  it 'GET /inner_space/scope/token/info routes to the token_info controller' do
     expect(get('/inner_space/scope/token/info')).to route_to('custom_authorizations#show')
   end
 

--- a/spec/routing/scoped_routes_spec.rb
+++ b/spec/routing/scoped_routes_spec.rb
@@ -1,6 +1,20 @@
 require 'spec_helper'
 
 describe 'Scoped routes' do
+  before :all do
+    Rails.application.routes.disable_clear_and_finalize = true
+
+    Rails.application.routes.draw do
+      use_doorkeeper scope: 'scope'
+    end
+  end
+
+  after :all do
+    Rails.application.routes.clear!
+
+    load File.expand_path('../dummy/config/routes.rb', __dir__)
+  end
+
   it 'GET /scope/authorize routes to authorizations controller' do
     expect(get('/scope/authorize')).to route_to('doorkeeper/authorizations#new')
   end


### PR DESCRIPTION
Remember Routes mapping on Doorkeeper routes setup and use it's
values inside responses. This one must fix an error with customized
token_info controller and authorization/token response.