### PR TITLE
Make breaking api change to native authorization code route optional

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ User-visible changes worth mentioning.
 
 ## master
 
+## 4.4.3
+- [#1143] Adds a config option opt_out_native_route_change to opt out of the
+  breaking api changed introduced in
+  https://github.com/doorkeeper-gem/doorkeeper/pull/1003
+
 ## 4.4.2
 - [#1130] Backport fix for native redirect_uri from 5.x.
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -114,6 +114,15 @@ doorkeeper.
       def reuse_access_token
         @config.instance_variable_set(:@reuse_access_token, true)
       end
+
+      # Opt out of breaking api change to the native authorization code flow.
+      # Opting out sets the authorization code response route for native
+      # redirect uris to oauth/authorize/<code>. The default is
+      # oauth/authorize/native?code=<code>.
+      # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1143
+      def opt_out_native_route_change
+        @config.instance_variable_set(:@opt_out_native_route_change, true)
+      end
     end
 
     module Option
@@ -293,6 +302,11 @@ doorkeeper.
 
     def token_grant_types
       @token_grant_types ||= calculate_token_grant_types
+    end
+
+    def native_authorization_code_route
+      @opt_out_native_route_change ||= false
+      @opt_out_native_route_change ? '/:code' : '/native'
     end
 
     private

--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -47,7 +47,7 @@ module Doorkeeper
           as: mapping[:as],
           controller: mapping[:controllers]
         ) do
-          routes.get '/native', action: :show, on: :member
+          routes.get native_authorization_code_route, action: :show, on: :member
           routes.get '/', action: :new, on: :member
         end
       end
@@ -84,6 +84,10 @@ module Doorkeeper
 
       def authorized_applications_routes(mapping)
         routes.resources :authorized_applications, only: %i[index destroy], controller: mapping[:controllers]
+      end
+
+      def native_authorization_code_route
+        Doorkeeper.configuration.native_authorization_code_route
       end
     end
   end

--- a/lib/doorkeeper/version.rb
+++ b/lib/doorkeeper/version.rb
@@ -28,7 +28,7 @@ HEREDOC
     # Semantic versioning
     MAJOR = 4
     MINOR = 4
-    TINY = 2
+    TINY = 3
 
     # Full version number
     STRING = [MAJOR, MINOR, TINY].compact.join('.')

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -164,6 +164,38 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     it 'should not issue a token' do
       expect(Doorkeeper::AccessToken.count).to be 0
     end
+
+    context 'with opt_out_native_route_change' do
+      around(:each) do |example|
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          opt_out_native_route_change
+        end
+
+        Rails.application.reload_routes!
+
+        example.run
+
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+        end
+
+        Rails.application.reload_routes!
+      end
+
+      it 'should redirect immediately' do
+        expect(response).to be_redirect
+        expect(response.location).to match(/oauth\/authorize\/#{Doorkeeper::AccessGrant.first.token}/)
+      end
+
+      it 'should issue a grant' do
+        expect(Doorkeeper::AccessGrant.count).to be 1
+      end
+
+      it 'should not issue a token' do
+        expect(Doorkeeper::AccessToken.count).to be 0
+      end
+    end
   end
 
   describe 'GET #new with skip_authorization true' do

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -29,6 +29,11 @@ Doorkeeper.configure do
   # Issue access tokens with refresh token (disabled by default)
   use_refresh_token
 
+  # Opt out of breaking api change to the native authorization code flow. Opting out sets the authorization
+  # code response route for native redirect uris to oauth/authorize/<code>. The default is oauth/authorize/native?code=<code>.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1143
+  # opt_out_native_route_change
+
   # Provide support for an owner to be assigned to each registered application (disabled by default)
   # Optional parameter confirmation: true (default false) if you want to enforce ownership of
   # a registered application

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -162,6 +162,31 @@ describe Doorkeeper, 'configuration' do
     end
   end
 
+  describe 'opt_out_native_route_change' do
+    around(:each) do |example|
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        opt_out_native_route_change
+      end
+
+      Rails.application.reload_routes!
+
+      subject { Doorkeeper.configuration }
+
+      example.run
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+      end
+
+      Rails.application.reload_routes!
+    end
+
+    it 'sets the native authorization code route /:code' do
+      expect(subject.native_authorization_code_route).to eq('/:code')
+    end
+  end
+
   describe 'client_credentials' do
     it 'has defaults order' do
       expect(subject.client_credentials_methods).to eq([:from_basic, :from_params])


### PR DESCRIPTION
### Summary

This PR creates the option to opt out of the breaking api change introduced in https://github.com/doorkeeper-gem/doorkeeper/pull/1003 . For an authorization code flow with a native redirect uri the default response route after resource owner authentication is still `oauth/authorize/native?code=<code>`. However if you add `opt_out_native_route_change` to your `config/initializers/doorkeeper.rb` the route will be `oauth/authorize/<code>` as it was in versions < `v4.3.0`.

### Other Information

This PR stems from https://github.com/doorkeeper-gem/doorkeeper/issues/1143
