### PR TITLE
Use Application#confidential? to determine revocation auth eligibility

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ User-visible changes worth mentioning.
 - [#1116] `AccessGrant`s will now be revoked along with `AccessToken`s when
   hitting the `AuthorizedApplicationController#destroy` route.
 - [#1114] Make token info endpoint's attributes consistent with token creation
+- [#1119] Fix token revocation for OAuth apps using "implicit" grant flow
 
 ## 5.0.0.rc1
 

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -56,16 +56,15 @@ module Doorkeeper
     # https://tools.ietf.org/html/rfc6749#section-2.1
     # https://tools.ietf.org/html/rfc7009
     def authorized?
-      if token.present?
-        # Client is confidential, therefore client authentication & authorization
-        # is required
-        if token.application_id?
-          # We authorize client by checking token's application
-          server.client && server.client.application == token.application
-        else
-          # Client is public, authentication unnecessary
-          true
-        end
+      return unless token.present?
+      # Client is confidential, therefore client authentication & authorization
+      # is required
+      if token.application_id? && token.application.confidential?
+        # We authorize client by checking token's application
+        server.client && server.client.application == token.application
+      else
+        # Client is public, authentication unnecessary
+        true
       end
     end
 


### PR DESCRIPTION
OAuth applications that obtain an access token using the "implicit" grant flow will have their ID set on the token record. Unfortunately this causes the revocation controller code to think it's as confidential application. Because of this, Doorkeeper enforces oauth client authentication and the revocation call fails.

Fixes #891 