### PR TITLE
Pass tests on Rails 6 and fix deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ gemfile:
   - gemfiles/rails_5_0.gemfile
   - gemfiles/rails_5_1.gemfile
   - gemfiles/rails_5_2.gemfile
+  - gemfiles/rails_6_0.gemfile
   - gemfiles/rails_master.gemfile
 
 matrix:
@@ -36,6 +37,14 @@ matrix:
       rvm: 2.1
     - gemfile: gemfiles/rails_5_2.gemfile
       rvm: 2.1
+    - gemfile: gemfiles/rails_6_0.gemfile
+      rvm: 2.1
+    - gemfile: gemfiles/rails_6_0.gemfile
+      rvm: 2.2
+    - gemfile: gemfiles/rails_6_0.gemfile
+      rvm: 2.3
+    - gemfile: gemfiles/rails_6_0.gemfile
+      rvm: 2.4
     - gemfile: gemfiles/rails_master.gemfile
       rvm: 2.1
     - gemfile: gemfiles/rails_master.gemfile
@@ -46,3 +55,4 @@ matrix:
       rvm: 2.4
   allow_failures:
     - gemfile: gemfiles/rails_master.gemfile
+    - rvm: ruby-head

--- a/Appraisals
+++ b/Appraisals
@@ -1,21 +1,44 @@
 appraise "rails-4-2" do
   gem "rails", "~> 4.2.0"
   gem "grape", '~> 0.16', '< 0.19.2'
+  gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 end
 
 appraise "rails-5-0" do
   gem "rails", "~> 5.0.0"
+  gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 end
 
 appraise "rails-5-1" do
   gem "rails", "~> 5.1.0"
+  gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 end
 
 appraise "rails-5-2" do
   gem "rails", "~> 5.2.0"
+  gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+end
+
+appraise "rails-6-0" do
+  gem "rails", "~> 6.0.0.beta2"
+  gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+
+  # TODO: Remove when rspec-rails 4.0 released
+  gem "rspec-core", github: "rspec/rspec-core"
+  gem "rspec-expectations", github: "rspec/rspec-expectations"
+  gem "rspec-mocks", github: "rspec/rspec-mocks"
+  gem "rspec-rails", github: "rspec/rspec-rails", branch: "4-0-dev"
+  gem "rspec-support", github: "rspec/rspec-support"
 end
 
 appraise "rails-master" do
   gem "rails", git: 'https://github.com/rails/rails'
   gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+
+  # TODO: Remove when rspec-rails 4.0 released
+  gem "rspec-core", github: "rspec/rspec-core"
+  gem "rspec-expectations", github: "rspec/rspec-expectations"
+  gem "rspec-mocks", github: "rspec/rspec-mocks"
+  gem "rspec-rails", github: "rspec/rspec-rails", branch: "4-0-dev"
+  gem "rspec-support", github: "rspec/rspec-support"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,20 @@
 source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-gem "rails", ">= 5.2.1.1", "< 6.0"
+gemspec
 
