### PR TITLE
Use scopes_string internally

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#1162] Fix `enforce_content_type` for requests without body.
 - [#1164] Fix error when `root_path` is not defined.
+- [#1175] Internal refactor: use `scopes_string` inside `scopes`.
 
 ## 5.0.2
 

--- a/lib/doorkeeper/models/concerns/scopes.rb
+++ b/lib/doorkeeper/models/concerns/scopes.rb
@@ -4,7 +4,7 @@ module Doorkeeper
   module Models
     module Scopes
       def scopes
-        OAuth::Scopes.from_string(self[:scopes])
+        OAuth::Scopes.from_string(scopes_string)
       end
 
       def scopes_string


### PR DESCRIPTION
This allows you to override `scopes_string` if you want to set default scopes for a particular type of model (eg. for a `Doorkeeper::Application`). Without this patch you'd need to override `scopes_string` and `scopes`.
