### PR TITLE
Fix random spec failures

### DIFF
--- a/spec/routing/custom_controller_routes_spec.rb
+++ b/spec/routing/custom_controller_routes_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe 'Custom controller for routes' do
   before :all do
+    Doorkeeper.configure do
+      orm DOORKEEPER_ORM
+    end
+
     Rails.application.routes.disable_clear_and_finalize = true
 
     Rails.application.routes.draw do


### PR DESCRIPTION
Fix random spec failures because of random order.

For example current master will fail with seed 3152
```bash
bundle exec rspec --seed 3152

[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's 'rails' settings.
====> Doorkeeper ORM: 'active_record'
====> Doorkeeper version: 5.1.0.rc1
====> Rails version: 5.2.2
====> Ruby version: 2.5.1 on x86_64-darwin17

Randomized with seed 3152
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................F...............F.......................................................................................................................................................................................................................*..........................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Doorkeeper::TokensController when authorization has succeeded returns the authorization
     # verify need of these specs
     # ./spec/controllers/tokens_controller_spec.rb:7


Failures:

  1) Custom controller for routes GET /inner_space/scope/applications routes to applications controller
     Failure/Error: expect(get('/inner_space/scope/applications')).to route_to('custom_authorizations#index')
       No route matches "/inner_space/scope/applications"
     # ./spec/routing/custom_controller_routes_spec.rb:73:in `block (2 levels) in <top (required)>'

  2) Custom controller for routes GET /space/oauth/applications routes to applications controller
     Failure/Error: expect(get('/space/oauth/applications')).to route_to('custom_authorizations#index')
       No route matches "/space/oauth/applications"
     # ./spec/routing/custom_controller_routes_spec.rb:105:in `block (2 levels) in <top (required)>'

Finished in 6.58 seconds (files took 5.21 seconds to load)
883 examples, 2 failures, 1 pending

Failed examples:

rspec ./spec/routing/custom_controller_routes_spec.rb:72 # Custom controller for routes GET /inner_space/scope/applications routes to applications controller
rspec ./spec/routing/custom_controller_routes_spec.rb:104 # Custom controller for routes GET /space/oauth/applications routes to applications controller

Randomized with seed 3152
```