### PR TITLE
This spec breaks for ORMs.

### DIFF
--- a/spec/lib/oauth/token_spec.rb
+++ b/spec/lib/oauth/token_spec.rb
@@ -115,7 +115,10 @@ module Doorkeeper
 
         context 'refresh tokens are enabled' do
           before do
-            Doorkeeper.configure { use_refresh_token }
+            Doorkeeper.configure do
+              orm DOORKEEPER_ORM
+              use_refresh_token
+            end
           end
 
           it 'revokes previous refresh_token if token was found' do


### PR DESCRIPTION
### Summary

I am working on the doorkeeper-mongoid ORM gem, and this spec breaks because this one spec doesn't follow the same pattern as all of the other specs.

Thanks for contributing to Doorkeeper project!
