### PR TITLE
Fix #1157: remove redundant index from migration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#] Add your description here.
+- [#1157] Remove redundant index from migration template.
 
 ## 5.0.1
 

--- a/lib/doorkeeper/version.rb
+++ b/lib/doorkeeper/version.rb
@@ -9,7 +9,7 @@ module Doorkeeper
     # Semantic versioning
     MAJOR = 5
     MINOR = 0
-    TINY = 1
+    TINY = 2
     PRE = nil
 
     # Full version number

--- a/lib/generators/doorkeeper/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/migration.rb.erb
@@ -31,7 +31,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
     )
 
     create_table :oauth_access_tokens do |t|
-      t.references :resource_owner
+      t.references :resource_owner, index: true
       t.references :application
 
       # If you use a custom token generator you may need to change this column
@@ -58,7 +58,6 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
     end
 
     add_index :oauth_access_tokens, :token, unique: true
-    add_index :oauth_access_tokens, :resource_owner_id
     add_index :oauth_access_tokens, :refresh_token, unique: true
     add_foreign_key(
       :oauth_access_tokens,


### PR DESCRIPTION
Fix #1157: remove redundant index from migration template