### PR TITLE
Fix #1183: Use params instead of request.POST

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1188]  Use `params` instead of `request.POST` in tokens controller (fixes #1183).
 - [#1179] Authorization Code Grant Flow without client id returns invalid_client error.
 - [#1182] Fix loopback IP redirect URIs to conform with RFC8252, p. 7.3 (fixes #1170).
 - [#1177] Allow to limit `scopes` for certain `grant_types`

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -4,11 +4,11 @@ module Doorkeeper
   class TokensController < Doorkeeper::ApplicationMetalController
     def create
       response = authorize_response
-      headers.merge! response.headers
+      headers.merge!(response.headers)
       self.response_body = response.body.to_json
       self.status = response.status
-    rescue Errors::DoorkeeperError => e
-      handle_token_exception e
+    rescue Errors::DoorkeeperError => error
+      handle_token_exception(error)
     end
 
     # OAuth 2.0 Token Revocation - http://tools.ietf.org/html/rfc7009
@@ -75,12 +75,12 @@ module Doorkeeper
     end
 
     def token
-      @token ||= AccessToken.by_token(request.POST['token']) ||
-        AccessToken.by_refresh_token(request.POST['token'])
+      @token ||= AccessToken.by_token(params['token']) ||
+        AccessToken.by_refresh_token(params['token'])
     end
 
     def strategy
-      @strategy ||= server.token_request params[:grant_type]
+      @strategy ||= server.token_request(params[:grant_type])
     end
 
     def authorize_response

--- a/spec/requests/flows/revoke_token_spec.rb
+++ b/spec/requests/flows/revoke_token_spec.rb
@@ -26,30 +26,28 @@ describe 'Revoke Token Flow' do
       it 'should revoke the access token provided' do
         post revocation_token_endpoint_url, params: { token: access_token.token }, headers: headers
 
-        access_token.reload
-
         expect(response).to be_successful
-        expect(access_token.revoked?).to be_truthy
+        expect(access_token.reload.revoked?).to be_truthy
       end
 
       it 'should revoke the refresh token provided' do
         post revocation_token_endpoint_url, params: { token: access_token.refresh_token }, headers: headers
 
-        access_token.reload
-
         expect(response).to be_successful
-        expect(access_token.revoked?).to be_truthy
+        expect(access_token.reload.revoked?).to be_truthy
       end
 
       context 'with invalid token to revoke' do
         it 'should not revoke any tokens and respond successfully' do
-          num_prev_revoked_tokens = Doorkeeper::AccessToken.where(revoked_at: nil).count
-          post revocation_token_endpoint_url, params: { token: 'I_AM_AN_INVALID_TOKEN' }, headers: headers
+          expect do
+            post revocation_token_endpoint_url,
+              params: { token: 'I_AM_AN_INVALID_TOKEN' },
+              headers: headers
+            end.not_to(change { Doorkeeper::AccessToken.where(revoked_at: nil).count })
 
           # The authorization server responds with HTTP status code 200 even if
           # token is invalid
           expect(response).to be_successful
-          expect(Doorkeeper::AccessToken.where(revoked_at: nil).count).to eq(num_prev_revoked_tokens)
         end
       end
 
@@ -62,10 +60,8 @@ describe 'Revoke Token Flow' do
         it 'should not revoke any tokens and respond successfully' do
           post revocation_token_endpoint_url, params: { token: access_token.token }, headers: headers
 
-          access_token.reload
-
           expect(response).to be_successful
-          expect(access_token.revoked?).to be_falsey
+          expect(access_token.reload.revoked?).to be_falsey
         end
       end
 
@@ -73,10 +69,8 @@ describe 'Revoke Token Flow' do
         it 'should not revoke any tokens and respond successfully' do
           post revocation_token_endpoint_url, params: { token: access_token.token }
 
-          access_token.reload
-
           expect(response).to be_successful
-          expect(access_token.revoked?).to be_falsey
+          expect(access_token.reload.revoked?).to be_falsey
         end
       end
 
@@ -92,10 +86,8 @@ describe 'Revoke Token Flow' do
         it 'should not revoke the token as its unauthorized' do
           post revocation_token_endpoint_url, params: { token: access_token.token }, headers: headers
 
-          access_token.reload
-
           expect(response).to be_successful
-          expect(access_token.revoked?).to be_falsey
+          expect(access_token.reload.revoked?).to be_falsey
         end
       end
     end
@@ -111,19 +103,15 @@ describe 'Revoke Token Flow' do
       it 'should revoke the access token provided' do
         post revocation_token_endpoint_url, params: { token: access_token.token }
 
-        access_token.reload
-
         expect(response).to be_successful
-        expect(access_token.revoked?).to be_truthy
+        expect(access_token.reload.revoked?).to be_truthy
       end
 
       it 'should revoke the refresh token provided' do
         post revocation_token_endpoint_url, params: { token: access_token.refresh_token }
 
-        access_token.reload
-
         expect(response).to be_successful
-        expect(access_token.revoked?).to be_truthy
+        expect(access_token.reload.revoked?).to be_truthy
       end
 
       context 'with a valid token issued for a confidential client' do
@@ -137,19 +125,15 @@ describe 'Revoke Token Flow' do
         it 'should not revoke the access token provided' do
           post revocation_token_endpoint_url, params: { token: access_token.token }
 
-          access_token.reload
-
           expect(response).to be_successful
-          expect(access_token.revoked?).to be_falsey
+          expect(access_token.reload.revoked?).to be_falsey
         end
 
         it 'should not revoke the refresh token provided' do
           post revocation_token_endpoint_url, params: { token: access_token.token }
 
-          access_token.reload
-
           expect(response).to be_successful
-          expect(access_token.revoked?).to be_falsey
+          expect(access_token.reload.revoked?).to be_falsey
         end
       end
     end


### PR DESCRIPTION
Fixes #1183 