### PR TITLE
Fix TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.6
 
 before_install:
+  - rvm @global do gem uninstall bundler -a -x -I || true
   - gem install bundler -v '~> 1.10'
 
 gemfile:


### PR DESCRIPTION
### Summary

Ruby 2.3 and Rails 4.2 build failed because of incorrect bundler version
in TravisCI. Bypass this one by deleting default bundler present in
TravisCI.

Let's make Travis badge green again! 🎉 