### PR TITLE
Try to load bcrypt for hashing of application secrets, but add fallback.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "rails", ">= 5.2.1.1", "< 6.0"
 
 gem "appraisal"
 
-gem "bcrypt", "~> 3.1"
+gem "bcrypt", "~> 3.1", require: false
 
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", platform: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,8 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#] Add your PR description here.
+- [#1191]: Try to load bcrypt for hashing of application secrets, but add fallback.
+
 
 ## 5.1.0.rc1
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ https://github.com/doorkeeper-gem/doorkeeper/releases
   - [API mode](#api-mode)
   - [Routes](#routes)
   - [Authenticating](#authenticating)
+  - [Hashing of token and application secrets](#hashing-of-token-and-application-secrets)
   - [Internationalization (I18n)](#internationalization-i18n)
   - [Customizing errors](#customizing-errors)
   - [Rake Tasks](#rake-tasks)
@@ -235,6 +236,47 @@ the methods defined over there.
 
 You may want to check other ways of authentication
 [here](https://github.com/doorkeeper-gem/doorkeeper/wiki/Authenticating-using-Clearance-or-DIY).
+
+
+### Hashing of token and application secrets
+
+Doorkeeper can optionally Hash access, refresh tokens, and application secrets before persisting them.
+Since integrations may have decided on showing application secrets later on, both options can be enabled individually.
+
+To enable hashing of access and refresh tokens, uncomment the initializer line `hash_token_secrets`.
+Upon issueing a new token, the plain token value will be available for presenting to the user in `token.plaintext_token`.
+Later comparisons will only be performed on the hashed token and the plain token can no longer be retrieved.
+
+#### Fallback to plain token lookup
+
+When you are upgrading doorkeeper and have existing access or refresh tokens in your database that you want to keep,
+enabling `hash_token_secrets` would implicitly invalidate all plaintext tokens since the plain tokens would no longer be found.
+
+To enable plain values to be found and upgraded to a hashed value whenever it is accessed, you may enable the additional option
+`fallback_to_plain_secrets`. This is only needed for _existing_ doorkeeper installations with plain tokens present.
+
+#### Incompatibility with reuse_access_token
+
+Enabling `hash_token_secrets` is incompatible with the option `reuse_access_token`
+since plain values can no longer be retrieved. If you enabled both,
+the latter will be disabled with a warning.
+
+To enable hashing application secrets (`client_secret`), uncomment the initializer line `hash_application_secrets`.
+This will result in the `secret` value of the application being available during the request that created in as `application.plaintext_secret`.
+In this request, you need to ensure the user noted the secret since you will no longer be able to show it afterwards.
+
+#### Using BCrypt gem for application secrets
+
+The hashing implementation for `Doorkeeper::Application` will try to load and use the `bcrypt` gem for hashing the secret.
+If the gem can not be loaded, it is falling back to a `SHA256` digest.
+
+If you want to use bcrypt, simply add it to your Gemfile.
+
+```
+  gem 'doorkeeper'
+  gem 'bcrypt', require: false
+```
+
 
 ### Internationalization (I18n)
 

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
-gem "bcrypt", "~> 3.1"
+gem "bcrypt", "~> 3.1", require: false
 gem "appraisal"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", platform: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
-gem "bcrypt", "~> 3.1"
+gem "bcrypt", "~> 3.1", require: false
 gem "appraisal"
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 gem "sqlite3", platforms: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
-gem "bcrypt", "~> 3.1"
+gem "bcrypt", "~> 3.1", require: false
 gem "appraisal"
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 gem "sqlite3", platforms: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
-gem "bcrypt", "~> 3.1"
+gem "bcrypt", "~> 3.1", require: false
 gem "appraisal"
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 gem "sqlite3", platforms: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/gemfiles/rails_master.gemfile
+++ b/gemfiles/rails_master.gemfile
@@ -6,7 +6,7 @@ gem "rails", git: 'https://github.com/rails/rails'
 gem "arel", git: 'https://github.com/rails/arel'
 
 gem "appraisal"
-gem "bcrypt", "~> 3.1"
+gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -80,8 +80,12 @@ Doorkeeper.configure do
   # reuse_access_token
 
   # Hash access and refresh tokens before persisting them.
-  # Note: This will disable the possibility to use +reuse_access_token+
+  # This will disable the possibility to use +reuse_access_token+
   # since plain values can no longer be retrieved.
+  #
+  # Note: If you are already a user of doorkeeper and have existing tokens
+  # in your installation, they will be invalid without enabling the additional
+  # setting `fallback_to_plain_secrets` below.
   #
   # hash_token_secrets
 
@@ -94,7 +98,7 @@ Doorkeeper.configure do
   # look up the plain text token as a fallback.
   #
   # This will ensure that old access tokens and secrets
-  # will remain valid even if the hashing above is enabled
+  # will remain valid even if the hashing above is enabled.
   #
   # fallback_to_plain_secrets
 

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'bcrypt'
 
 module Doorkeeper
   describe Application do
@@ -127,10 +128,33 @@ module Doorkeeper
       include_context 'with application hashing enabled'
       let(:app) { FactoryBot.create :application }
 
+      context 'assuming we cannot load bcrypt' do
+        after do
+          # Ensure configuration is called again to reset setup
+          allow(described_class).to receive(:bcrypt_present?).and_call_original
+          ::Doorkeeper::Application.configure_secrets_hashing
+          expect(::Doorkeeper::Application.secret_comparer).to be_present
+          expect(::Doorkeeper::Application.secret_hash_function).to be_present
+        end
+
+        it 'uses SHA256 to avoid additional dependencies' do
+          allow(described_class).to receive(:bcrypt_present?).and_return false
+
+          ::Doorkeeper::Application.configure_secrets_hashing
+
+          expect(app.class.secret_comparer).to be_nil
+          expect(app.class.secret_hash_function).to be_nil
+
+          # Ensure token was generated
+          app.validate
+          expect(app.secret).to eq(described_class.default_hash_function(app.plaintext_secret))
+        end
+      end
+
       it 'holds a volatile plaintext and BCrypt secret' do
         expect(app.plaintext_secret).to be_a(String)
         expect(app.secret).not_to eq(app.plaintext_secret)
-        expect { BCrypt::Password.create(app.secret) }.not_to raise_error
+        expect { ::BCrypt::Password.create(app.secret) }.not_to raise_error
       end
 
       it 'does not fallback to plain lookup by default' do


### PR DESCRIPTION
Currently bcrypt was an implicit dependency of the token hashing added to bcrypt without explicitly adding it to the gemspec.

Since bcrypt hashing on applications was merely a choice without much implied security, we should not push this requirement on all users of doorkeeper.

Instead, this PR will try to configure `Doorkeeper::Application` with bcrypt secret hashing and fall back to the default SHA256 digest if it was not found.

A documentation section was added to the README that introduces token hashing and also documents how to add bcrypt.

Fixes #1190