### PR TITLE
fix as discussed in issue #1089

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ upgrade guides.
 User-visible changes worth mentioning.
 
 ## master
+- [#1089] Removed enable_pkce_without_secret configuration option
 - [#1102] Expiration time based on scopes
 - [#1099] All the configuration variables in `Doorkeeper.configuration` now
           always return a non-nil value (`true` or `false`)

--- a/README.md
+++ b/README.md
@@ -116,22 +116,16 @@ migration:
     rails generate doorkeeper:pkce
 ```
 
-If you want to allow PKCE flow without secrets, you can configure doorkeeper to
-allow this:
-
-```ruby
-Doorkeeper.configure do
-  # ...
-  enable_pkce_without_secret
-  # ...
-end
-```
-
 Then run migrations:
 
 ```sh
 rake db:migrate
 ```
+
+Ensure to use non-confidential apps for pkce. PKCE is created, because
+you cannot trust its apps' secret. So whatever app needs pkce: it means, it cannot
+be a confidential app by design.
+
 
 Remember to add associations to your model so the related records are deleted.
 If you don't do this an `ActiveRecord::InvalidForeignKey`-error will be raised

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -103,18 +103,6 @@ module Doorkeeper
         @config.instance_variable_set(:@access_token_methods, methods)
       end
 
-      # There is a big Android oAuth library, that does not send a client secret in PKCE authorization_code flow:
-      # https://github.com/openid/AppAuth-Android/blob/7089089ab6a5950da773d68168e2683da523bfd5/library/java/net/openid/
-      # appauth/AuthorizationManagementActivity.java
-      # It is quite easily understandable, why they do not support secrets. Although its defined in RCF7636 where secret
-      # is required, as it is in the standard authorization_code flow it's required. RCF7636 explains itself, that PKCE
-      # is invented, because you never can trust a static client_secret in a mobile app. Still it should be default,
-      # that secret is expected. But whoever wants to support a library as above, can use enable_pkce_without_secret
-      # in doorkeeper initializer to do so.
-      def enable_pkce_without_secret
-        @config.instance_variable_set(:@pkce_without_secret_enabled, true)
-      end
-
       # Issue access tokens with refresh token (disabled by default)
       def use_refresh_token
         @config.instance_variable_set(:@refresh_token_enabled, true)
@@ -302,10 +290,6 @@ module Doorkeeper
 
     def refresh_token_enabled?
       !!(defined?(@refresh_token_enabled) && @refresh_token_enabled)
-    end
-
-    def pkce_without_secret_enabled?
-      !!(defined?(@pkce_without_secret_enabled) && @pkce_without_secret_enabled)
     end
 
     def enforce_configured_scopes?

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -18,16 +18,9 @@ module Doorkeeper
         @grant_type = Doorkeeper::OAuth::AUTHORIZATION_CODE
         @redirect_uri = parameters[:redirect_uri]
         @code_verifier = parameters[:code_verifier]
-        @client = client_by_uid(parameters) if no_secret_allowed_for_pkce?
       end
 
       private
-
-      def no_secret_allowed_for_pkce?
-        Doorkeeper.configuration.pkce_without_secret_enabled? &&
-          grant.pkce_supported? &&
-          grant.code_challenge.present? && @client.blank?
-      end
 
       def client_by_uid(parameters)
         Doorkeeper::Application.by_uid(parameters[:client_id])

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -176,15 +176,6 @@ Doorkeeper.configure do
   #       .logout_uri
   # end
 
-  # If you enabled PKCE by running rails g doorkeeper:pkce and migrating, you
-  # can configure to allow PKCE authorization_code grant without providing a
-  # secret. To do so is inconsistent with RCF7636. But since PKCE is created,
-  # because you cannot trust secrets on mobile apps, there are implementations
-  # on Android, which implemented it completely without secret. If you need to
-  # support those libraries, you can do so by uncommenting following line:
-  #
-  # enable_pkce_without_secret
-
   # Under some circumstances you might want to have applications auto-approved,
   # so that the user skips the authorization step.
   # For example if dealing with a trusted application.

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -177,21 +177,6 @@ describe Doorkeeper, 'configuration' do
     end
   end
 
-  describe 'enable_pkce_without_secret' do
-    it 'is false by default' do
-      expect(subject.pkce_without_secret_enabled?).to eq(false)
-    end
-
-    it 'can change the value' do
-      Doorkeeper.configure do
-        orm DOORKEEPER_ORM
-        enable_pkce_without_secret
-      end
-
-      expect(subject.pkce_without_secret_enabled?).to eq(true)
-    end
-  end
-
   describe 'client_credentials' do
     it 'has defaults order' do
       expect(subject.client_credentials_methods).to eq([:from_basic, :from_params])

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -218,8 +218,8 @@ feature 'Authorization Code Flow' do
           should_not_have_json 'access_token'
         end
 
-        scenario 'mobile app requests an access token with authorization code and without secret but doorkeeper allows' do
-          Doorkeeper.configuration.instance_variable_set :@pkce_without_secret_enabled, true
+        scenario 'mobile app requests an access token with authorization code and without secret but is marked as not confidential' do
+          @client.update_attribute :confidential, false
           visit authorization_endpoint_url(client: @client, code_challenge: code_challenge, code_challenge_method: 'S256')
           click_on 'Authorize'
 


### PR DESCRIPTION
### Summary

As discussed in https://github.com/doorkeeper-gem/doorkeeper/issues/1089:
I removed the option for disabling secret for pkce flow. This should be done by using non-confidential apps from now on.
