### PR TITLE
Allow for custom scheme in native redirect

### DIFF
--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -20,7 +20,7 @@ module Doorkeeper
         end
 
         def native_redirect
-          if 'urn:ietf:wg:oauth:2.0:oob' == pre_auth.redirect_uri
+          if pre_auth.redirect_uri == 'urn:ietf:wg:oauth:2.0:oob'
             { action: :show, code: token.token }
           else
             "#{pre_auth.redirect_uri}?code=#{token.token}"

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -20,7 +20,11 @@ module Doorkeeper
         end
 
         def native_redirect
-          { action: :show, code: token.token }
+          if 'urn:ietf:wg:oauth:2.0:oob' == pre_auth.redirect_uri
+            { action: :show, code: token.token }
+          else
+            "#{pre_auth.redirect_uri}?code=#{token.token}"
+          end
         end
 
         def configuration


### PR DESCRIPTION
### Summary

Doorkeeper doesn't seem to currently allow custom scheme redirection in 'native redirect' only Google's non-standard OOB methodology. This PR attempts to address this gap.

Relates to [this issue](https://github.com/doorkeeper-gem/doorkeeper/issues/1221) 

I don't expect that this will be the final form but I wanted start the discussion on how best get this functionality into doorkeeper.