### PR TITLE
Use correct HTTP status codes for error responses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,11 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1202] Use correct HTTP status codes for error responses
+
+  **[IMPORTANT]**: this change might break your application if you were relying on the previous
+  401 status codes, this is now a 400 by default, or a 401 for `invalid_client` and `invalid_token` errors.
+
 - [#1201] Fix custom TTL block `client` parameter to always be an `Doorkeeper::Application` instance.
 
   **[IMPORTANT]**: those who defined `custom_access_token_expires_in` configuration option need to check

--- a/app/controllers/doorkeeper/token_info_controller.rb
+++ b/app/controllers/doorkeeper/token_info_controller.rb
@@ -6,7 +6,7 @@ module Doorkeeper
       if doorkeeper_token && doorkeeper_token.accessible?
         render json: doorkeeper_token, status: :ok
       else
-        error = OAuth::ErrorResponse.new(name: :invalid_request)
+        error = OAuth::InvalidTokenResponse.new
         response.headers.merge!(error.headers)
         render json: error.body, status: error.status
       end

--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -32,7 +32,11 @@ module Doorkeeper
       end
 
       def status
-        :unauthorized
+        if name == :invalid_client
+          :unauthorized
+        else
+          :bad_request
+        end
       end
 
       def redirectable?

--- a/lib/doorkeeper/oauth/invalid_token_response.rb
+++ b/lib/doorkeeper/oauth/invalid_token_response.rb
@@ -22,6 +22,10 @@ module Doorkeeper
         @reason = attributes[:reason] || :unknown
       end
 
+      def status
+        :unauthorized
+      end
+
       def description
         scope = { scope: %i[doorkeeper errors messages invalid_token] }
         @description ||= I18n.translate @reason, scope

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -165,7 +165,7 @@ describe Doorkeeper::AuthorizationsController, 'implicit grant flow' do
     let(:redirect_uri) { response_json_body['redirect_uri'] }
 
     it 'renders 400 error' do
-      expect(response.status).to eq 401
+      expect(response.status).to eq 400
     end
 
     it 'includes correct redirect URI' do

--- a/spec/controllers/token_info_controller_spec.rb
+++ b/spec/controllers/token_info_controller_spec.rb
@@ -40,7 +40,7 @@ describe Doorkeeper::TokenInfoController do
         get :show
 
         expect(response.body).to eq(
-          Doorkeeper::OAuth::ErrorResponse.new(name: :invalid_request, status: :unauthorized).body.to_json
+          Doorkeeper::OAuth::InvalidTokenResponse.new.body.to_json
         )
       end
     end

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -20,7 +20,7 @@ describe Doorkeeper::TokensController do
 
       post :create
 
-      expect(response.status).to eq 401
+      expect(response.status).to eq 400
       expect(response.headers['WWW-Authenticate']).to match(/Bearer/)
     end
   end
@@ -49,7 +49,7 @@ describe Doorkeeper::TokensController do
         "error"             => custom_message,
         "error_description" => "Authorization custom message"
       }
-      expect(response.status).to eq 401
+      expect(response.status).to eq 400
       expect(response.headers['WWW-Authenticate']).to match(/Bearer/)
       expect(JSON.parse(response.body)).to eq expected_response_body
     end
@@ -284,7 +284,7 @@ describe Doorkeeper::TokensController do
         post :introspect, params: { token: access_token.token }
 
         expect(response).not_to be_successful
-        response_status_should_be 401
+        response_status_should_be 400
 
         should_not_have_json 'active'
         should_have_json 'error', 'invalid_request'

--- a/spec/lib/oauth/error_response_spec.rb
+++ b/spec/lib/oauth/error_response_spec.rb
@@ -3,7 +3,13 @@ require 'spec_helper'
 module Doorkeeper::OAuth
   describe ErrorResponse do
     describe '#status' do
-      it 'should have a status of unauthorized' do
+      it 'should have a status of bad_request' do
+        expect(subject.status).to eq(:bad_request)
+      end
+
+      it 'should have a status of unauthorized for an invalid_client error' do
+        subject = described_class.new(name: :invalid_client)
+
         expect(subject.status).to eq(:unauthorized)
       end
     end

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -58,7 +58,7 @@ describe 'Client Credentials Request' do
           should_have_json 'error_description', translated_error_message(:invalid_scope)
           should_not_have_json 'access_token'
 
-          expect(response.status).to eq(401)
+          expect(response.status).to eq(400)
         end
       end
     end

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -217,7 +217,7 @@ describe 'Resource Owner Password Credentials Flow' do
       should_have_json 'error_description', translated_error_message(:invalid_scope)
       should_not_have_json 'access_token'
 
-      expect(response.status).to eq(401)
+      expect(response.status).to eq(400)
     end
   end
 


### PR DESCRIPTION
### Summary

Fixes https://github.com/doorkeeper-gem/doorkeeper/issues/550

Changes the HTTP status codes for error responses to conform with the OAuth specs, as discussed in the issue.

https://tools.ietf.org/html/rfc6749#section-5.2:

- a 400 status should be returned for most error conditions
  - implemented
- a 401 MAY be be returned for an `invalid_client` error, and MUST be returned if the `Authorization` request header is used.
  - implemented

https://tools.ietf.org/html/rfc6750#section-3.1:

- a 401 SHOULD be returned for an `invalid_token` error
  - implemented
- a 403 SHOULD be returned for an `insufficient_scope` error
  - not implemented, Doorkeeper doesn't seem to use this error currently