### PR TITLE
Fix #1170: add check for loopback IP URIs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,8 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#1177] Limiting `scopes` for certain `grant_types`
+- [#1182] Fix loopback IP redirect URIs to conform with RFC8252, p. 7.3 (fixes #1170).
+- [#1177] Allow to limit `scopes` for certain `grant_types`
 - [#1162] Fix `enforce_content_type` for requests without body.
 - [#1164] Fix error when `root_path` is not defined.
 - [#1175] Internal refactor: use `scopes_string` inside `scopes`.

--- a/spec/lib/oauth/helpers/uri_checker_spec.rb
+++ b/spec/lib/oauth/helpers/uri_checker_spec.rb
@@ -61,16 +61,34 @@ module Doorkeeper::OAuth::Helpers
         expect(URIChecker.matches?(uri, client_uri)).to be_truthy
       end
 
-      it 'doesn\'t allow non-matching domains through' do
+      it "doesn't allow non-matching domains through" do
         uri = 'http://app.abc/?query=hello'
         client_uri = 'http://app.co'
         expect(URIChecker.matches?(uri, client_uri)).to be_falsey
       end
 
-      it 'doesn\'t allow non-matching domains that don\'t start at the beginning' do
+      it "doesn't allow non-matching domains that don't start at the beginning" do
         uri = 'http://app.co/?query=hello'
         client_uri = 'http://example.com?app.co=test'
         expect(URIChecker.matches?(uri, client_uri)).to be_falsey
+      end
+
+      context 'loopback IP redirect URIs' do
+        it 'ignores port for same URIs' do
+          uri = 'http://127.0.0.1:5555/auth/callback'
+          client_uri = 'http://127.0.0.1:48599/auth/callback'
+          expect(URIChecker.matches?(uri, client_uri)).to be_truthy
+
+          uri = 'http://[::1]:5555/auth/callback'
+          client_uri = 'http://[::1]:5555/auth/callback'
+          expect(URIChecker.matches?(uri, client_uri)).to be_truthy
+        end
+
+        it "doesn't ignore port for URIs with different queries" do
+          uri = 'http://127.0.0.1:5555/auth/callback'
+          client_uri = 'http://127.0.0.1:48599/auth/callback2'
+          expect(URIChecker.matches?(uri, client_uri)).to be_falsey
+        end
       end
 
       context "client registered query params" do


### PR DESCRIPTION
Fix issue for callback URIs that is loopback IP redirects 
Paragraph 7.3 of RFC8252

https://tools.ietf.org/html/rfc8252