### PR TITLE
Add nil check to `expires_at` method.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1216] Add nil check to `expires_at` method.
 - [#1215] Fix deprecates for Rails 6.
 - [#1209] Fix tokens validation for Token Introspection request.
 - [#1202] Use correct HTTP status codes for error responses.

--- a/lib/doorkeeper/models/concerns/expirable.rb
+++ b/lib/doorkeeper/models/concerns/expirable.rb
@@ -24,10 +24,11 @@ module Doorkeeper
 
       # Expiration time (date time of creation + TTL).
       #
-      # @return [Time] expiration time in UTC
+      # @return [Time, nil] expiration time in UTC
+      #   or nil if the object never expires.
       #
       def expires_at
-        created_at + expires_in.seconds
+        expires_in && created_at + expires_in.seconds
       end
     end
   end

--- a/spec/lib/models/expirable_spec.rb
+++ b/spec/lib/models/expirable_spec.rb
@@ -44,4 +44,16 @@ describe 'Expirable' do
       expect(subject.expires_in_seconds).to be_nil
     end
   end
+
+  describe :expires_at do
+    it 'should return the expiration time of the token' do
+      allow(subject).to receive(:expires_in).and_return(2.minutes)
+      expect(subject.expires_at).to be_a(Time)
+    end
+
+    it 'should return nil when expires_in is nil' do
+      allow(subject).to receive(:expires_in).and_return(nil)
+      expect(subject.expires_at).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### Summary
Add nil check to `expires_at` method in `Expirable` concern.

### Other Information
Resolves issues with token introspection for tokens that don't expire:
```
NoMethodError (undefined method `seconds' for nil:NilClass):

doorkeeper (4.4.1) lib/doorkeeper/models/concerns/expirable.rb:28:in `expires_at'
doorkeeper (4.4.1) lib/doorkeeper/oauth/token_introspection.rb:66:in `success_response'
doorkeeper (4.4.1) lib/doorkeeper/oauth/token_introspection.rb:22:in `to_json'
doorkeeper (4.4.1) app/controllers/doorkeeper/tokens_controller.rb:34:in `introspect'
```