### PR TITLE
Fix typo in commented description for initializer's generator template .

### DIFF
--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -195,7 +195,7 @@ Doorkeeper.configure do
   # end
 
   # Hook into Authorization flow in order to implement Single Sign Out
-  # or add ny other functionality.
+  # or add any other functionality.
   #
   # before_successful_authorization do |controller|
   #   Rails.logger.info(params.inspect)


### PR DESCRIPTION
I just found this small typo while reading this file.

Please let me know if I need to do further actions (open an issue/update NEWS.md/etc..)