### PR TITLE
scopes field accepts Array

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#1215] Fix deprecates for Rails 6.
+- [#1214] Scopes field accepts array.
 - [#1209] Fix tokens validation for Token Introspection request.
 - [#1202] Use correct HTTP status codes for error responses.
 

--- a/lib/doorkeeper/models/concerns/scopes.rb
+++ b/lib/doorkeeper/models/concerns/scopes.rb
@@ -7,6 +7,10 @@ module Doorkeeper
         OAuth::Scopes.from_string(scopes_string)
       end
 
+      def scopes=(value)
+        super Array(value).join(' ')
+      end
+
       def scopes_string
         self[:scopes]
       end

--- a/spec/lib/models/scopes_spec.rb
+++ b/spec/lib/models/scopes_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Doorkeeper::Models::Scopes' do
   subject do
-    Class.new(Hash) do
+    Class.new(Struct.new(:scopes)) do
       include Doorkeeper::Models::Scopes
     end.new
   end
@@ -18,6 +18,18 @@ describe 'Doorkeeper::Models::Scopes' do
 
     it 'includes scopes' do
       expect(subject.scopes).to include('public')
+    end
+  end
+
+  describe :scopes= do
+    it 'accepts String' do
+      subject.scopes = 'private admin'
+      expect(subject.scopes_string).to eq('private admin')
+    end
+
+    it 'accepts Array' do
+      subject.scopes = %w[private admin]
+      expect(subject.scopes_string).to eq('private admin')
     end
   end
 


### PR DESCRIPTION
### Summary

Let `scopes` can accepts Array value, that useful to support select scopes checkbox like Gitlab

![image](https://user-images.githubusercontent.com/1024162/54145044-0ef90880-4468-11e9-9c43-6a026e248342.png)