### PR TITLE
#1097: make admin controller forbidden by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,8 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [] Add new entries here.
+- [#1106] Restrict access to AdminController with 'Forbidden 403' if admin_authenticator is not
+  configured by developers..
 
 ## 5.0.0.rc1
 
@@ -15,9 +16,9 @@ User-visible changes worth mentioning.
 - [#1089] Removed enable_pkce_without_secret configuration option
 - [#1102] Expiration time based on scopes
 - [#1099] All the configuration variables in `Doorkeeper.configuration` now
-          always return a non-nil value (`true` or `false`)
+  always return a non-nil value (`true` or `false`)
 - [#1099] ORM / Query optimization: Do not revoke the refresh token if it is not enabled
-          in `doorkeeper.rb`
+  in `doorkeeper.rb`
 - [#996] Expiration Time Base On Grant Type
 - [#997] Allow PKCE authorization_code flow as specified in RFC7636
 - [#907] Fix lookup for matching tokens in certain edge-cases

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,7 @@ en:
         # Configuration error messages
         credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
         resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured.'
+        admin_authenticator_not_configured: 'Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured.'
 
         # Access grant errors
         unsupported_response_type: 'The authorization server does not support this response type.'

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -210,7 +210,13 @@ module Doorkeeper
 
     option :admin_authenticator,
            as: :authenticate_admin,
-           default: ->(_routes) {}
+           default: (lambda do |_routes|
+             ::Rails.logger.warn(
+               I18n.t('doorkeeper.errors.messages.admin_authenticator_not_configured')
+             )
+
+             head :forbidden
+           end)
 
     option :resource_owner_from_credentials,
            default: (lambda do |_routes|

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -67,6 +67,17 @@ describe Doorkeeper, 'configuration' do
 
   describe 'admin_authenticator' do
     it 'sets the block that is accessible via authenticate_admin' do
+      default_behaviour = 'default behaviour'
+      allow(Doorkeeper::Config).to receive(:head).and_return(default_behaviour)
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+      end
+
+      expect(subject.authenticate_admin.call({})).to eq(default_behaviour)
+    end
+
+    it 'sets the block that is accessible via authenticate_admin' do
       block = proc {}
       Doorkeeper.configure do
         orm DOORKEEPER_ORM

--- a/spec/requests/applications/applications_request_spec.rb
+++ b/spec/requests/applications/applications_request_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 feature 'Adding applications' do
   context 'in application form' do
     background do
+      i_am_logged_in
       visit '/oauth/applications/new'
     end
 
@@ -96,12 +97,15 @@ end
 
 feature 'Listing applications' do
   background do
+    i_am_logged_in
+
     FactoryBot.create :application, name: 'Oauth Dude'
     FactoryBot.create :application, name: 'Awesome App'
   end
 
   scenario 'application list' do
     visit '/oauth/applications'
+
     i_should_see 'Awesome App'
     i_should_see 'Oauth Dude'
   end
@@ -126,11 +130,14 @@ end
 
 feature 'Show application' do
   given :app do
+    i_am_logged_in
+
     FactoryBot.create :application, name: 'Just another oauth app'
   end
 
   scenario 'visiting application page' do
     visit "/oauth/applications/#{app.id}"
+
     i_should_see 'Just another oauth app'
   end
 end
@@ -141,12 +148,15 @@ feature 'Edit application' do
   end
 
   background do
+    i_am_logged_in
+
     visit "/oauth/applications/#{app.id}/edit"
   end
 
   scenario 'updating a valid app' do
     fill_in 'doorkeeper_application[name]', with: 'Serious app'
     click_button 'Submit'
+
     i_should_see 'Application updated'
     i_should_see 'Serious app'
     i_should_not_see 'OMG my app'
@@ -155,21 +165,27 @@ feature 'Edit application' do
   scenario 'updating an invalid app' do
     fill_in 'doorkeeper_application[name]', with: ''
     click_button 'Submit'
+
     i_should_see 'Whoops! Check your form for possible errors'
   end
 end
 
 feature 'Remove application' do
   background do
+    i_am_logged_in
+
     @app = FactoryBot.create :application
   end
 
   scenario 'deleting an application from list' do
     visit '/oauth/applications'
+
     i_should_see @app.name
+
     within(:css, "tr#application_#{@app.id}") do
       click_button 'Destroy'
     end
+
     i_should_see 'Application deleted'
     i_should_not_see @app.name
   end
@@ -177,6 +193,35 @@ feature 'Remove application' do
   scenario 'deleting an application from show' do
     visit "/oauth/applications/#{@app.id}"
     click_button 'Destroy'
+
     i_should_see 'Application deleted'
+  end
+end
+
+context 'when admin authenticator block is default' do
+  let(:app) { FactoryBot.create :application, name: 'app' }
+
+  feature 'application list' do
+    scenario 'fails with forbidden' do
+      visit '/oauth/applications'
+
+      should_have_status 403
+    end
+  end
+
+  feature 'adding an app' do
+    scenario 'fails with forbidden' do
+      visit '/oauth/applications/new'
+
+      should_have_status 403
+    end
+  end
+
+  feature 'editing an app' do
+    scenario 'fails with forbidden' do
+      visit "/oauth/applications/#{app.id}/edit"
+
+      should_have_status 403
+    end
   end
 end

--- a/spec/support/helpers/request_spec_helper.rb
+++ b/spec/support/helpers/request_spec_helper.rb
@@ -1,4 +1,8 @@
 module RequestSpecHelper
+  def i_am_logged_in
+    allow(Doorkeeper.configuration).to receive(:authenticate_admin).and_return(->(*) {})
+  end
+
   def i_should_see(content)
     expect(page).to have_content(content)
   end
@@ -37,6 +41,10 @@ module RequestSpecHelper
 
   def should_have_header(header, value)
     expect(headers[header]).to eq(value)
+  end
+
+  def should_have_status(status)
+    expect(page.driver.response.status).to eq(status)
   end
 
   def with_access_token_header(token)


### PR DESCRIPTION
Restrict access to admin controller with head 403 if admin_authenticator is not configured by developers.