### PR TITLE
Specify ruby 2.6 to 2.6.1 for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
-  - 2.6
+  - 2.6.1
   - ruby-head
 
 before_install:


### PR DESCRIPTION
### Summary

I found relates Travis CI builds all failed on Ruby 2.6, this is a workaround that specify 2.6 to 2.6.1