### PR TITLE
Uses `expires_in` on token show endpoint for consistency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ User-visible changes worth mentioning.
 - [#1108] Simple formating of callback URLs when listing oauth applications
 - [#1116] `AccessGrant`s will now be revoked along with `AccessToken`s when
   hitting the `AuthorizedApplicationController#destroy` route.
+- [#1114] Make token info endpoint's attributes consistent with token creation
 
 ## 5.0.0.rc1
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -187,8 +187,8 @@ module Doorkeeper
     def as_json(_options = {})
       {
         resource_owner_id:  resource_owner_id,
-        scopes:             scopes,
-        expires_in_seconds: expires_in_seconds,
+        scope:              scopes,
+        expires_in:         expires_in_seconds,
         application:        { uid: application.try(:uid) },
         created_at:         created_at.to_i
       }

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -450,8 +450,8 @@ module Doorkeeper
         token = FactoryBot.create :access_token
         token_hash = {
           resource_owner_id:  token.resource_owner_id,
-          scopes:             token.scopes,
-          expires_in_seconds: token.expires_in_seconds,
+          scope:              token.scopes,
+          expires_in:         token.expires_in_seconds,
           application:        { uid: token.application.uid },
           created_at:         token.created_at.to_i
         }


### PR DESCRIPTION
Creating an access token yields a response body with the parameter "expires_in" which is recommended as part of the OAuth2 spec. It makes sense to be consistent with this parameter on the info/show token equivalent endpoint instead of calling it "expires_in_seconds"

This makes consumers of Doorkeeper write less code since the response from both POST /oauth/token and GET /oauth/token/info are more uniform.

### Before

```json
{
    "resource_owner_id": "foobar",
    "scopes": [
        "read",
        "write"
    ],
    "expires_in_seconds": 6508,
    "application": {
        "uid": "484bcd6326d810eab40569c6035a199c8d104389c7ba191c79af47fbdd2381c4"
    },
    "created_at": 1529939540
}
```

### After

```json
{
    "resource_owner_id": "foobar",
    "scopes": [
        "read",
        "write"
    ],
    "expires_in": 6508,
    "application": {
        "uid": "484bcd6326d810eab40569c6035a199c8d104389c7ba191c79af47fbdd2381c4"
    },
    "created_at": 1529939540
}
```

### What POST /oauth/token looks like

```json
{
    "access_token": "a56502c067f5ffea09665e3d38d6e087092713f8f94a2041657ca3b3a23a927c",
    "token_type": "bearer",
    "expires_in": 7200,
    "refresh_token": "80a270eaf934ceedbf62bcca64e942342c5f1bbb4358a36e04b63d80123d7062",
    "scope": "read write",
    "created_at": 1529940302,
    "resource_owner_id": "foobar"
}
```