### PR TITLE
Warn on improper usage of OAuth strategies

### DIFF
--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -119,7 +119,7 @@ module Doorkeeper
       #
       # @return [Doorkeeper::AccessToken] existing record or a new one
       #
-      def find_or_create_for(application, resource_owner_id, scopes, expires_in, use_refresh_token)
+      def find_or_create_for(application, resource_owner_id, scopes, expires_in, use_refresh_token, strategy)
         if Doorkeeper.configuration.reuse_access_token
           access_token = matching_token_for(application, resource_owner_id, scopes)
 
@@ -131,6 +131,7 @@ module Doorkeeper
           resource_owner_id: resource_owner_id,
           scopes:            scopes.to_s,
           expires_in:        expires_in,
+          strategy_used:     strategy,
           use_refresh_token: use_refresh_token
         )
       end

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -54,7 +54,8 @@ module Doorkeeper
             resource_owner.id,
             pre_auth.scopes,
             self.class.access_token_expires_in(configuration, context),
-            false
+            false,
+            Doorkeeper::OAuth::IMPLICIT
           )
         end
 

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -37,7 +37,8 @@ module Doorkeeper
           resource_owner_id,
           scopes,
           Authorization::Token.access_token_expires_in(server, context),
-          Authorization::Token.refresh_token_enabled?(server, context)
+          Authorization::Token.refresh_token_enabled?(server, context),
+          strategy
         )
       end
 
@@ -50,6 +51,21 @@ module Doorkeeper
       end
 
       private
+
+      def strategy
+        case self
+        when ClientCredentialsRequest
+          CLIENT_CREDENTIALS
+        when AuthorizationCodeRequest
+          grant.uses_pkce? ? "#{AUTHORIZATION_CODE}_with_pkce" : AUTHORIZATION_CODE
+        when RefreshTokenRequest
+          REFRESH_TOKEN
+        when PasswordAccessTokenRequest
+          PASSWORD
+        when CodeResponse
+          IMPLICIT
+        end
+      end
 
       def build_scopes
         if @original_scopes.present?

--- a/lib/doorkeeper/oauth/client.rb
+++ b/lib/doorkeeper/oauth/client.rb
@@ -3,7 +3,7 @@ module Doorkeeper
     class Client
       attr_accessor :application
 
-      delegate :id, :name, :uid, :redirect_uri, :scopes, to: :@application
+      delegate :id, :name, :uid, :redirect_uri, :scopes, :confidential?, to: :@application
 
       def initialize(application)
         @application = application

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -5,7 +5,7 @@ module Doorkeeper
         def call(client, scopes, attributes = {})
           AccessToken.find_or_create_for(
             client, nil, scopes, attributes[:expires_in],
-            attributes[:use_refresh_token])
+            attributes[:use_refresh_token], Doorkeeper::OAuth::CLIENT_CREDENTIALS)
         end
       end
     end

--- a/lib/doorkeeper/orm/active_record/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/access_token.rb
@@ -17,6 +17,7 @@ module Doorkeeper
     belongs_to :application, belongs_to_options
 
     validates :token, presence: true, uniqueness: true
+    validates :strategy_used, presence: true, inclusion: { in: (Doorkeeper::OAuth::GRANT_TYPES + ["#{Doorkeeper::OAuth::AUTHORIZATION_CODE}_with_pkce"]).freeze }
     validates :refresh_token, uniqueness: true, if: :use_refresh_token?
 
     # @attr_writer [Boolean, nil] use_refresh_token

--- a/spec/dummy/db/migrate/20180710152529_add_strategy_used_to_access_token.rb
+++ b/spec/dummy/db/migrate/20180710152529_add_strategy_used_to_access_token.rb
@@ -1,0 +1,10 @@
+class AddStrategyUsedToAccessToken < ActiveRecord::Migration[5.2]
+  def change
+    add_column(
+      :oauth_access_tokens,
+      :strategy_used,
+      :string,
+      null: true
+    )
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180210183654) do
+ActiveRecord::Schema.define(version: 2018_07_10_152529) do
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 20180210183654) do
     t.datetime "created_at", null: false
     t.string "scopes"
     t.string "previous_refresh_token", default: "", null: false
+    t.string "strategy_used"
     t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
     t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     sequence(:resource_owner_id) { |n| n }
     application
     expires_in 2.hours
+    strategy_used 'authorization_code'
 
     factory :clientless_access_token do
       application nil


### PR DESCRIPTION
Attempts to solve #1055.

TODO:

- [x] Store the strategy used when creating an access token
- [ ] Don't warn if refresh token is used by a public app that previously obtained token via PKCE
- [ ] Write Doorkeeper wiki pages explaining proper usage (Auth0 is a good reference)
- [ ] Support non-Rails apps by using `Doorkeeeper.configuration.logger`

Am I missing anything?