### PR TITLE
[migration templates fix] migration generator template, resource_owner integer to references

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ User-visible changes worth mentioning.
   triggers every time)
 - [#1149] Fix for `URIChecker#valid_for_authorization?` false negative when query is blank, but `?` present.
 - [#1151] Fix Refresh Token strategy: add proper validation of client credentials both for Public & Private clients.
+- [#1152] Fixmigration template: change resource owner data type from integer to references
 
 ## 5.0.0
 

--- a/lib/generators/doorkeeper/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/migration.rb.erb
@@ -13,7 +13,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
     add_index :oauth_applications, :uid, unique: true
 
     create_table :oauth_access_grants do |t|
-      t.integer  :resource_owner_id, null: false
+      t.references :resource_owner,  null: false
       t.references :application,     null: false
       t.string   :token,             null: false
       t.integer  :expires_in,        null: false
@@ -31,7 +31,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
     )
 
     create_table :oauth_access_tokens do |t|
-      t.integer  :resource_owner_id
+      t.references :resource_owner
       t.references :application
 
       # If you use a custom token generator you may need to change this column


### PR DESCRIPTION
### Summary

In over Rails5.1, Default primary key has been bigint.
If Rails version is below 5.1, resource_owner_id column will be set INT, above 5.1 it will be set BIGINT
