### PR TITLE
 Change the token_type initials of the Banner Token to uppercase

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#] Add description here
+- [#1127] Change the token_type initials of the Banner Token to uppercase to comply with the RFC6750 specification.
 
 ## 5.0.0.rc2
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -173,7 +173,7 @@ module Doorkeeper
     #   The OAuth 2.0 Authorization Framework: Bearer Token Usage
     #
     def token_type
-      'bearer'
+      'Bearer'
     end
 
     def use_refresh_token?

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -57,7 +57,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     end
 
     it 'includes token type in fragment' do
-      expect(response.query_params['token_type']).to eq('bearer')
+      expect(response.query_params['token_type']).to eq('Bearer')
     end
 
     it 'includes token expiration in fragment' do
@@ -95,7 +95,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     end
 
     it "includes token type in fragment" do
-      expect(redirect_uri.match(/token_type=(\w+)&?/)[1]).to eq "bearer"
+      expect(redirect_uri.match(/token_type=(\w+)&?/)[1]).to eq "Bearer"
     end
 
     it "includes token expiration in fragment" do
@@ -293,7 +293,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     end
 
     it 'includes token type in fragment' do
-      expect(response.query_params['token_type']).to eq('bearer')
+      expect(response.query_params['token_type']).to eq('Bearer')
     end
 
     it 'includes token expiration in fragment' do
@@ -355,7 +355,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     it "sets redirect_uri to correct value" do
       redirect_uri = JSON.parse(response.body)["redirect_uri"]
       expect(redirect_uri).to_not be_nil
-      expect(redirect_uri.match(/token_type=(\w+)&?/)[1]).to eq "bearer"
+      expect(redirect_uri.match(/token_type=(\w+)&?/)[1]).to eq "Bearer"
       expect(redirect_uri.match(/expires_in=(\d+)&?/)[1].to_i).to eq 1234
       expect(
         redirect_uri.match(/access_token=([a-f0-9]+)&?/)[1]

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -54,7 +54,7 @@ feature 'Authorization Code Flow' do
     should_not_have_json 'error'
 
     should_have_json 'access_token', Doorkeeper::AccessToken.first.token
-    should_have_json 'token_type', 'bearer'
+    should_have_json 'token_type', 'Bearer'
     should_have_json_within 'expires_in', Doorkeeper::AccessToken.first.expires_in, 1
   end
 
@@ -107,7 +107,7 @@ feature 'Authorization Code Flow' do
         should_not_have_json 'error'
 
         should_have_json 'access_token', Doorkeeper::AccessToken.first.token
-        should_have_json 'token_type', 'bearer'
+        should_have_json 'token_type', 'Bearer'
         should_have_json_within 'expires_in', Doorkeeper::AccessToken.first.expires_in, 1
       end
 
@@ -150,7 +150,7 @@ feature 'Authorization Code Flow' do
         should_not_have_json 'error'
 
         should_have_json 'access_token', Doorkeeper::AccessToken.first.token
-        should_have_json 'token_type', 'bearer'
+        should_have_json 'token_type', 'Bearer'
         should_have_json_within 'expires_in', Doorkeeper::AccessToken.first.expires_in, 1
       end
 
@@ -185,7 +185,7 @@ feature 'Authorization Code Flow' do
         should_not_have_json 'error'
 
         should_have_json 'access_token', Doorkeeper::AccessToken.first.token
-        should_have_json 'token_type', 'bearer'
+        should_have_json 'token_type', 'Bearer'
         should_have_json_within 'expires_in', Doorkeeper::AccessToken.first.expires_in, 1
       end
 


### PR DESCRIPTION
### Summary

Change the token_type initials of the Banner Token to uppercase to comply with the RFC6750 specification. 

The current version of the doorkeeper has compatibility issues with [AWS ALB's OIDC functionality](https://aws.amazon.com/blogs/aws/built-in-authentication-in-alb/). The reason this failure occurred is that the load balancer was expecting the access token type as "token_type":"Bearer" (uppercase B) as per the OpenID Connect Specification mentioned below: 


> "The OAuth 2.0 token_type response parameter value MUST be Bearer, as specified in OAuth 2.0 Bearer Token Usage [RFC6750](https://tools.ietf.org/html/rfc6750
) , unless another Token Type has been negotiated with the Client. Servers SHOULD support the Bearer Token Type; use of other Token Types is outside the scope of this specification." 
