### PR TITLE
Erowlin/fix default config values and do not trigger double sql queries when refresh token is disabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,10 @@ upgrade guides.
 User-visible changes worth mentioning.
 
 ## master
-
+- [#1099] All the configuration variables in `Doorkeeper.configuration` now
+          always return a non-nil value (`true` or `false`)
+- [#1099] ORM / Query optimization: Do not revoke the refresh token if it is not enabled
+          in `doorkeeper.rb`
 - [#996] Expiration Time Base On Grant Type
 - [#997] Allow PKCE authorization_code flow as specified in RFC7636
 - [#907] Fix lookup for matching tokens in certain edge-cases

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -292,24 +292,32 @@ module Doorkeeper
     attr_reader :api_only
     attr_reader :enforce_content_type
 
+    def api_only
+      @api_only ||= false
+    end
+
+    def enforce_content_type
+      @enforce_content_type ||= false
+    end
+
     def refresh_token_enabled?
-      defined?(@refresh_token_enabled) && @refresh_token_enabled
+      !!(defined?(@refresh_token_enabled) && @refresh_token_enabled)
     end
 
     def pkce_without_secret_enabled?
-      defined?(@pkce_without_secret_enabled) && @pkce_without_secret_enabled
+      !!(defined?(@pkce_without_secret_enabled) && @pkce_without_secret_enabled)
     end
 
     def enforce_configured_scopes?
-      defined?(@enforce_configured_scopes) && @enforce_configured_scopes
+      !!(defined?(@enforce_configured_scopes) && @enforce_configured_scopes)
     end
 
     def enable_application_owner?
-      defined?(@enable_application_owner) && @enable_application_owner
+      !!(defined?(@enable_application_owner) && @enable_application_owner)
     end
 
     def confirm_application_owner?
-      defined?(@confirm_application_owner) && @confirm_application_owner
+      !!(defined?(@confirm_application_owner) && @confirm_application_owner)
     end
 
     def default_scopes

--- a/lib/doorkeeper/oauth/token.rb
+++ b/lib/doorkeeper/oauth/token.rb
@@ -13,7 +13,10 @@ module Doorkeeper
         def authenticate(request, *methods)
           if (token = from_request(request, *methods))
             access_token = AccessToken.by_token(token)
-            access_token.revoke_previous_refresh_token! if access_token
+            refresh_token_enabled = Doorkeeper.configuration.refresh_token_enabled?
+            if access_token.present? && refresh_token_enabled
+              access_token.revoke_previous_refresh_token!
+            end
             access_token
           end
         end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -132,7 +132,7 @@ describe Doorkeeper, 'configuration' do
 
   describe 'use_refresh_token' do
     it 'is false by default' do
-      expect(subject.refresh_token_enabled?).to be_falsey
+      expect(subject.refresh_token_enabled?).to eq(false)
     end
 
     it 'can change the value' do
@@ -141,7 +141,7 @@ describe Doorkeeper, 'configuration' do
         use_refresh_token
       end
 
-      expect(subject.refresh_token_enabled?).to be_truthy
+      expect(subject.refresh_token_enabled?).to eq(true)
     end
 
     it "does not includes 'refresh_token' in authorization_response_types" do
@@ -164,7 +164,7 @@ describe Doorkeeper, 'configuration' do
 
   describe 'enforce_configured_scopes' do
     it 'is false by default' do
-      expect(subject.enforce_configured_scopes?).to be_falsey
+      expect(subject.enforce_configured_scopes?).to eq(false)
     end
 
     it 'can change the value' do
@@ -173,13 +173,13 @@ describe Doorkeeper, 'configuration' do
         enforce_configured_scopes
       end
 
-      expect(subject.enforce_configured_scopes?).to be_truthy
+      expect(subject.enforce_configured_scopes?).to eq(true)
     end
   end
 
   describe 'enable_pkce_without_secret' do
     it 'is false by default' do
-      expect(subject.pkce_without_secret_enabled?).to be_falsey
+      expect(subject.pkce_without_secret_enabled?).to eq(false)
     end
 
     it 'can change the value' do
@@ -188,7 +188,7 @@ describe Doorkeeper, 'configuration' do
         enable_pkce_without_secret
       end
 
-      expect(subject.pkce_without_secret_enabled?).to be_truthy
+      expect(subject.pkce_without_secret_enabled?).to eq(true)
     end
   end
 
@@ -209,7 +209,7 @@ describe Doorkeeper, 'configuration' do
 
   describe 'force_ssl_in_redirect_uri' do
     it 'is true by default in non-development environments' do
-      expect(subject.force_ssl_in_redirect_uri).to be_truthy
+      expect(subject.force_ssl_in_redirect_uri).to eq(true)
     end
 
     it 'can change the value' do
@@ -218,7 +218,7 @@ describe Doorkeeper, 'configuration' do
         force_ssl_in_redirect_uri(false)
       end
 
-      expect(subject.force_ssl_in_redirect_uri).to be_falsey
+      expect(subject.force_ssl_in_redirect_uri).to eq(false)
     end
 
     it 'can be a callable object' do
@@ -229,7 +229,7 @@ describe Doorkeeper, 'configuration' do
       end
 
       expect(subject.force_ssl_in_redirect_uri).to eq(block)
-      expect(subject.force_ssl_in_redirect_uri.call).to be_falsey
+      expect(subject.force_ssl_in_redirect_uri.call).to eq(false)
     end
   end
 
@@ -250,7 +250,7 @@ describe Doorkeeper, 'configuration' do
 
   describe 'forbid_redirect_uri' do
     it 'is false by default' do
-      expect(subject.forbid_redirect_uri.call(URI.parse('https://localhost'))).to be_falsey
+      expect(subject.forbid_redirect_uri.call(URI.parse('https://localhost'))).to eq(false)
     end
 
     it 'can be a callable object' do
@@ -261,13 +261,13 @@ describe Doorkeeper, 'configuration' do
       end
 
       expect(subject.forbid_redirect_uri).to eq(block)
-      expect(subject.forbid_redirect_uri.call).to be_truthy
+      expect(subject.forbid_redirect_uri.call).to eq(true)
     end
   end
 
   describe 'enable_application_owner' do
     it 'is disabled by default' do
-      expect(Doorkeeper.configuration.enable_application_owner?).not_to be_truthy
+      expect(Doorkeeper.configuration.enable_application_owner?).not_to eq(true)
     end
 
     context 'when enabled without confirmation' do
@@ -283,7 +283,7 @@ describe Doorkeeper, 'configuration' do
       end
 
       it 'Doorkeeper.configuration.confirm_application_owner? returns false' do
-        expect(Doorkeeper.configuration.confirm_application_owner?).not_to be_truthy
+        expect(Doorkeeper.configuration.confirm_application_owner?).not_to eq(true)
       end
     end
 
@@ -300,7 +300,7 @@ describe Doorkeeper, 'configuration' do
       end
 
       it 'Doorkeeper.configuration.confirm_application_owner? returns true' do
-        expect(Doorkeeper.configuration.confirm_application_owner?).to be_truthy
+        expect(Doorkeeper.configuration.confirm_application_owner?).to eq(true)
       end
     end
   end
@@ -467,7 +467,7 @@ describe Doorkeeper, 'configuration' do
 
   describe "api_only" do
     it "is false by default" do
-      expect(subject.api_only).to be_falsey
+      expect(subject.api_only).to eq(false)
     end
 
     it "can change the value" do
@@ -476,13 +476,13 @@ describe Doorkeeper, 'configuration' do
         api_only
       end
 
-      expect(subject.api_only).to be_truthy
+      expect(subject.api_only).to eq(true)
     end
   end
 
   describe 'strict_content_type' do
     it 'is false by default' do
-      expect(subject.enforce_content_type).to be_falsey
+      expect(subject.enforce_content_type).to eq(false)
     end
 
     it "can change the value" do
@@ -491,7 +491,7 @@ describe Doorkeeper, 'configuration' do
         enforce_content_type
       end
 
-      expect(subject.enforce_content_type).to be_truthy
+      expect(subject.enforce_content_type).to eq(true)
     end
   end
 end


### PR DESCRIPTION
### Summary

This solves #1099 : Whenever authenticating on the server, we tried to revoke a refresh token, even if it was not enabled in the configuration (initializer). 
It removes the unnecessary call to the ORM (or the storage). 

I also updated the `config` builder because it were returning tri-state booleans (`nil`, `true`, `false`) instead of `true` or `false`. Methods finishing with `question mark ?` should never return nil. 

### Other Information

Should I update `NEWS.md`? 