### PR TITLE
Implement optional hashing of tokens and secrets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gem "rails", "~> 5.2", ">= 5.2.1.1"
 
 gem "appraisal"
 
+gem "bcrypt", "~> 3.1"
+
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ User-visible changes worth mentioning.
 - [#1164] Fix error when `root_path` is not defined.
 - [#1175] Internal refactor: use `scopes_string` inside `scopes`.
 - [#1176] Fix test factory support for `factory_bot_rails`
+- [#1168]: Allow optional hashing of tokens and secrets.
 
 ## 5.0.2
 

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -8,7 +8,7 @@
     <p><code class="bg-light" id="application_id"><%= @application.uid %></code></p>
 
     <h4><%= t('.secret') %>:</h4>
-    <p><code class="bg-light" id="secret"><%= @application.secret %></code></p>
+    <p><code class="bg-light" id="secret"><%= @application.plaintext_secret %></code></p>
 
     <h4><%= t('.scopes') %>:</h4>
     <p><code class="bg-light" id="scopes"><%= @application.scopes.presence || raw('&nbsp;') %></code></p>

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
+gem "bcrypt", "~> 3.1"
 gem "appraisal"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", platform: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
+gem "bcrypt", "~> 3.1"
 gem "appraisal"
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 gem "sqlite3", platforms: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
+gem "bcrypt", "~> 3.1"
 gem "appraisal"
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 gem "sqlite3", platforms: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
+gem "bcrypt", "~> 3.1"
 gem "appraisal"
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 gem "sqlite3", platforms: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/gemfiles/rails_master.gemfile
+++ b/gemfiles/rails_master.gemfile
@@ -6,6 +6,7 @@ gem "rails", git: 'https://github.com/rails/rails'
 gem "arel", git: 'https://github.com/rails/arel'
 
 gem "appraisal"
+gem "bcrypt", "~> 3.1"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -56,6 +56,7 @@ require 'doorkeeper/models/concerns/scopes'
 require 'doorkeeper/models/concerns/expirable'
 require 'doorkeeper/models/concerns/revocable'
 require 'doorkeeper/models/concerns/accessible'
+require 'doorkeeper/models/concerns/hashable'
 
 require 'doorkeeper/models/access_grant_mixin'
 require 'doorkeeper/models/access_token_mixin'

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -9,6 +9,7 @@ module Doorkeeper
     include Models::Revocable
     include Models::Accessible
     include Models::Orderable
+    include Models::Hashable
     include Models::Scopes
 
     # never uses pkce, if pkce migrations were not generated
@@ -30,7 +31,13 @@ module Doorkeeper
       #   if there is no record with such token
       #
       def by_token(token)
-        find_by(token: token.to_s)
+        find_by_plaintext_token(:token, token)
+      end
+
+      # We want to perform secret hashing whenever the user
+      # enables the configuration option +hash_token_secrets+
+      def perform_secret_hashing?
+        Doorkeeper.configuration.hash_token_secrets?
       end
 
       # Revokes AccessGrant records that have not been revoked and associated

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -1,14 +1,40 @@
 # frozen_string_literal: true
 
+require 'bcrypt'
+
 module Doorkeeper
   module ApplicationMixin
     extend ActiveSupport::Concern
 
     include OAuth::Helpers
     include Models::Orderable
+    include Models::Hashable
     include Models::Scopes
 
+    included do
+      # Use BCrypt as the hashing function for applications
+      self.secret_hash_function = lambda do |plain_token|
+        BCrypt::Password.create(plain_token.to_s)
+      end
+
+      # Also need to override the comparer function for BCrypt
+      self.secret_comparer = lambda do |plain, secret|
+        begin
+          BCrypt::Password.new(secret.to_s) == plain.to_s
+        rescue BCrypt::Errors::InvalidHash
+          false
+        end
+      end
+    end
+
+    # :nodoc
     module ClassMethods
+      # We want to perform secret hashing whenever the user
+      # enables the configuration option +hash_application_secrets+
+      def perform_secret_hashing?
+        Doorkeeper.configuration.hash_application_secrets?
+      end
+
       # Returns an instance of the Doorkeeper::Application with
       # specific UID and secret.
       #
@@ -25,7 +51,7 @@ module Doorkeeper
         app = by_uid(uid)
         return unless app
         return app if secret.blank? && !app.confidential?
-        return unless app.secret == secret
+        return unless app.secret_matches?(secret)
         app
       end
 
@@ -48,6 +74,31 @@ module Doorkeeper
     # @return [String] The redirect URI(s) seperated by newlines.
     def redirect_uri=(uris)
       super(uris.is_a?(Array) ? uris.join("\n") : uris)
+    end
+
+    # Check whether the given plain text secret matches our stored secret
+    #
+    # @param input [#to_s] Plain secret provided by user
+    #        (any object that responds to `#to_s`)
+    #
+    # @return [true] Whether the given secret matches the stored secret
+    #                of this application.
+    #
+    def secret_matches?(input)
+      # return false if either is nil, since secure_compare depends on strings
+      # but Application secrets MAY be nil depending on confidentiality.
+      return false if input.nil? || secret.nil?
+
+      # When matching the secret by comparer function, all is well.
+      return true if self.class.secret_matches?(input, secret)
+
+      # When fallback lookup is enabled, ensure applications
+      # with plain secrets can still be found
+      if Doorkeeper.configuration.fallback_to_plain_secrets?
+        ActiveSupport::SecurityUtils.secure_compare(input, secret)
+      else
+        false
+      end
     end
   end
 end

--- a/lib/doorkeeper/models/concerns/hashable.rb
+++ b/lib/doorkeeper/models/concerns/hashable.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Models
+    ##
+    # Hashable finder to provide lookups for input plaintext values which are
+    # mapped to their hashes before lookup.
+    module Hashable
+      extend ActiveSupport::Concern
+
+      delegate :perform_secret_hashing?,
+               :hashed_or_plain_token,
+               to: :class
+
+      # :nodoc
+      module ClassMethods
+        # Allow to override the hashing method by the including module
+        attr_accessor :secret_hash_function, :secret_comparer
+
+        # Compare the given plaintext with the secret
+        #
+        # @param input [String]
+        #   The plain input to compare.
+        #
+        # @param secret [String]
+        #   The secret value to compare with.
+        #
+        # @return [Boolean]
+        #   If hashing is enabled: Whether the secret equals hashed input
+        #   If hashing is disabled: Whether input matches secret
+        #
+        def secret_matches?(input, secret)
+          unless perform_secret_hashing?
+            return ActiveSupport::SecurityUtils.secure_compare input, secret
+          end
+
+          (secret_comparer || method(:default_comparer))
+            .call(input, secret)
+        end
+
+        # Returns an instance of the Doorkeeper::AccessToken with
+        # specific token value.
+        #
+        # @param attr [Symbol]
+        #   The token attribute we're looking with.
+        #
+        # @param token [#to_s]
+        #   token value (any object that responds to `#to_s`)
+        #
+        # @return [Doorkeeper::AccessToken, nil] AccessToken object or nil
+        #   if there is no record with such token
+        #
+        def find_by_plaintext_token(attr, token)
+          token = token.to_s
+
+          find_by(attr => hashed_or_plain_token(token)) ||
+            find_by_fallback_token(attr, token)
+        end
+
+        # Allow looking up previously plain tokens as a fallback
+        # IFF respective options are enabled
+        #
+        # @param attr [Symbol]
+        #   The token attribute we're looking with.
+        #
+        # @param token [#to_s]
+        #   token value (any object that responds to `#to_s`)
+        #
+        # @return [Doorkeeper::AccessToken, nil] AccessToken object or nil
+        #   if there is no record with such token
+        #
+        def find_by_fallback_token(attr, token)
+          return nil unless perform_secret_hashing?
+          return nil unless Doorkeeper.configuration.fallback_to_plain_secrets?
+
+          find_by(attr => token).tap do |fallback|
+            upgrade_fallback_value fallback, attr
+          end
+        end
+
+        # Hash the given input token
+        #
+        # @param plain_token [String]
+        #   The plain text token to hash.
+        #
+        # @return [String]
+        #   IFF secret hashing enabled, the hashed token,
+        #   otherwise returns the plain token.
+        def hashed_or_plain_token(plain_token)
+          if perform_secret_hashing?
+            (secret_hash_function || method(:default_hash_function))
+              .call plain_token
+          else
+            plain_token
+          end
+        end
+
+        # Allow implementations in ORMs to replace a plain
+        # value falling back to to avoid it remaining as plain text.
+        #
+        # @param instance
+        #   An instance of this model with a plain value token.
+        #
+        # @param attr
+        #   The token attribute to upgrade
+        #
+        def upgrade_fallback_value(instance, attr)
+          plain_token = instance.public_send attr
+          instance.update_column(attr, hashed_or_plain_token(plain_token))
+        end
+
+        # Including classes can override this function to
+        # disable or enable secret hashing dynamically
+        def perform_secret_hashing?
+          true
+        end
+
+        # Return a default hashing function to be used when including
+        # module or user does not specify what to use
+        # @param plain_token [String]
+        #   The plain text token to hash.
+        #
+        # @return [String] Hashed plain text token
+        #
+        def default_hash_function(plain_token)
+          ::Digest::SHA256.hexdigest plain_token
+        end
+
+        # Return a default comparer for the given hash function
+        def default_comparer(plain, secret)
+          hashed = hashed_or_plain_token(plain)
+          ActiveSupport::SecurityUtils.secure_compare hashed, secret
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -62,7 +62,7 @@ module Doorkeeper
           {
             controller: controller,
             action: :show,
-            access_token: token.token
+            access_token: token.plaintext_token
           }
         end
 

--- a/lib/doorkeeper/oauth/code_response.rb
+++ b/lib/doorkeeper/oauth/code_response.rb
@@ -23,7 +23,7 @@ module Doorkeeper
         elsif response_on_fragment
           Authorization::URIBuilder.uri_with_fragment(
             pre_auth.redirect_uri,
-            access_token: auth.token.token,
+            access_token: auth.token.plaintext_token,
             token_type: auth.token.token_type,
             expires_in: auth.token.expires_in_seconds,
             state: pre_auth.state
@@ -31,7 +31,7 @@ module Doorkeeper
         else
           Authorization::URIBuilder.uri_with_query(
             pre_auth.redirect_uri,
-            code: auth.token.token,
+            code: auth.token.plaintext_token,
             state: pre_auth.state
           )
         end

--- a/lib/doorkeeper/oauth/token_response.rb
+++ b/lib/doorkeeper/oauth/token_response.rb
@@ -11,10 +11,10 @@ module Doorkeeper
 
       def body
         {
-          'access_token'  => token.token,
+          'access_token'  => token.plaintext_token,
           'token_type'    => token.token_type,
           'expires_in'    => token.expires_in_seconds,
-          'refresh_token' => token.refresh_token,
+          'refresh_token' => token.plaintext_refresh_token,
           'scope'         => token.scopes_string,
           'created_at'    => token.created_at.to_i
         }.reject { |_, value| value.blank? }

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -75,7 +75,38 @@ Doorkeeper.configure do
   # doesn't updates existing token expiration time, it will create a new token instead.
   # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
   #
+  # You can not enable this option together with +hash_token_secrets+.
+  #
   # reuse_access_token
+
+  # Hash access and refresh tokens before persisting them.
+  # Note: This will disable the possibility to use +reuse_access_token+
+  # since plain values can no longer be retrieved.
+  #
+  # hash_token_secrets
+
+  # Hash application secrets before persisting them.
+  #
+  # hash_application_secrets
+
+  # When the above option is enabled,
+  # and a hashed token or secret is not found,
+  # look up the plain text token as a fallback.
+  #
+  # This will ensure that old access tokens and secrets
+  # will remain valid even if the hashing above is enabled
+  #
+  # fallback_to_plain_secrets
+
+  #
+  # Since old values will not be re-hashed, lookups to tokens and secrets
+  # will fall back to plain value comparison so any existing tokens will
+  # not be invalidated.
+  #
+  # For example, to use SHA256 digests on plain values, uncomment these lines:
+  # hash_secrets do |plain_value|
+  #   Digest::SHA256.hexdigest plain_value
+  # end
 
   # Issue access tokens with refresh token (disabled by default), you may also
   # pass a block which accepts `context` to customize when to give a refresh

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -525,4 +525,72 @@ describe Doorkeeper, 'configuration' do
       expect(subject.handle_auth_errors).to eq(:raise)
     end
   end
+
+  describe 'hash_application_secrets' do
+    it 'is disabled by default' do
+      expect(subject.hash_application_secrets?).to eq(false)
+      expect(::Doorkeeper::Application.perform_secret_hashing?).to eq(false)
+    end
+
+    context 'when provided' do
+      before do
+        Doorkeeper.configure do
+          reuse_access_token
+          hash_application_secrets
+        end
+      end
+
+      it 'will enable hashing for applications' do
+        expect(subject.reuse_access_token).to eq(true)
+        expect(subject.hash_application_secrets?).to eq(true)
+
+        expect(::Doorkeeper::Application.perform_secret_hashing?).to eq(true)
+      end
+    end
+  end
+
+  describe 'hash_token_secrets' do
+    it 'is disabled by default' do
+      expect(subject.hash_token_secrets?).to eq(false)
+      expect(::Doorkeeper::AccessToken.perform_secret_hashing?).to eq(false)
+      expect(::Doorkeeper::AccessGrant.perform_secret_hashing?).to eq(false)
+    end
+
+    context 'when provided' do
+      include_context 'with token hashing enabled'
+
+      it 'will enable hashing for AccessToken and AccessGrant' do
+        expect(subject.hash_token_secrets?).to eq(true)
+        expect(::Doorkeeper::AccessToken.perform_secret_hashing?).to eq(true)
+        expect(::Doorkeeper::AccessGrant.perform_secret_hashing?).to eq(true)
+      end
+    end
+  end
+
+  describe 'fallback_to_plain_secrets' do
+    it 'is disabled by default' do
+      expect(subject.fallback_to_plain_secrets?).to eq(false)
+    end
+
+    context 'when provided' do
+      include_context 'with token hashing and fallback lookup enabled'
+
+      it 'will enable fallbacks' do
+        expect(subject.fallback_to_plain_secrets?).to eq(true)
+      end
+    end
+  end
+
+  describe 'hash_token_secrets together with reuse_access_token' do
+    it 'will disable reuse_access_token' do
+      expect(Rails.logger).to receive(:warn).with(/reuse_access_token will be disabled/)
+
+      Doorkeeper.configure do
+        reuse_access_token
+        hash_token_secrets
+      end
+
+      expect(subject.reuse_access_token).to eq(false)
+    end
+  end
 end

--- a/spec/lib/models/hashable_spec.rb
+++ b/spec/lib/models/hashable_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Hashable' do
+  let(:clazz) do
+    Class.new do
+      include Doorkeeper::Models::Hashable
+
+      def self.find_by(*)
+        raise 'stub this'
+      end
+
+      def update_column(*)
+        raise 'stub this'
+      end
+
+      def token
+        raise 'stub this'
+      end
+    end
+  end
+
+  describe :hashed_or_plain_token do
+    let(:enabled_hashing?) { false }
+    subject { clazz.send(:hashed_or_plain_token, 'input') }
+
+    before do
+      allow(clazz).to receive(:perform_secret_hashing?)
+        .and_return enabled_hashing?
+    end
+
+    context 'when no hash function set' do
+      it 'returns the plain input' do
+        expect(subject).to eq 'input'
+      end
+
+      context 'when hashing enabled' do
+        let(:enabled_hashing?) { true }
+
+        it 'uses the default function' do
+          expect(clazz)
+            .to receive(:default_hash_function)
+            .with('input')
+            .and_call_original
+
+          expect(subject).not_to eq 'input'
+        end
+      end
+    end
+
+    context 'when hash_function defined' do
+      let(:hash_function) { ->(input) { input + '-hashed' } }
+
+      before do
+        clazz.secret_hash_function = hash_function
+      end
+
+      it 'returns the plain input' do
+        expect(clazz).not_to receive(:default_hash_function)
+        expect(subject).to eq 'input'
+      end
+
+      context 'when hashing enabled' do
+        let(:enabled_hashing?) { true }
+
+        it 'uses that function' do
+          expect(hash_function)
+            .to receive(:call)
+            .with('input')
+            .and_call_original
+
+          expect(subject).to eq 'input-hashed'
+        end
+      end
+    end
+  end
+
+  describe :secret_matches? do
+    context 'when comparer undefined' do
+      it 'uses a default compare' do
+        expect(clazz).to receive(:default_comparer).with('a', 'a').and_return true
+        expect(clazz.secret_matches?('a', 'a')).to be_truthy
+      end
+    end
+
+    context 'when comparer defined' do
+      let(:comparer) do
+        ->(*) { false }
+      end
+
+      before do
+        clazz.secret_comparer = comparer
+      end
+
+      it 'uses that comparer' do
+        expect(comparer).to receive(:call).with('a', 'a').and_call_original
+        expect(clazz.secret_matches?('a', 'a')).to be_falsey
+      end
+    end
+  end
+
+  describe :find_by_fallback_token do
+    let(:old_token) { instance_double(clazz, token: 'input') }
+    subject { clazz.send(:find_by_fallback_token, :token, 'input') }
+
+    it 'does not call find_by when not configured' do
+      expect(clazz).not_to receive(:find_by)
+      expect(subject).to eq(nil)
+    end
+
+    context 'when fallback configured' do
+      include_context 'with token hashing and fallback lookup enabled'
+      let(:hashed_token) { hashed_or_plain_token_func.call('input') }
+
+      it 'upgrades the plain token if no hashed exists' do
+        expect(clazz).to receive(:find_by).with(token: 'input').and_return(old_token)
+        expect(old_token).to receive(:update_column).with(:token, hashed_token)
+
+        expect(subject).to eq(old_token)
+      end
+    end
+  end
+
+  describe :find_by_plaintext_token do
+    let(:plain_token) { 'asdf' }
+    let(:subject) { clazz.send(:find_by_plaintext_token, :token, plain_token) }
+    let(:hashing_enabled?) { false }
+
+    before do
+      allow(clazz).to receive(:perform_secret_hashing?).and_return(hashing_enabled?)
+    end
+
+    context 'when not configured' do
+      it 'always finds with the plain value even when nil' do
+        expect(clazz).to receive(:find_by).with(token: plain_token).once.and_return(nil)
+        expect(subject).to eq(nil)
+      end
+    end
+
+    context 'when hashing configured' do
+      let(:hashing_enabled?) { true }
+      let(:hashed_token) { clazz.send(:default_hash_function, plain_token) }
+
+      it 'calls find_by only on the hashed value if it returns' do
+        expect(clazz).not_to receive(:find_by).with(token: plain_token)
+        expect(clazz).to receive(:find_by).with(token: hashed_token).and_return(:result)
+
+        expect(subject).to eq(:result)
+      end
+
+      it 'does not fall back to plain token' do
+        expect(clazz).not_to receive(:find_by).with(token: plain_token)
+        expect(clazz).to receive(:find_by).with(token: hashed_token).and_return(nil)
+
+        expect(subject).to eq(nil)
+      end
+
+      context 'when fallback configured' do
+        let(:old_token) { instance_double(clazz, token: plain_token) }
+        let(:hashed_token) { hashed_or_plain_token_func.call(plain_token) }
+
+        include_context 'with token hashing and fallback lookup enabled'
+
+        it 'does not fallback if found by hashed token' do
+          expect(clazz).to receive(:find_by).with(token: hashed_token).and_return old_token
+          expect(clazz).not_to receive(:find_by).with(token: plain_token)
+          expect(clazz).not_to receive(:upgrade_fallback_value)
+
+          expect(subject).to eq(old_token)
+        end
+
+        it 'also searches for the plain token if no hashed exists' do
+          expect(clazz).to receive(:find_by).with(token: hashed_token).and_return nil
+          expect(clazz).to receive(:find_by).with(token: plain_token).and_return(old_token)
+          expect(old_token).to receive(:update_column).with(:token, hashed_token)
+
+          expect(subject).to eq(old_token)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/oauth/base_request_spec.rb
+++ b/spec/lib/oauth/base_request_spec.rb
@@ -4,13 +4,13 @@ module Doorkeeper::OAuth
   describe BaseRequest do
     let(:access_token) do
       double :access_token,
-             token:              "some-token",
-             expires_in:         "3600",
-             expires_in_seconds: "300",
-             scopes_string:      "two scopes",
-             refresh_token:      "some-refresh-token",
-             token_type:         "bearer",
-             created_at:         0
+             plaintext_token:         "some-token",
+             expires_in:              "3600",
+             expires_in_seconds:      "300",
+             scopes_string:           "two scopes",
+             plaintext_refresh_token: "some-refresh-token",
+             token_type:              "bearer",
+             created_at:              0
     end
 
     let(:client) { double :client, id: '1' }

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -17,13 +17,13 @@ module Doorkeeper::OAuth
     describe '.body' do
       let(:access_token) do
         double :access_token,
-               token:              'some-token',
-               expires_in:         '3600',
-               expires_in_seconds: '300',
-               scopes_string:      'two scopes',
-               refresh_token:      'some-refresh-token',
-               token_type:         'bearer',
-               created_at:         0
+               plaintext_token:         "some-token",
+               expires_in:              "3600",
+               expires_in_seconds:      "300",
+               scopes_string:           "two scopes",
+               plaintext_refresh_token: "some-refresh-token",
+               token_type:              "bearer",
+               created_at:              0
       end
 
       subject { TokenResponse.new(access_token).body }
@@ -58,12 +58,12 @@ module Doorkeeper::OAuth
     describe '.body filters out empty values' do
       let(:access_token) do
         double :access_token,
-               token:              'some-token',
-               expires_in_seconds: '',
-               scopes_string:      '',
-               refresh_token:      '',
-               token_type:         'bearer',
-               created_at:         0
+               plaintext_token:         'some-token',
+               expires_in_seconds:      '',
+               scopes_string:           '',
+               plaintext_refresh_token: '',
+               token_type:              'bearer',
+               created_at:              0
       end
 
       subject { TokenResponse.new(access_token).body }

--- a/spec/lib/oauth/token_spec.rb
+++ b/spec/lib/oauth/token_spec.rb
@@ -113,6 +113,20 @@ module Doorkeeper
           end
         end
 
+        context 'token hashing is enabled' do
+          include_context 'with token hashing enabled'
+
+          let(:hashed_token) { hashed_or_plain_token_func.call('token') }
+          let(:token) { ->(_r) { 'token' } }
+
+          it 'searches with the hashed token' do
+            expect(
+              AccessToken
+            ).to receive(:find_by).with(token: hashed_token).and_return(token)
+            Token.authenticate double, token
+          end
+        end
+
         context 'refresh tokens are enabled' do
           before do
             Doorkeeper.configure do

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 module Doorkeeper
   describe Application do
+    let(:clazz) { Doorkeeper::Application }
     let(:require_owner) { Doorkeeper.configuration.instance_variable_set('@confirm_application_owner', true) }
     let(:unset_require_owner) { Doorkeeper.configuration.instance_variable_set('@confirm_application_owner', false) }
     let(:new_application) { FactoryBot.build(:application) }
@@ -120,6 +121,42 @@ module Doorkeeper
       new_application.save
       new_application.secret = nil
       expect(new_application).not_to be_valid
+    end
+
+    context 'with hashing enabled' do
+      include_context 'with application hashing enabled'
+      let(:app) { FactoryBot.create :application }
+
+      it 'holds a volatile plaintext and BCrypt secret' do
+        expect(app.plaintext_secret).to be_a(String)
+        expect(app.secret).not_to eq(app.plaintext_secret)
+        expect { BCrypt::Password.create(app.secret) }.not_to raise_error
+      end
+
+      it 'does not fallback to plain lookup by default' do
+        lookup = clazz.by_uid_and_secret(app.uid, app.secret)
+        expect(lookup).to eq(nil)
+
+        lookup = clazz.by_uid_and_secret(app.uid, app.plaintext_secret)
+        expect(lookup).to eq(app)
+      end
+
+      context 'with fallback enabled' do
+        include_context 'with token hashing and fallback lookup enabled'
+
+        it 'provides plain and hashed lookup' do
+          lookup = clazz.by_uid_and_secret(app.uid, app.secret)
+          expect(lookup).to eq(app)
+
+          lookup = clazz.by_uid_and_secret(app.uid, app.plaintext_secret)
+          expect(lookup).to eq(app)
+        end
+      end
+
+      it 'does not provide access to secret after loading' do
+        lookup = clazz.by_uid_and_secret(app.uid, app.plaintext_secret)
+        expect(lookup.plaintext_secret).to be_nil
+      end
     end
 
     describe 'destroy related models on cascade' do

--- a/spec/support/shared/hashing_shared_context.rb
+++ b/spec/support/shared/hashing_shared_context.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+shared_context 'with token hashing enabled' do
+  let(:hashed_or_plain_token_func) { Doorkeeper::AccessToken.method(:hashed_or_plain_token) }
+  before do
+    Doorkeeper.configure do
+      hash_token_secrets
+    end
+  end
+end
+
+shared_context 'with token hashing and fallback lookup enabled' do
+  let(:hashed_or_plain_token_func) { Doorkeeper::AccessToken.method(:hashed_or_plain_token) }
+  before do
+    Doorkeeper.configure do
+      hash_token_secrets
+      fallback_to_plain_secrets
+    end
+  end
+end
+
+shared_context 'with application hashing enabled' do
+  let(:hashed_or_plain_token_func) { Doorkeeper::Application.method(:hashed_or_plain_token) }
+  before do
+    Doorkeeper.configure do
+      hash_application_secrets
+    end
+  end
+end


### PR DESCRIPTION
There have been previous requests with regards to encryption or hashing OAuth secrets in the database to avoid storing them in plain texts. Primarily, these discussions have taken place in #320 and #675 (at
least, that's where I took note of them).

For us, adaptation of doorkeeper is limited due to this exact storing of plain text tokens, especially longlived refresh tokens as well as client secrets in the database. Different from some of the commenters in the above discussion, since tokens are already cryptographically secure randoms, a secure hash function is sufficient to address the immediate threat of leaking tokens and secrets, e.g., from an unencrypted backup. 

Encryption does not provide much of an advantage IF an attacker is able to get access to the resource server and leak the encryption key. (granted, it's a big IF and strong adversary, but still)

This PR thus implements an *optional* hashing filter configurable
through the initializer that:

1. Hashes access_tokens, refresh_tokens, access_grants and application
client_secrets.

2. Allow models to maintain the volatile plaintext value for one-time communication to the user (e.g., showing the application, token in the same request).

3. Alters lookups to allow finding input tokens through either their hashed value, or the original plaintext as fallback. This allows users to switch on this hashing option without losing any old authenticated clients. They may want to reduce TTL of their refresh tokens to ensure all clients will have hashed secrets persisted in the near future.

Arguments against some of the discussions:

1. Using bcrypt. Since the original plaintext token is a cryptographically secure random string, we do not gain much by salting the values. The UniqueToken generator of doorkeeper has 128-bit entropy by default, and can be extended. However, this implementation allows users to use bcrypt or
whatever they prefer, it is just my opinion that the extra overhead is useless.

2. Not storing tokens at all whereever possible. This was a fascinating read, but out of my scope of what I'm capable to implement and would be completely orthogonal to what doorkeeper currently does. I for one like having the tokens around for auditing purposes.

I have deliberately not updated neither news nor contributions yet while we're still discussion what this PR will lead to.