### PR TITLE
Remove issue#854 when root_path is not set.

### DIFF
--- a/app/views/layouts/doorkeeper/admin.html.erb
+++ b/app/views/layouts/doorkeeper/admin.html.erb
@@ -17,9 +17,11 @@
       <li class="nav-item <%= 'active' if request.path == oauth_applications_path %>">
         <%= link_to t('doorkeeper.layouts.admin.nav.applications'), oauth_applications_path, class: 'nav-link' %>
       </li>
-      <li class="nav-item">
-        <%= link_to t('doorkeeper.layouts.admin.nav.home'), root_path, class: 'nav-link' %>
-      </li>
+      <% if respond_to?(:root_path) %>
+        <li class="nav-item">
+          <%= link_to t('doorkeeper.layouts.admin.nav.home'), root_path, class: 'nav-link' %>
+        </li>
+      <% end %>
     </ul>
   </div>
 </nav>


### PR DESCRIPTION
### Summary

I ran into the following issue#854 (https://github.com/doorkeeper-gem/doorkeeper/issues/854) while using doorkeeper  and thought about a quick fix that will prevent this issue all together. It seems a bit annoying to have to set a root_path just because of a view. This fixes the issue by checking that the method root_path is available before calling it.