### PR TITLE
Add note about Rails CSRF protections

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,7 @@ end
 ```
 
 Keep in mind, that in this mode you will not be able to access `Applications` or
-`Authorized Applications` controllers because they will be skipped. Also all the
-redirects will be returned as JSON response with corresponding locations.
+`Authorized Applications` controllers because they will be skipped. CSRF protections (which are otherwise enabled) will be skipped, and all the redirects will be returned as JSON response with corresponding locations.
 
 ### Routes
 


### PR DESCRIPTION
It would be helpful if the documentation included a reference to Doorkeeper providing CSRF protection by default -- I just spent a while debugging why my client was failing with CSRF protections even though my app was configured not to use it; hopefully having the term in the readme will help others as well.

Thanks for the great gem!
