### PR TITLE
Define test factory classes using stringified class names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ User-visible changes worth mentioning.
 - [#1162] Fix `enforce_content_type` for requests without body.
 - [#1164] Fix error when `root_path` is not defined.
 - [#1175] Internal refactor: use `scopes_string` inside `scopes`.
+- [#1176] Fix test factory support for `factory_bot_rails`
 
 ## 5.0.2
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :access_grant, class: Doorkeeper::AccessGrant do
+  factory :access_grant, class: "Doorkeeper::AccessGrant" do
     sequence(:resource_owner_id) { |n| n }
     application
     redirect_uri { 'https://app.com/callback' }
@@ -7,7 +7,7 @@ FactoryBot.define do
     scopes { 'public write' }
   end
 
-  factory :access_token, class: Doorkeeper::AccessToken do
+  factory :access_token, class: "Doorkeeper::AccessToken" do
     sequence(:resource_owner_id) { |n| n }
     application
     expires_in { 2.hours }
@@ -17,7 +17,7 @@ FactoryBot.define do
     end
   end
 
-  factory :application, class: Doorkeeper::Application do
+  factory :application, class: "Doorkeeper::Application" do
     sequence(:name) { |n| "Application #{n}" }
     redirect_uri { 'https://app.com/callback' }
   end


### PR DESCRIPTION
As described in https://github.com/doorkeeper-gem/doorkeeper/issues/1043, factories defined by doorkeeper are unable to be loaded by host apps using the `factory_bot_rails` gem (receiving errors such as `uninitialized constant Doorkeeper::AccessGrant`)

Documentation for factory_bot was later added to explain an easy fix for this: instead of defining the factory's `class: ` with a named constant, wrap the constant in a string. By doing so, the constant isn't evaluated until the factory actually runs, at which point the `Doorkeeper::` models have all been loaded.

Fixes https://github.com/thoughtbot/factory_bot/issues/1188