### PR TITLE
Better format callback URLs on index page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#1106] Restrict access to AdminController with 'Forbidden 403' if admin_authenticator is not
   configured by developers..
+- [#1108] Simple formating of callback URLs when listing oauth applications
 
 ## 5.0.0.rc1
 

--- a/app/views/doorkeeper/applications/index.html.erb
+++ b/app/views/doorkeeper/applications/index.html.erb
@@ -21,7 +21,7 @@
         <%= link_to application.name, oauth_application_path(application) %>
       </td>
       <td class="align-middle">
-        <%= application.redirect_uri %>
+        <%= simple_format(application.redirect_uri) %>
       </td>
       <td class="align-middle">
         <%= application.confidential? ? t('doorkeeper.applications.index.confidentiality.yes') : t('doorkeeper.applications.index.confidentiality.no') %>


### PR DESCRIPTION
### Summary

Just a visual improvement to show each callback URL on it's own line per application

### Before

![unnamed-3](https://user-images.githubusercontent.com/740/41739440-48190358-7552-11e8-8f17-d3511aa1e90d.png)

### After

![unnamed-4](https://user-images.githubusercontent.com/740/41739443-4cd5e5fa-7552-11e8-8e44-95199fff7a48.png)
