### PR TITLE
Fix TravisCI for ruby-head and Rails 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - ruby-head
 
 before_install:
+  - "find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete"
   - rvm @global do gem uninstall bundler -a -x -I || true
   - gem install bundler -v '~> 1.10'
 


### PR DESCRIPTION
### Summary

Comments in this issue https://github.com/travis-ci/travis-ci/issues/8717 helped to bypass default bundler version. 

Let's make the badge green again. 🎉 