### PR TITLE
Fix ApplicationsController for API-only mode

### DIFF
--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   class ApplicationsController < Doorkeeper::ApplicationController
-    layout 'doorkeeper/admin'
+    try(:layout, 'doorkeeper/admin') # there's no layout method in API-only mode
 
     before_action :authenticate_admin!
     before_action :set_application, only: %i[show edit update destroy]


### PR DESCRIPTION
There's no `layout` method when in Rails API mode.

Fixes #1096 .