### PR TITLE
Support OIDC 1.0's optional `prompt` parameter

### DIFF
--- a/app/views/doorkeeper/authorizations/error.html.erb
+++ b/app/views/doorkeeper/authorizations/error.html.erb
@@ -3,5 +3,5 @@
 </div>
 
 <main role="main">
-  <pre><%= @pre_auth.error_response.body[:error_description] %></pre>
+  <pre><%= @prompt_error || @pre_auth.error_response.body[:error_description] %></pre>
 </main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,10 @@ en:
         access_denied: 'The resource owner or authorization server denied the request.'
         invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
         invalid_code_challenge_method: 'The code challenge method must be plain or S256.'
+        invalid_prompt: 'The requested prompt is invalid, unknown, or malformed.'
+        login_required: 'The authorization server requires resource owner authentication.'
+        interaction_required: 'The authorization server requires resource owner interaction.'
+        consent_required: 'The authorization server requires resource owner consent.'
         server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
         temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
 

--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -29,7 +29,7 @@ module Doorkeeper
         }.reject { |_, v| v.blank? }
       end
 
-      def as_json(_options)
+      def as_json(_options = {})
         body
       end
 

--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -29,6 +29,10 @@ module Doorkeeper
         }.reject { |_, v| v.blank? }
       end
 
+      def as_json(_options)
+        body
+      end
+
       def status
         :unauthorized
       end

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -8,9 +8,10 @@ module Doorkeeper
       validate :scopes, error: :invalid_scope
       validate :redirect_uri, error: :invalid_redirect_uri
       validate :code_challenge_method, error: :invalid_code_challenge_method
+      validate :prompt, error: :invalid_prompt
 
       attr_accessor :server, :client, :response_type, :redirect_uri, :state,
-                    :code_challenge, :code_challenge_method
+                    :code_challenge, :code_challenge_method, :prompt
       attr_writer   :scope
 
       def initialize(server, client, attrs = {})
@@ -22,6 +23,7 @@ module Doorkeeper
         @state                 = attrs[:state]
         @code_challenge        = attrs[:code_challenge]
         @code_challenge_method = attrs[:code_challenge_method]
+        @prompt                = attrs[:prompt].try(:to_sym)
       end
 
       def authorizable?
@@ -50,6 +52,18 @@ module Doorkeeper
           client_name: client.name,
           status: I18n.t('doorkeeper.pre_authorization.status')
         }
+      end
+
+      def prompt_login?
+        prompt == :login
+      end
+
+      def prompt_consent?
+        prompt == :consent
+      end
+
+      def no_prompt?
+        prompt == :none
       end
 
       private
@@ -83,6 +97,12 @@ module Doorkeeper
 
       def validate_code_challenge_method
         !code_challenge.present? || (code_challenge_method.present? && code_challenge_method =~ /^plain$|^S256$/)
+      end
+
+      def validate_prompt
+        # TODO: Should we handle `select_account` as specified in OIDC 1.0?
+        return true unless prompt.present?
+        %i[none login consent].include?(prompt)
       end
     end
   end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -46,6 +46,72 @@ module Doorkeeper::OAuth
       expect(subject).to be_authorizable
     end
 
+    context 'when prompt' do
+      let :attributes do
+        {
+          response_type: 'code',
+          redirect_uri: 'http://tst.com/auth',
+          state: 'save-this',
+          prompt: prompt
+        }
+      end
+      context 'is invalid' do
+        let(:prompt) { 'garbage' }
+
+        it 'is not authorizable' do
+          expect(subject).not_to be_authorizable
+        end
+      end
+      context 'is none' do
+        let(:prompt) { 'none' }
+
+        it 'is authorizable' do
+          expect(subject).to be_authorizable
+        end
+        it 'should have prompt_login? as false' do
+          expect(subject.prompt_login?).to eq(false)
+        end
+        it 'should have prompt_consent? as false' do
+          expect(subject.prompt_consent?).to eq(false)
+        end
+        it 'should have no_prompt? as true' do
+          expect(subject.no_prompt?).to eq(true)
+        end
+      end
+      context 'is login' do
+        let(:prompt) { 'login' }
+
+        it 'is authorizable' do
+          expect(subject).to be_authorizable
+        end
+        it 'should have prompt_login? as true' do
+          expect(subject.prompt_login?).to eq(true)
+        end
+        it 'should have prompt_consent? as false' do
+          expect(subject.prompt_consent?).to eq(false)
+        end
+        it 'should have no_prompt? as false' do
+          expect(subject.no_prompt?).to eq(false)
+        end
+      end
+      context 'is consent' do
+        let(:prompt) { 'consent' }
+
+        it 'is authorizable' do
+          expect(subject).to be_authorizable
+        end
+        it 'should have prompt_login? as false' do
+          expect(subject.prompt_login?).to eq(false)
+        end
+        it 'should have prompt_consent? as true' do
+          expect(subject.prompt_consent?).to eq(true)
+        end
+        it 'should have no_prompt? as false' do
+          expect(subject.no_prompt?).to eq(false)
+        end
+      end
+    end
+
     context 'when using default grant flows' do
       it 'accepts "code" as response type' do
         subject.response_type = 'code'


### PR DESCRIPTION
Per http://openid.net/specs/openid-connect-core-1_0.html

Prompt accepts a few different values:

- `none`: Must not display consent or authorization pages. Either will redirect or error with `login_required` or `consent_required`. This param allows devs to use The Silent Authentication method as described by Auth0.
- `login`: Should prompt user for reauthentication. Doorkeeper will just fail with `login_required`.
- `consent`: Should prompt user for consent. Doorkeeper will not automatically redirect even if matching token.

Fixes #1073 