### PR TITLE
adds an option to limit scopes by grant_type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1177] Limiting `scopes` for certain `grant_types`
 - [#1162] Fix `enforce_content_type` for requests without body.
 - [#1164] Fix error when `root_path` is not defined.
 - [#1175] Internal refactor: use `scopes_string` inside `scopes`.

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -83,6 +83,13 @@ module Doorkeeper
         @config.instance_variable_set(:@optional_scopes, OAuth::Scopes.from_array(scopes))
       end
 
+      # Define scopes_by_grant_type to limit certain scope to certain grant_type
+      # @param { Hash } with grant_types as keys.
+      # Default set to {} i.e. no limitation on scopes usage
+      def scopes_by_grant_type(hash = {})
+        @config.instance_variable_set(:@scopes_by_grant_type, hash)
+      end
+
       # Change the way client credentials are retrieved from the request object.
       # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
       # falls back to the `:client_id` and `:client_secret` params from the
@@ -332,6 +339,10 @@ module Doorkeeper
 
     def scopes
       @scopes ||= default_scopes + optional_scopes
+    end
+
+    def scopes_by_grant_type
+      @scopes_by_grant_type ||= {}
     end
 
     def client_credentials_methods

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -98,9 +98,9 @@ module Doorkeeper
 
         (token_scopes.sort == param_scopes.sort) &&
           Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
-            param_scopes.to_s,
-            Doorkeeper.configuration.scopes,
-            app_scopes
+            scope_str: param_scopes.to_s,
+            server_scopes: Doorkeeper.configuration.scopes,
+            app_scopes: app_scopes
           )
       end
 

--- a/lib/doorkeeper/oauth/client_credentials/validation.rb
+++ b/lib/doorkeeper/oauth/client_credentials/validation.rb
@@ -34,9 +34,10 @@ module Doorkeeper
                                end
 
           ScopeChecker.valid?(
-            @request.scopes.to_s,
-            @server.scopes,
-            application_scopes
+            scope_str: @request.scopes.to_s,
+            server_scopes: @server.scopes,
+            app_scopes: application_scopes,
+            grant_type: Doorkeeper::OAuth::CLIENT_CREDENTIALS
           )
         end
       end

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -32,7 +32,12 @@ module Doorkeeper
         client_scopes = client.try(:scopes)
         return true if scopes.blank?
 
-        ScopeChecker.valid?(scopes.to_s, server.scopes, client_scopes)
+        ScopeChecker.valid?(
+          scope_str: scopes.to_s,
+          server_scopes: server.scopes,
+          app_scopes: client_scopes,
+          grant_type: grant_type
+        )
       end
 
       def validate_resource_owner

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -77,10 +77,15 @@ module Doorkeeper
         return true if scope.blank?
 
         Helpers::ScopeChecker.valid?(
-          scope,
-          server.scopes,
-          client.application.scopes
+          scope_str: scope,
+          server_scopes: server.scopes,
+          app_scopes: client.application.scopes,
+          grant_type: grant_type
         )
+      end
+
+      def grant_type
+        response_type == 'code' ? AUTHORIZATION_CODE : IMPLICIT
       end
 
       def validate_redirect_uri

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -99,7 +99,10 @@ module Doorkeeper
 
       def validate_scope
         if @original_scopes.present?
-          ScopeChecker.valid?(@original_scopes, refresh_token.scopes)
+          ScopeChecker.valid?(
+            scope_str: @original_scopes,
+            server_scopes: refresh_token.scopes
+          )
         else
           true
         end

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -57,7 +57,8 @@ module Doorkeeper
 
     def scopes_match_configured
       if scopes.present? &&
-         !ScopeChecker.valid?(scopes.to_s, Doorkeeper.configuration.scopes)
+         !ScopeChecker.valid?(scope_str: scopes.to_s,
+                              server_scopes: Doorkeeper.configuration.scopes)
         errors.add(:scopes, :not_match_configured)
       end
     end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -108,6 +108,15 @@ Doorkeeper.configure do
   # default_scopes  :public
   # optional_scopes :write, :update
 
+  # Define scopes_by_grant_type to restrict only certain scopes for grant_type
+  # By default, all the scopes will be available for all the grant types.
+  #
+  # Keys to this hash should be the name of grant_type and
+  # values should be the array of scopes for that grant type.
+  # Note: scopes should be from configured_scopes(i.e. deafult or optional)
+  #
+  # scopes_by_grant_type password: [:write], client_credentials: [:update]
+
   # Change the way client credentials are retrieved from the request object.
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
   # falls back to the `:client_id` and `:client_secret` params from the `params` object.

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -141,6 +141,22 @@ describe Doorkeeper, 'configuration' do
     end
   end
 
+  describe 'scopes_by_grant_type' do
+    it 'is {} by default' do
+      expect(subject.scopes_by_grant_type).to eq({})
+    end
+
+    it 'has hash value' do
+      hash = {}
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        scopes_by_grant_type hash
+      end
+
+      expect(subject.scopes_by_grant_type).to eq(hash)
+    end
+  end
+
   describe 'use_refresh_token' do
     it 'is false by default' do
       expect(subject.refresh_token_enabled?).to eq(false)

--- a/spec/lib/oauth/client_credentials/validation_spec.rb
+++ b/spec/lib/oauth/client_credentials/validation_spec.rb
@@ -21,6 +21,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
     context 'with scopes' do
       it 'is invalid when scopes are not included in the server' do
         server_scopes = Doorkeeper::OAuth::Scopes.from_string 'email'
+        allow(request).to receive(:grant_type).and_return(Doorkeeper::OAuth::CLIENT_CREDENTIALS)
         allow(server).to receive(:scopes).and_return(server_scopes)
         allow(request).to receive(:scopes).and_return(
           Doorkeeper::OAuth::Scopes.from_string('invalid')
@@ -34,6 +35,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
           server_scopes = Doorkeeper::OAuth::Scopes.from_string 'email app'
           allow(application).to receive(:scopes).and_return(application_scopes)
           allow(server).to receive(:scopes).and_return(server_scopes)
+          allow(request).to receive(:grant_type).and_return(Doorkeeper::OAuth::CLIENT_CREDENTIALS)
           allow(request).to receive(:scopes).and_return(application_scopes)
           expect(subject).to be_valid
         end
@@ -42,6 +44,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
           application_scopes = Doorkeeper::OAuth::Scopes.from_string 'app'
           server_scopes = Doorkeeper::OAuth::Scopes.from_string 'email app'
           allow(application).to receive(:scopes).and_return(application_scopes)
+          allow(request).to receive(:grant_type).and_return(Doorkeeper::OAuth::CLIENT_CREDENTIALS)
           allow(server).to receive(:scopes).and_return(server_scopes)
           allow(request).to receive(:scopes).and_return(
             Doorkeeper::OAuth::Scopes.from_string('email')

--- a/spec/lib/oauth/helpers/scope_checker_spec.rb
+++ b/spec/lib/oauth/helpers/scope_checker_spec.rb
@@ -6,31 +6,31 @@ module Doorkeeper::OAuth::Helpers
 
     it 'is valid if scope is present' do
       server_scopes.add :scope
-      expect(ScopeChecker.valid?('scope', server_scopes)).to be_truthy
+      expect(ScopeChecker.valid?(scope_str: 'scope', server_scopes: server_scopes)).to be_truthy
     end
 
     it 'is invalid if includes tabs space' do
-      expect(ScopeChecker.valid?("\tsomething", server_scopes)).to be_falsey
+      expect(ScopeChecker.valid?(scope_str: "\tsomething", server_scopes: server_scopes)).to be_falsey
     end
 
     it 'is invalid if scope is not present' do
-      expect(ScopeChecker.valid?(nil, server_scopes)).to be_falsey
+      expect(ScopeChecker.valid?(scope_str: nil, server_scopes: server_scopes)).to be_falsey
     end
 
     it 'is invalid if scope is blank' do
-      expect(ScopeChecker.valid?(' ', server_scopes)).to be_falsey
+      expect(ScopeChecker.valid?(scope_str: ' ', server_scopes: server_scopes)).to be_falsey
     end
 
     it 'is invalid if includes return space' do
-      expect(ScopeChecker.valid?("scope\r", server_scopes)).to be_falsey
+      expect(ScopeChecker.valid?(scope_str: "scope\r", server_scopes: server_scopes)).to be_falsey
     end
 
     it 'is invalid if includes new lines' do
-      expect(ScopeChecker.valid?("scope\nanother", server_scopes)).to be_falsey
+      expect(ScopeChecker.valid?(scope_str: "scope\nanother", server_scopes: server_scopes)).to be_falsey
     end
 
     it 'is invalid if any scope is not included in server scopes' do
-      expect(ScopeChecker.valid?('scope another', server_scopes)).to be_falsey
+      expect(ScopeChecker.valid?(scope_str: 'scope another', server_scopes: server_scopes)).to be_falsey
     end
 
     context 'with application_scopes' do
@@ -42,19 +42,54 @@ module Doorkeeper::OAuth::Helpers
       end
 
       it 'is valid if scope is included in the application scope list' do
-        expect(ScopeChecker.valid?(
-                 'app123',
-                 server_scopes,
-                 application_scopes
-               )).to be_truthy
+        expect(ScopeChecker.valid?(scope_str: 'app123',
+                                   server_scopes: server_scopes,
+                                   app_scopes: application_scopes)).to be_truthy
       end
 
       it 'is invalid if any scope is not included in the application' do
-        expect(ScopeChecker.valid?(
-                 'svr',
-                 server_scopes,
-                 application_scopes
-               )).to be_falsey
+        expect(ScopeChecker.valid?(scope_str: 'svr',
+                                   server_scopes: server_scopes,
+                                   app_scopes: application_scopes)).to be_falsey
+      end
+    end
+
+    context 'with grant_type' do
+      let(:server_scopes) do
+        Doorkeeper::OAuth::Scopes.from_string 'scope1 scope2'
+      end
+
+      context 'with scopes_by_grant_type not configured for grant_type' do
+        it 'is valid if the scope is in server scopes' do
+          expect(ScopeChecker.valid?(scope_str: 'scope1',
+                                     server_scopes: server_scopes,
+                                     grant_type: Doorkeeper::OAuth::PASSWORD)).to be_truthy
+        end
+
+        it 'is invalid if the scope is not in server scopes' do
+          expect(ScopeChecker.valid?(scope_str: 'unknown',
+                                     server_scopes: server_scopes,
+                                     grant_type: Doorkeeper::OAuth::PASSWORD)).to be_falsey
+        end
+      end
+
+      context 'when scopes_by_grant_type configured for grant_type' do
+        before do
+          allow(Doorkeeper.configuration).to receive(:scopes_by_grant_type).
+            and_return(password: [:scope1])
+        end
+
+        it 'is valid if the scope is permitted for grant_type' do
+          expect(ScopeChecker.valid?(scope_str: 'scope1',
+                                     server_scopes: server_scopes,
+                                     grant_type: Doorkeeper::OAuth::PASSWORD)).to be_truthy
+        end
+
+        it 'is invalid if the scope is permitted for grant_type' do
+          expect(ScopeChecker.valid?(scope_str: 'scope2',
+                                     server_scopes: server_scopes,
+                                     grant_type: Doorkeeper::OAuth::PASSWORD)).to be_falsey
+        end
       end
     end
   end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -91,6 +91,18 @@ module Doorkeeper::OAuth
         subject.scope = 'invalid'
         expect(subject).not_to be_authorizable
       end
+
+      it 'accepts scopes which are permitted for grant_type' do
+        allow(server).to receive(:scopes_by_grant_type).and_return(authorization_code: [:public])
+        subject.scope = 'public'
+        expect(subject).to be_authorizable
+      end
+
+      it 'rejects scopes which are not permitted for grant_type' do
+        allow(server).to receive(:scopes_by_grant_type).and_return(authorization_code: [:profile])
+        subject.scope = 'public'
+        expect(subject).not_to be_authorizable
+      end
     end
 
     context 'client application restricts valid scopes' do
@@ -113,6 +125,18 @@ module Doorkeeper::OAuth
       it 'rejects (application level) non-valid scopes' do
         subject.scope = 'profile'
         expect(subject).to_not be_authorizable
+      end
+
+      it 'accepts scopes which are permitted for grant_type' do
+        allow(server).to receive(:scopes_by_grant_type).and_return(authorization_code: [:public])
+        subject.scope = 'public'
+        expect(subject).to be_authorizable
+      end
+
+      it 'rejects scopes which are not permitted for grant_type' do
+        allow(server).to receive(:scopes_by_grant_type).and_return(authorization_code: [:profile])
+        subject.scope = 'public'
+        expect(subject).not_to be_authorizable
       end
     end
 


### PR DESCRIPTION
### Summary
 This PR aims to implement the feature from #1177 .

To limit scopes for any grant type, you can configure `scopes_by_grant_type` following way:
 `scopes_by_grant_type implicit: [:view_profile, :check_status]`
 Now only `view_profile` and `check_status` will be available for `implicit` `grant_type`.

By default, all the `scopes` will be available for all the `grant_type`.