### PR TITLE
Add application secrets and tokens encryption

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1205] Allow optional encryption of tokens and secrets
+
 - [#1201] Fix custom TTL block `client` parameter to always be an `Doorkeeper::Application` instance.
 
   **[IMPORTANT]**: those who defined `custom_access_token_expires_in` configuration option need to check

--- a/README.md
+++ b/README.md
@@ -277,6 +277,26 @@ If you want to use bcrypt, simply add it to your Gemfile.
   gem 'bcrypt', require: false
 ```
 
+### Encryption of tokens and application secrets
+
+To enable encryption of access tokens and refresh tokens, uncomment the initializer lines
+`encrypt_token_secrets` and `encryption_key`. The option automatically enable
+`hash_token_secrets` and `hash_application_secrets`. The plain token/secret value will
+be available for presenting to the user in `token.plaintext_token`/`application.plaintext_secret`.
+
+By default gem uses `ActiveSupport::MessageEncryptor` for encryption. 
+You can redefine encryption algorithm by implementing class with methods `encrypt(plaintext)`
+and `decrypt(ciphertext)` (look default_encryption_box.rb as example)
+
+For example, you can use `rbnacl` SimpleBox for encryption
+Add gem `rbnacl` to you Gemfile and uncomment/add following lines in initializer
+
+```ruby
+encryption_box do
+  key = [Doorkeeper.configuration.encryption_key].pack('H*')
+  RbNaCl::SimpleBox.from_secret_key(key[0, RbNaCl::SecretBox.key_bytes])
+end
+```
 
 ### Internationalization (I18n)
 

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -2,6 +2,8 @@ require 'doorkeeper/version'
 require 'doorkeeper/engine'
 require 'doorkeeper/config'
 
+require 'doorkeeper/default_encryption_box.rb'
+
 require 'doorkeeper/request/strategy'
 require 'doorkeeper/request/authorization_code'
 require 'doorkeeper/request/client_credentials'
@@ -58,6 +60,7 @@ require 'doorkeeper/models/concerns/reusable'
 require 'doorkeeper/models/concerns/revocable'
 require 'doorkeeper/models/concerns/accessible'
 require 'doorkeeper/models/concerns/hashable'
+require 'doorkeeper/models/concerns/encryptable'
 
 require 'doorkeeper/models/access_grant_mixin'
 require 'doorkeeper/models/access_token_mixin'

--- a/lib/doorkeeper/default_encryption_box.rb
+++ b/lib/doorkeeper/default_encryption_box.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  class DefaultEncryptionBox
+    attr_reader :encryptor
+
+    def initialize(key)
+      @encryptor = ActiveSupport::MessageEncryptor.new(
+        key[0, ActiveSupport::MessageEncryptor.key_len]
+      )
+    end
+
+    def encrypt(plaintext)
+      encryptor.encrypt_and_sign(plaintext)
+    end
+
+    def decrypt(ciphertext)
+      encryptor.decrypt_and_verify(ciphertext)
+    end
+  end
+end

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -10,6 +10,7 @@ module Doorkeeper
     include Models::Accessible
     include Models::Orderable
     include Models::Hashable
+    include Models::Encryptable
     include Models::Scopes
 
     # never uses pkce, if pkce migrations were not generated

--- a/lib/doorkeeper/models/application_mixin.rb
+++ b/lib/doorkeeper/models/application_mixin.rb
@@ -7,6 +7,7 @@ module Doorkeeper
     include OAuth::Helpers
     include Models::Orderable
     include Models::Hashable
+    include Models::Encryptable
     include Models::Scopes
 
     included do

--- a/lib/doorkeeper/models/concerns/encryptable.rb
+++ b/lib/doorkeeper/models/concerns/encryptable.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Models
+    module Encryptable
+      extend ActiveSupport::Concern
+
+      delegate :encrypt_token_secrets?,
+               :encrypt_token,
+               :decrypt_token,
+               :encrypted_column,
+               to: :class
+
+      module ClassMethods
+        def encrypt_token_secrets?
+          Doorkeeper.configuration.encrypt_token_secrets?
+        end
+
+        def encrypt_token(plain_token)
+          default_encryption_box.encrypt(plain_token)
+        end
+
+        def decrypt_token(encrypted_token)
+          default_encryption_box.decrypt(encrypted_token)
+        end
+
+        def default_encryption_box
+          @default_encryption_box ||=
+            Doorkeeper.configuration.encryption_box.call
+        end
+
+        def encrypted_column(attribute)
+          "#{Doorkeeper.configuration.encryption_prefix_column}_#{attribute}"
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/access_grant.rb
@@ -33,7 +33,9 @@ module Doorkeeper
     #
     # If hash tokens are enabled, this will return nil on fetched tokens
     def plaintext_token
-      if perform_secret_hashing?
+      if encrypt_token_secrets?
+        @raw_token ||= decrypt_token(read_attribute(encrypted_column(:token)))
+      elsif perform_secret_hashing?
         @raw_token
       else
         token
@@ -49,6 +51,9 @@ module Doorkeeper
     def generate_token
       @raw_token = UniqueToken.generate
       self.token = hashed_or_plain_token(@raw_token)
+      if encrypt_token_secrets?
+        assign_attributes(encrypted_column(:token) => encrypt_token(@raw_token))
+      end
     end
   end
 end

--- a/lib/generators/doorkeeper/encrypted_columns_generator.rb
+++ b/lib/generators/doorkeeper/encrypted_columns_generator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails/generators'
+require 'rails/generators/active_record'
+
+module Doorkeeper
+  class EncryptedColumnsGenerator < ::Rails::Generators::Base
+    include ::Rails::Generators::Migration
+    source_root File.expand_path('templates', __dir__)
+    desc 'Add encrypted columns to Doorkeeper applications'
+
+    def pkce
+      migration_template(
+        'add_encrypted_columns.rb.erb',
+        'db/migrate/add_encrypted_columns.rb',
+        migration_version: migration_version
+      )
+    end
+
+    def self.next_migration_number(dirname)
+      ActiveRecord::Generators::Base.next_migration_number(dirname)
+    end
+
+    private
+
+    def migration_version
+      if ActiveRecord::VERSION::MAJOR >= 5
+        "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+      end
+    end
+  end
+end

--- a/lib/generators/doorkeeper/templates/add_encrypted_columns.rb.erb
+++ b/lib/generators/doorkeeper/templates/add_encrypted_columns.rb.erb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddEncryptedColumns < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_column :oauth_applications, :encrypted_secret, :binary
+
+    add_column :oauth_access_tokens, :encrypted_token, :binary
+    add_column :oauth_access_tokens, :encrypted_refresh_token, :binary
+
+    add_column :oauth_access_grants, :encrypted_token, :binary
+  end
+end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -112,6 +112,26 @@ Doorkeeper.configure do
   #
   # fallback_to_plain_secrets
 
+  # Encrypt access, refresh tokens and application secrets
+  # Note: If you are already a user of doorkeeper and have existing tokens
+  # with enabled hashing in your installation, then it's not possible to
+  # retrieve plaintext_token for existing tokens
+  #
+  # encrypt_token_secrets
+  # encryption_key Rails.application.secrets.secret_key_base
+
+  # By default gem uses `ActiveSupport::MessageEncryptor` for encryption
+  # You can redefine encryption algorithm by implementing class with methods
+  # `encrypt(plaintext)` and `decrypt(ciphertext)`
+  #
+  # For example, you can use `rbnacl` SimpleBox for encryption
+  # Add gem `rbnacl` to you Gemfile and uncomment following lines
+  #
+  # encryption_box do
+  #   key = [Doorkeeper.configuration.encryption_key].pack('H*')
+  #   RbNaCl::SimpleBox.from_secret_key(key[0, RbNaCl::SecretBox.key_bytes])
+  # end
+
   #
   # Since old values will not be re-hashed, lookups to tokens and secrets
   # will fall back to plain value comparison so any existing tokens will

--- a/lib/generators/doorkeeper/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/migration.rb.erb
@@ -7,7 +7,10 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
       t.text    :redirect_uri, null: false
       t.string  :scopes,       null: false, default: ''
       t.boolean :confidential, null: false, default: true
-      t.timestamps             null: false
+      t.timestamps             null: false,
+      
+      # Uncomment following lines if using encrypt_token_secrets
+      # t.binary :encrypted_secret
     end
 
     add_index :oauth_applications, :uid, unique: true
@@ -21,6 +24,9 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
       t.datetime :created_at,        null: false
       t.datetime :revoked_at
       t.string   :scopes
+      
+      # Uncomment following lines if using encrypt_token_secrets
+      # t.binary :encrypted_token
     end
 
     add_index :oauth_access_grants, :token, unique: true
@@ -55,6 +61,10 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
       # Comment out this line if you'd rather have refresh tokens
       # instantly revoked.
       t.string   :previous_refresh_token, null: false, default: ""
+
+      # Uncomment following lines if using encrypt_token_secrets
+      # t.binary :encrypted_token
+      # t.binary :encrypted_refresh_token
     end
 
     add_index :oauth_access_tokens, :token, unique: true

--- a/spec/dummy/db/migrate/20190225040212_add_encrypted_columns.rb
+++ b/spec/dummy/db/migrate/20190225040212_add_encrypted_columns.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddEncryptedColumns < ActiveRecord::Migration[5.2]
+  def change
+    add_column :oauth_applications, :encrypted_secret, :binary
+
+    add_column :oauth_access_tokens, :encrypted_token, :binary
+    add_column :oauth_access_tokens, :encrypted_refresh_token, :binary
+
+    add_column :oauth_access_grants, :encrypted_token, :binary
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180210183654) do
+ActiveRecord::Schema.define(version: 20190225040212) do
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20180210183654) do
       t.string   "code_challenge"
       t.string   "code_challenge_method"
     end
+    t.binary "encrypted_token"
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
@@ -38,6 +39,8 @@ ActiveRecord::Schema.define(version: 20180210183654) do
     t.datetime "created_at", null: false
     t.string "scopes"
     t.string "previous_refresh_token", default: "", null: false
+    t.binary "encrypted_token"
+    t.binary "encrypted_refresh_token"
     t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
     t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
@@ -54,6 +57,7 @@ ActiveRecord::Schema.define(version: 20180210183654) do
     t.integer "owner_id"
     t.string "owner_type"
     t.boolean "confidential", default: true, null: false
+    t.binary "encrypted_secret"
     t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end

--- a/spec/generators/encrypted_columns_generator_spec.rb
+++ b/spec/generators/encrypted_columns_generator_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'generators/doorkeeper/encrypted_columns_generator'
+
+describe 'Doorkeeper::EncryptedColumnsGenerator' do
+  include GeneratorSpec::TestCase
+
+  tests Doorkeeper::EncryptedColumnsGenerator
+  destination ::File.expand_path('../tmp/dummy', __FILE__)
+
+  describe 'after running the generator' do
+    before :each do
+      prepare_destination
+    end
+
+    context 'pre Rails 5.0.0' do
+      it 'creates a migration with no version specifier' do
+        stub_const("ActiveRecord::VERSION::MAJOR", 4)
+        stub_const("ActiveRecord::VERSION::MINOR", 2)
+
+        run_generator
+
+        assert_migration 'db/migrate/add_encrypted_columns.rb' do |migration|
+          assert migration.include?("ActiveRecord::Migration\n")
+          assert migration.include?(':encrypted_secret')
+          assert migration.include?(':encrypted_token')
+          assert migration.include?(':encrypted_refresh_token')
+        end
+      end
+    end
+
+    context 'post Rails 5.0.0' do
+      it 'creates a migration with a version specifier' do
+        stub_const("ActiveRecord::VERSION::MAJOR", 5)
+        stub_const("ActiveRecord::VERSION::MINOR", 0)
+
+        run_generator
+
+        assert_migration 'db/migrate/add_encrypted_columns.rb' do |migration|
+          assert migration.include?("ActiveRecord::Migration[5.0]\n")
+          assert migration.include?(':encrypted_secret')
+          assert migration.include?(':encrypted_token')
+          assert migration.include?(':encrypted_refresh_token')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/doorkeeper/access_grant_spec.rb
+++ b/spec/models/doorkeeper/access_grant_spec.rb
@@ -12,6 +12,17 @@ describe Doorkeeper::AccessGrant do
     let(:factory_name) { :access_grant }
   end
 
+  context 'with encryption enabled' do
+    let(:grant) { FactoryBot.create :access_grant }
+    include_context 'with encryption enabled'
+
+    it 'decrypts a volatile plaintext token' do
+      # Finder method only finds the hashed token
+      loaded = clazz.find_by(token: grant.token)
+      expect(loaded.plaintext_token).to eq(grant.plaintext_token)
+    end
+  end
+
   context 'with hashing enabled' do
     let(:grant) { FactoryBot.create :access_grant }
     include_context 'with token hashing enabled'

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -25,6 +25,20 @@ module Doorkeeper
         expect(token.token).to be_a(String)
       end
 
+      context 'with encryption enabled' do
+        let(:token) { FactoryBot.create :access_token, use_refresh_token: true }
+        let(:loaded) { clazz.find_by(token: token.token) }
+        include_context 'with encryption enabled'
+
+        it 'decrypts a volatile plaintext token' do
+          expect(loaded.plaintext_token).to eq(token.plaintext_token)
+        end
+
+        it 'decrypts a volatile plaintext refresh token' do
+          expect(loaded.plaintext_refresh_token).to eq(token.plaintext_refresh_token)
+        end
+      end
+
       context 'with hashing enabled' do
         let(:token) { FactoryBot.create :access_token }
         include_context 'with token hashing enabled'

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -183,6 +183,16 @@ module Doorkeeper
       end
     end
 
+    context 'with encryption enabled' do
+      include_context 'with encryption enabled'
+      let(:app) { FactoryBot.create :application }
+
+      it 'does not provide access to secret after loading' do
+        lookup = clazz.by_uid_and_secret(app.uid, app.plaintext_secret)
+        expect(lookup.plaintext_secret).to eq(app.plaintext_secret)
+      end
+    end
+
     describe 'destroy related models on cascade' do
       before(:each) do
         new_application.save

--- a/spec/support/shared/hashing_shared_context.rb
+++ b/spec/support/shared/hashing_shared_context.rb
@@ -27,3 +27,13 @@ shared_context 'with application hashing enabled' do
     end
   end
 end
+
+shared_context 'with encryption enabled' do
+  let(:hashed_or_plain_token_func) { Doorkeeper::Application.method(:hashed_or_plain_token) }
+  before do
+    Doorkeeper.configure do
+      encrypt_token_secrets
+      encryption_key '0c829d3227f04bf8c751bab43fa35ca8925b4615bf18472856e1a004c1081269'
+    end
+  end
+end


### PR DESCRIPTION
This PR adds optional encryption of secrets and tokens.

For example if you are using `doorkeeper-jwt` gem with `use_application_secret` enabled, then this PR gives you ability to retrieve plaintext secret of application to sign JWT. In the same time your secrets are encrypted in DB.