### PR TITLE
Update .hound.yml to unify RuboCop config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,3 @@
-ruby:
-  config_file: .rubocop.yml
 rubocop:
+  config_file: .rubocop.yml
   version: 0.64.0


### PR DESCRIPTION
### Summary

Update `.hound.yml` to fix Hound and RuboCop behavior.

### Other Information

Hound looks for either `ruby` or `rubocop` keys in the config file.
`rubocop` is the new preferred way.
