### PR TITLE
Jw revoke patch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ User-visible changes worth mentioning.
 - [#1106] Restrict access to AdminController with 'Forbidden 403' if admin_authenticator is not
   configured by developers..
 - [#1108] Simple formating of callback URLs when listing oauth applications
+- [#1116] `AccessGrant`s will now be revoked along with `AccessToken`s when
+  hitting the `AuthorizedApplicationController#destroy` route.
 
 ## 5.0.0.rc1
 

--- a/app/controllers/doorkeeper/authorized_applications_controller.rb
+++ b/app/controllers/doorkeeper/authorized_applications_controller.rb
@@ -12,7 +12,10 @@ module Doorkeeper
     end
 
     def destroy
-      AccessToken.revoke_all_for params[:id], current_resource_owner
+      Application.revoke_tokens_and_grants_for(
+        params[:id],
+        current_resource_owner
+      )
 
       respond_to do |format|
         format.html do

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -31,6 +31,21 @@ module Doorkeeper
         find_by(token: token.to_s)
       end
 
+      # Revokes AccessGrant records that have not been revoked and associated
+      # with the specific Application and Resource Owner.
+      #
+      # @param application_id [Integer]
+      #   ID of the Application
+      # @param resource_owner [ActiveRecord::Base]
+      #   instance of the Resource Owner model
+      #
+      def revoke_all_for(application_id, resource_owner, clock = Time)
+        where(application_id: application_id,
+              resource_owner_id: resource_owner.id,
+              revoked_at: nil).
+          update_all(revoked_at: clock.now.utc)
+      end
+
       # Implements PKCE code_challenge encoding without base64 padding as described in the spec.
       # https://tools.ietf.org/html/rfc7636#appendix-A
       #   Appendix A.  Notes on Implementing Base64url Encoding without Padding

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -34,6 +34,17 @@ module Doorkeeper
       where(id: resource_access_tokens.select(:application_id).distinct)
     end
 
+    # Revokes AccessToken and AccessGrant records that have not been revoked and
+    # associated with the specific Application and Resource Owner.
+    #
+    # @param resource_owner [ActiveRecord::Base]
+    #   instance of the Resource Owner model
+    #
+    def self.revoke_tokens_and_grants_for(id, resource_owner)
+      AccessToken.revoke_all_for(id, resource_owner)
+      AccessGrant.revoke_all_for(id, resource_owner)
+    end
+
     private
 
     def generate_uid

--- a/spec/models/doorkeeper/access_grant_spec.rb
+++ b/spec/models/doorkeeper/access_grant_spec.rb
@@ -33,4 +33,47 @@ describe Doorkeeper::AccessGrant do
       expect(subject).not_to be_valid
     end
   end
+
+  describe '.revoke_all_for' do
+    let(:resource_owner) { double(id: 100) }
+    let(:application) { FactoryBot.create :application }
+    let(:default_attributes) do
+      {
+        application: application,
+        resource_owner_id: resource_owner.id
+      }
+    end
+
+    it 'revokes all tokens for given application and resource owner' do
+      FactoryBot.create :access_grant, default_attributes
+
+      described_class.revoke_all_for(application.id, resource_owner)
+
+      described_class.all.each do |token|
+        expect(token).to be_revoked
+      end
+    end
+
+    it 'matches application' do
+      access_grant_for_different_app = FactoryBot.create(
+        :access_grant,
+        default_attributes.merge(application: FactoryBot.create(:application))
+      )
+
+      described_class.revoke_all_for(application.id, resource_owner)
+
+      expect(access_grant_for_different_app.reload).not_to be_revoked
+    end
+
+    it 'matches resource owner' do
+      access_grant_for_different_owner = FactoryBot.create(
+        :access_grant,
+        default_attributes.merge(resource_owner_id: 90)
+      )
+
+      described_class.revoke_all_for application.id, resource_owner
+
+      expect(access_grant_for_different_owner.reload).not_to be_revoked
+    end
+  end
 end

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -306,15 +306,25 @@ module Doorkeeper
       end
 
       it 'matches application' do
-        FactoryBot.create :access_token, default_attributes.merge(application: FactoryBot.create(:application))
+        access_token_for_different_app = FactoryBot.create(
+          :access_token,
+          default_attributes.merge(application: FactoryBot.create(:application))
+        )
+
         AccessToken.revoke_all_for application.id, resource_owner
-        expect(AccessToken.all).not_to be_empty
+
+        expect(access_token_for_different_app.reload).not_to be_revoked
       end
 
       it 'matches resource owner' do
-        FactoryBot.create :access_token, default_attributes.merge(resource_owner_id: 90)
+        access_token_for_different_owner = FactoryBot.create(
+          :access_token,
+          default_attributes.merge(resource_owner_id: 90)
+        )
+
         AccessToken.revoke_all_for application.id, resource_owner
-        expect(AccessToken.all).not_to be_empty
+
+        expect(access_token_for_different_owner.reload).not_to be_revoked
       end
     end
 

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -206,6 +206,19 @@ module Doorkeeper
       end
     end
 
+    describe :revoke_tokens_and_grants_for do
+      it 'revokes all access tokens and access grants' do
+        application_id = 42
+        resource_owner = double
+        expect(Doorkeeper::AccessToken).
+          to receive(:revoke_all_for).with(application_id, resource_owner)
+        expect(Doorkeeper::AccessGrant).
+          to receive(:revoke_all_for).with(application_id, resource_owner)
+
+        Application.revoke_tokens_and_grants_for(application_id, resource_owner)
+      end
+    end
+
     describe :by_uid_and_secret do
       context "when application is private/confidential" do
         it "finds the application via uid/secret" do


### PR DESCRIPTION
### Summary

Hey folks,

Someone recently submitted an issue to my team about a security issue surrounding Doorkeeper access grants. Seems small but probably worth fixing.

The issue is that post-revocation of an access token, any access grants outstanding are still valid (until expiration which is default 10 mins). Since this code can be exchanged for an access token it should also be revoked with the other access tokens.

Notes are in the respective commits but to summarize changes:
- Update specs for `AccessToken.revoke_all_for` to ensure scope is respected
- Add `AccessGrant.revoke_all_for`
- Add `Application.revoke_all_for` which in turn calls `revoke_all_for` on both `AccessGrant` and `AccessToken`
- Call `Application.revoke_all_for` in `AuthorizedApplicationsController#destroy` action