### PR TITLE
minor CI relates update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
-sudo: false
 
 rvm:
   - 2.1

--- a/Appraisals
+++ b/Appraisals
@@ -1,18 +1,21 @@
 appraise "rails-4-2" do
   gem "rails", "~> 4.2.0"
+  gem "grape", '~> 0.16', '< 0.19.2'
 end
 
 appraise "rails-5-0" do
   gem "rails", "~> 5.0.0"
-  gem "rspec-rails", "~> 3.7"
 end
 
 appraise "rails-5-1" do
   gem "rails", "~> 5.1.0"
-  gem "rspec-rails", "~> 3.7"
+end
+
+appraise "rails-5-2" do
+  gem "rails", "~> 5.2.0"
 end
 
 appraise "rails-master" do
   gem "rails", git: 'https://github.com/rails/rails'
-  gem "arel", git: 'https://github.com/rails/arel'
+  gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 end

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'capybara', '~> 2.18'
   gem.add_development_dependency 'coveralls'
   gem.add_development_dependency 'danger', '~> 5.0'
-  gem.add_development_dependency 'grape'
   gem.add_development_dependency 'database_cleaner', '~> 1.6'
   gem.add_development_dependency 'factory_bot', '~> 4.8'
   gem.add_development_dependency 'generator_spec', '~> 0.9.3'
+  gem.add_development_dependency 'grape'
   gem.add_development_dependency 'rake', '>= 11.3.0'
   gem.add_development_dependency 'rspec-rails'
 end

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -3,12 +3,11 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
-gem "bcrypt", "~> 3.1", require: false
 gem "appraisal"
+gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
-# Older Grape requires Ruby >= 2.2.2
-gem "grape", '~> 0.16', '< 0.19.2'
+gem "grape", "~> 0.16", "< 0.19.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -3,11 +3,10 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
-gem "bcrypt", "~> 3.1", require: false
 gem "appraisal"
-gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
-gem "sqlite3", "~> 1.3", "< 1.4", platforms: [:ruby, :mswin, :mingw, :x64_mingw]
+gem "bcrypt", "~> 3.1", require: false
+gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
+gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
-gem "rspec-rails", "~> 3.5"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -3,11 +3,10 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
-gem "bcrypt", "~> 3.1", require: false
 gem "appraisal"
-gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
-gem "sqlite3", "~> 1.3", "< 1.4", platforms: [:ruby, :mswin, :mingw, :x64_mingw]
+gem "bcrypt", "~> 3.1", require: false
+gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
+gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
-gem "rspec-rails", "~> 3.7"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -3,11 +3,10 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
-gem "bcrypt", "~> 3.1", require: false
 gem "appraisal"
-gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
-gem "sqlite3", "~> 1.3", "< 1.4", platforms: [:ruby, :mswin, :mingw, :x64_mingw]
+gem "bcrypt", "~> 3.1", require: false
+gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
+gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
-gem "rspec-rails", "~> 3.7"
 
 gemspec path: "../"

--- a/gemfiles/rails_master.gemfile
+++ b/gemfiles/rails_master.gemfile
@@ -2,17 +2,11 @@
 
 source "https://rubygems.org"
 
-gem "rails", git: 'https://github.com/rails/rails'
-gem "arel", git: 'https://github.com/rails/arel'
-
+gem "rails", git: "https://github.com/rails/rails"
 gem "appraisal"
 gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
-gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
-
-%w[rspec-core rspec-expectations rspec-mocks rspec-rails rspec-support].each do |lib|
-  gem lib, git: "https://github.com/rspec/#{lib}.git", branch: 'master'
-end
 
 gemspec path: "../"


### PR DESCRIPTION
### Summary

- I found there's misconfigure of appraisal, correct it.
- `sudo: false` in `.travis.yml` is deprecated, see <https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration>
- regroup order of gems in `gemspec` as RubyMine suggests
