### PR TITLE
Implement custom use_refresh_token

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ upgrade guides.
 User-visible changes worth mentioning.
 
 ## master
+- [#1103] Allow customizing use_refresh_token
 - [#1089] Removed enable_pkce_without_secret configuration option
 - [#1102] Expiration time based on scopes
 - [#1099] All the configuration variables in `Doorkeeper.configuration` now

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -103,9 +103,12 @@ module Doorkeeper
         @config.instance_variable_set(:@access_token_methods, methods)
       end
 
-      # Issue access tokens with refresh token (disabled by default)
-      def use_refresh_token
-        @config.instance_variable_set(:@refresh_token_enabled, true)
+      # Issue access tokens with refresh token (disabled if not set)
+      def use_refresh_token(enabled = true, &block)
+        @config.instance_variable_set(
+          :@refresh_token_enabled,
+          block ? block : enabled
+        )
       end
 
       # Reuse access token for the same resource owner within an application
@@ -289,7 +292,11 @@ module Doorkeeper
     end
 
     def refresh_token_enabled?
-      !!(defined?(@refresh_token_enabled) && @refresh_token_enabled)
+      if defined?(@refresh_token_enabled)
+        @refresh_token_enabled
+      else
+        false
+      end
     end
 
     def enforce_configured_scopes?

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -31,12 +31,13 @@ module Doorkeeper
       end
 
       def find_or_create_access_token(client, resource_owner_id, scopes, server)
+        context = Authorization::Token.build_context(client, grant_type, scopes)
         @access_token = AccessToken.find_or_create_for(
           client,
           resource_owner_id,
           scopes,
-          Authorization::Token.access_token_expires_in(server, client, grant_type, scopes),
-          server.refresh_token_enabled?
+          Authorization::Token.access_token_expires_in(server, context),
+          Authorization::Token.refresh_token_enabled?(server, context)
         )
       end
 

--- a/lib/doorkeeper/oauth/client_credentials/issuer.rb
+++ b/lib/doorkeeper/oauth/client_credentials/issuer.rb
@@ -25,12 +25,12 @@ module Doorkeeper
         private
 
         def create_token(client, scopes, creator)
-          ttl = Authorization::Token.access_token_expires_in(
-            @server,
+          context = Authorization::Token.build_context(
             client,
             Doorkeeper::OAuth::CLIENT_CREDENTIALS,
             scopes
           )
+          ttl = Authorization::Token.access_token_expires_in(@server, context)
 
           creator.call(
             client,

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -65,12 +65,12 @@ module Doorkeeper
       end
 
       def access_token_expires_in
-        Authorization::Token.access_token_expires_in(
-          server,
+        context = Authorization::Token.build_context(
           client,
           Doorkeeper::OAuth::REFRESH_TOKEN,
           scopes
         )
+        Authorization::Token.access_token_expires_in(server, context)
       end
 
       def validate_token_presence

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -66,7 +66,14 @@ Doorkeeper.configure do
   #
   # reuse_access_token
 
-  # Issue access tokens with refresh token (disabled by default)
+  # Issue access tokens with refresh token (disabled by default), you may also
+  # pass a block which accepts `context` to customize when to give a refresh
+  # token or not. Similar to `custom_access_token_expires_in`, `context` has
+  # the properties:
+  #
+  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
   #
   # use_refresh_token
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -144,6 +144,24 @@ describe Doorkeeper, 'configuration' do
       expect(subject.refresh_token_enabled?).to eq(true)
     end
 
+    it 'can accept a boolean parameter' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        use_refresh_token false
+      end
+
+      expect(subject.refresh_token_enabled?).to eq(false)
+    end
+
+    it 'can accept a block parameter' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        use_refresh_token { |_context| nil }
+      end
+
+      expect(subject.refresh_token_enabled?).to be_a(Proc)
+    end
+
     it "does not includes 'refresh_token' in authorization_response_types" do
       expect(subject.token_grant_types).not_to include 'refresh_token'
     end

--- a/spec/lib/oauth/base_request_spec.rb
+++ b/spec/lib/oauth/base_request_spec.rb
@@ -119,6 +119,30 @@ module Doorkeeper::OAuth
         )
         expect(result.expires_in).to eql(500)
       end
+
+      it "respects use_refresh_token with a block" do
+        server = double(:server,
+                        access_token_expires_in: 100,
+                        custom_access_token_expires_in: ->(_context) { nil },
+                        refresh_token_enabled?: lambda { |context|
+                          context.scopes == "public"
+                        })
+        result = subject.find_or_create_access_token(
+          client,
+          "1",
+          "public",
+          server
+        )
+        expect(result.refresh_token).to_not be_nil
+
+        result = subject.find_or_create_access_token(
+          client,
+          "1",
+          "private",
+          server
+        )
+        expect(result.refresh_token).to be_nil
+      end
     end
 
     describe "#scopes" do


### PR DESCRIPTION
### Summary

This is meant to address #646, it lets you customize when to give a refresh token or not. This uses the same `context` as `custom_access_token_expires_in` that was added in #1102
