### PR TITLE
AccessGrant: Fix hashed access when token hashing active

### DIFF
--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -16,7 +16,7 @@ module Doorkeeper
         end
 
         def native_redirect
-          { action: :show, code: token.token }
+          { action: :show, code: token.plaintext_token }
         end
 
         def configuration


### PR DESCRIPTION
This addresses #1180, sorry for missing this in the specs.

### Summary

Fixes returning of a hashed AccessGrant code value in case a native redirect_uri is present in the application.

While using the hashed token feature of doorkeeper, I found that native redirect_uri with authorization code returns the wrong token for AccessGrants.