### PR TITLE
Fix client validation in authorization code flow

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1179] Authorization Code Grant Flow without client id returns invalid_client error.
 - [#1182] Fix loopback IP redirect URIs to conform with RFC8252, p. 7.3 (fixes #1170).
 - [#1177] Allow to limit `scopes` for certain `grant_types`
 - [#1162] Fix `enforce_content_type` for requests without body.
@@ -64,12 +65,12 @@ User-visible changes worth mentioning.
   `Doorkeeper#installed?` method
 - [#1031] Allow public clients to authenticate without `client_secret`. Define an app as
   either public or private/confidential
-  
+
   **[IMPORTANT]**: all the applications (clients) now are considered as private by default.
     You need to manually change `confidential` column to `false` if you are using public clients,
     in other case your mobile (or other) applications will not be able to authorize.
     See [#1142](https://github.com/doorkeeper-gem/doorkeeper/issues/1142) for more details.
-  
+
 - [#1010] Add configuration to enforce configured scopes (`default_scopes` and
   `optional_scopes`) for applications
 - [#1060] Ensure that the native redirect_uri parameter matches with redirect_uri of the client
@@ -87,26 +88,26 @@ User-visible changes worth mentioning.
 - [#1076] Add config to enforce content type to application/x-www-form-urlencoded
 - Fix bug with `force_ssl_in_redirect_uri` when it breaks existing applications with an
   SSL redirect_uri.
-  
+
 ## 4.4.3
-  
+
 - [#1143] Adds a config option `opt_out_native_route_change` to opt out of the breaking api
   changed introduced in https://github.com/doorkeeper-gem/doorkeeper/pull/1003
 
-  
+
 ## 4.4.2
 
 - [#1130] Backport fix for native redirect_uri from 5.x.
-  
+
 ## 4.4.1
 
 - [#1127] Backport token type to comply with the RFC6750 specification.
 - [#1125] Backport Quote surround I18n yes/no keys
-  
+
 ## 4.4.0
-  
+
 - [#1120] Backport security fix from 5.x for token revocation when using public clients
-  
+
   **[IMPORTANT]**: all the applications (clients) now are considered as private by default.
   You need to manually change `confidential` column to `false` if you are using public clients,
   in other case your mobile (or other) applications will not be able to authorize.

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -49,7 +49,7 @@ module Doorkeeper
       end
 
       def validate_client
-        !client.nil?
+        client.present?
       end
 
       def validate_grant

--- a/lib/doorkeeper/oauth/client.rb
+++ b/lib/doorkeeper/oauth/client.rb
@@ -18,7 +18,7 @@ module Doorkeeper
       end
 
       def self.authenticate(credentials, method = Application.method(:by_uid_and_secret))
-        return false if credentials.blank?
+        return if credentials.blank?
 
         if (application = method.call(credentials.uid, credentials.secret))
           new(application)

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -45,7 +45,7 @@ module Doorkeeper
       end
 
       def validate_client
-        !parameters[:client_id] || !client.nil?
+        !parameters[:client_id] || client.present?
       end
     end
   end

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -98,6 +98,19 @@ feature 'Authorization Code Flow' do
     should_have_json 'error', 'invalid_client'
   end
 
+  scenario 'resource owner requests an access token with authorization code but without client id' do
+    visit authorization_endpoint_url(client: @client)
+    click_on 'Authorize'
+
+    authorization_code = Doorkeeper::AccessGrant.first.token
+    page.driver.post token_endpoint_url(code: authorization_code, client_secret: @client.secret,
+                                        redirect_uri: @client.redirect_uri)
+
+    expect(Doorkeeper::AccessToken.count).to be_zero
+
+    should_have_json 'error', 'invalid_client'
+  end
+
   scenario 'silently authorizes if matching token exists' do
     default_scopes_exist :public, :write
 

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -64,7 +64,8 @@ describe 'Resource Owner Password Credentials Flow' do
               )
             end.not_to(change { Doorkeeper::AccessToken.count })
 
-            expect(response).not_to be_ok
+            expect(response.status).to eq(401)
+            should_have_json 'error', 'invalid_client'
           end
         end
       end
@@ -88,7 +89,8 @@ describe 'Resource Owner Password Credentials Flow' do
             post password_token_endpoint_url(client_id: @client.uid, resource_owner: @resource_owner)
           end.not_to(change { Doorkeeper::AccessToken.count })
 
-          expect(response).not_to be_ok
+          expect(response.status).to eq(401)
+          should_have_json 'error', 'invalid_client'
         end
       end
     end


### PR DESCRIPTION
### Summary

Fixes https://github.com/doorkeeper-gem/doorkeeper/issues/1179. 

### Problem

`POST /oauth/token` without client_id returns 500

### Root cause

[Doorkeeper::OAuth::Client::authenticate](https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib/doorkeeper/oauth/client.rb#L21) method was returning `false`, `nil` or `new(application)`, but [Doorkeeper::OAuth::AuthorizationCodeRequest#validate_client](https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib/doorkeeper/oauth/authorization_code_request.rb#L52) method wasn't aware of possible `false` value and relied on `!client.nil?`.

### Changes

* Return invalid_client error if client_id is missing
* Unify client validation interface across validate_client calls
* Add test for authorization code flow with missing client_id

