### PR TITLE
Fix token introspection tokens validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,8 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#1202] Use correct HTTP status codes for error responses
+- [#1209] Fix tokens validation for Token Introspection request.
+- [#1202] Use correct HTTP status codes for error responses.
 
   **[IMPORTANT]**: this change might break your application if you were relying on the previous
   401 status codes, this is now a 400 by default, or a 401 for `invalid_client` and `invalid_token` errors.

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -33,7 +33,7 @@ module Doorkeeper
       if introspection.authorized?
         render json: introspection.to_json, status: 200
       else
-        error = OAuth::ErrorResponse.new(name: introspection.error)
+        error = introspection.error_response
         response.headers.merge!(error.headers)
         render json: error.body, status: error.status
       end


### PR DESCRIPTION
Some fixes for issues addressed in #1204

* Check validness of the token used to authorize (not revoked, expired, etc)
* Don't allow to introspect token used for authorization