-gem "appraisal"
+gem "rails", "~> 6.0.0.beta2"
+
+# TODO: Remove when rspec-rails 4.0 released
+gem "rspec-core", github: "rspec/rspec-core"
+gem "rspec-expectations", github: "rspec/rspec-expectations"
+gem "rspec-mocks", github: "rspec/rspec-mocks"
+gem "rspec-rails", github: "rspec/rspec-rails", branch: "4-0-dev"
+gem "rspec-support", github: "rspec/rspec-support"
 
 gem "bcrypt", "~> 3.1", require: false
 
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
-gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
-gemspec

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1215] Fix deprecates for Rails 6.
 - [#1209] Fix tokens validation for Token Introspection request.
 - [#1202] Use correct HTTP status codes for error responses.
 

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'railties', '>= 4.2'
   gem.required_ruby_version = '>= 2.1'
 
-  gem.add_development_dependency 'capybara', '~> 2.18'
+  gem.add_development_dependency 'appraisal'
+  gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'coveralls'
   gem.add_development_dependency 'danger', '~> 5.0'
   gem.add_development_dependency 'database_cleaner', '~> 1.6'

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -3,7 +3,11 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
-gem "appraisal"
+gem "rspec-core", git: "https://github.com/rspec/rspec-core.git"
+gem "rspec-expectations", git: "https://github.com/rspec/rspec-expectations.git"
+gem "rspec-mocks", git: "https://github.com/rspec/rspec-mocks.git"
+gem "rspec-rails", branch: "4-0-dev", git: "https://github.com/rspec/rspec-rails.git"
+gem "rspec-support", git: "https://github.com/rspec/rspec-support.git"
 gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -3,7 +3,11 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
-gem "appraisal"
+gem "rspec-core", git: "https://github.com/rspec/rspec-core.git"
+gem "rspec-expectations", git: "https://github.com/rspec/rspec-expectations.git"
+gem "rspec-mocks", git: "https://github.com/rspec/rspec-mocks.git"
+gem "rspec-rails", branch: "4-0-dev", git: "https://github.com/rspec/rspec-rails.git"
+gem "rspec-support", git: "https://github.com/rspec/rspec-support.git"
 gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -3,7 +3,11 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
-gem "appraisal"
+gem "rspec-core", git: "https://github.com/rspec/rspec-core.git"
+gem "rspec-expectations", git: "https://github.com/rspec/rspec-expectations.git"
+gem "rspec-mocks", git: "https://github.com/rspec/rspec-mocks.git"
+gem "rspec-rails", branch: "4-0-dev", git: "https://github.com/rspec/rspec-rails.git"
+gem "rspec-support", git: "https://github.com/rspec/rspec-support.git"
 gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.2.0"
+gem "rails", "~> 6.0.0.beta2"
 gem "rspec-core", git: "https://github.com/rspec/rspec-core.git"
 gem "rspec-expectations", git: "https://github.com/rspec/rspec-expectations.git"
 gem "rspec-mocks", git: "https://github.com/rspec/rspec-mocks.git"
@@ -10,7 +10,7 @@ gem "rspec-rails", branch: "4-0-dev", git: "https://github.com/rspec/rspec-rails
 gem "rspec-support", git: "https://github.com/rspec/rspec-support.git"
 gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
-gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 
 gemspec path: "../"

--- a/gemfiles/rails_master.gemfile
+++ b/gemfiles/rails_master.gemfile
@@ -3,7 +3,11 @@
 source "https://rubygems.org"
 
 gem "rails", git: "https://github.com/rails/rails"
-gem "appraisal"
+gem "rspec-core", git: "https://github.com/rspec/rspec-core.git"
+gem "rspec-expectations", git: "https://github.com/rspec/rspec-expectations.git"
+gem "rspec-mocks", git: "https://github.com/rspec/rspec-mocks.git"
+gem "rspec-rails", branch: "4-0-dev", git: "https://github.com/rspec/rspec-rails.git"
+gem "rspec-support", git: "https://github.com/rspec/rspec-support.git"
 gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,6 +1,17 @@
 require File.expand_path('boot', __dir__)
 
-require 'rails/all'
+require "rails"
+
+%w[
+  action_controller/railtie
+  action_view/railtie
+  sprockets/railtie
+].each do |railtie|
+  begin
+    require railtie
+  rescue LoadError
+  end
+end
 
 Bundler.require(*Rails.groups)
 

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -330,7 +330,7 @@ feature 'Authorization Code Flow' do
 
   context 'when application scopes are present and no scope is passed' do
     background do
-      @client.update_attributes(scopes: 'public write read')
+      @client.update(scopes: 'public write read')
     end
 
     scenario 'access grant has no scope' do

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -66,7 +66,7 @@ describe 'Client Credentials Request' do
 
   context 'when application scopes contain some of the default scopes and no scope is passed' do
     before do
-      client.update_attributes(scopes: 'read write public')
+      client.update(scopes: 'read write public')
     end
 
     it 'issues new token with one default scope that are present in application scopes' do

--- a/spec/requests/flows/implicit_grant_spec.rb
+++ b/spec/requests/flows/implicit_grant_spec.rb
@@ -20,7 +20,7 @@ feature 'Implicit Grant Flow (feature spec)' do
 
   context 'when application scopes are present and no scope is passed' do
     background do
-      @client.update_attributes(scopes: 'public write read')
+      @client.update(scopes: 'public write read')
     end
 
     scenario 'access token has no scopes' do

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -149,7 +149,7 @@ describe 'Resource Owner Password Credentials Flow' do
   context 'when application scopes are present and differs from configured default scopes and no scope is passed' do
     before do
       default_scopes_exist :public
-      @client.update_attributes(scopes: 'abc')
+      @client.update(scopes: 'abc')
     end
 
     it 'issues new token without any scope' do
@@ -168,7 +168,7 @@ describe 'Resource Owner Password Credentials Flow' do
 
   context 'when application scopes contain some of the default scopes and no scope is passed' do
     before do
-      @client.update_attributes(scopes: 'read write public')
+      @client.update(scopes: 'read write public')
     end
 
     it 'issues new token with one default scope that are present in application scopes' do


### PR DESCRIPTION
### Summary

- Refactor dummy app preventing Rails 6 crash
- Rails 6 needs rspec-rails 4 to pass some cases (relates to view, I think it because tenderlove give a big refactor on actionview)
- Fix deprecated `update_attributes` -> `update`, this no harm for older Rails
- Add Rails 6 to build matrix
- Pinned Rails 6 as default local development dependency

### Other Information

This is just a initial work, although it pass tests on Rails 6, Zeitwerk breaks old extending way, I have to fix it for my app. I already committed an issue #1211

Also, Doorkeeper's build matrix is huge, and since Devise and other popular gems starting remove support of Rails 4 and Ruby 2.1 - 2.3, I suggest Doorkeeper follow them, we can discuss at #1212