### PR TITLE
Post /oauth/token returning 500 #1179

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1179] Authorization Code flow without client id returns invalid_grant error.
 - [#1182] Fix loopback IP redirect URIs to conform with RFC8252, p. 7.3 (fixes #1170).
 - [#1177] Allow to limit `scopes` for certain `grant_types`
 - [#1162] Fix `enforce_content_type` for requests without body.

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -53,7 +53,7 @@ module Doorkeeper
       end
 
       def validate_grant
-        return false unless grant && grant.application_id == client.id
+        return false unless grant && client && grant.application_id == client.id
         grant.accessible?
       end
 

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -85,6 +85,20 @@ feature 'Authorization Code Flow' do
     should_have_json_within 'expires_in', Doorkeeper::AccessToken.first.expires_in, 1
   end
 
+  scenario 'resource owner requests an access token with authorization code but without client id' do
+    visit authorization_endpoint_url(client: @client)
+    click_on 'Authorize'
+
+    authorization_code = Doorkeeper::AccessGrant.first.token
+    page.driver.post token_endpoint_url(code: authorization_code,
+                                        client_secret: @client.secret,
+                                        redirect_uri: @client.redirect_uri)
+
+    expect(Doorkeeper::AccessToken.count).to be_zero
+
+    should_have_json 'error', 'invalid_grant'
+  end
+
   scenario 'resource owner requests an access token with authorization code but without secret' do
     visit authorization_endpoint_url(client: @client)
     click_on 'Authorize'


### PR DESCRIPTION
This is regarding https://github.com/doorkeeper-gem/doorkeeper/issues/1179

When POST to /oauth/token in the Authorization Code flow without `client_id`, it is currently returning a 500. This fix will check for the `client` in the `validate_client` method and return invalid_grant instead.