### PR TITLE
Fix StaleRecordsCleaner to consider big amount of records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1234] Fix `StaleRecordsCleaner` to properly work with big amount of records.
 - [#1228] Allow to explicitly set non-expiring tokens in `custom_access_token_expires_in` configuration
   option using `Float::INIFINITY` return value.
 - [#1224] Do not try to store token if not found by fallback hashing strategy.

--- a/lib/doorkeeper/orm/active_record/stale_records_cleaner.rb
+++ b/lib/doorkeeper/orm/active_record/stale_records_cleaner.rb
@@ -3,22 +3,29 @@
 module Doorkeeper
   module Orm
     module ActiveRecord
+      # Helper class to clear stale and non-active tokens and grants.
+      # Used by Doorkeeper Rake tasks.
+      #
       class StaleRecordsCleaner
         def initialize(base_scope)
           @base_scope = base_scope
         end
 
+        # Clears revoked records
         def clean_revoked
           table = @base_scope.arel_table
+
           @base_scope.where.not(revoked_at: nil)
             .where(table[:revoked_at].lt(Time.current))
-            .delete_all
+            .in_batches(&:delete_all)
         end
 
+        # Clears expired records
         def clean_expired(ttl)
           table = @base_scope.arel_table
+
           @base_scope.where(table[:created_at].lt(Time.current - ttl))
-            .delete_all
+            .in_batches(&:delete_all)
         end
       end
     end


### PR DESCRIPTION
Fix `StaleRecordsCleaner` to work with bit amount of records without stopping the database with huge queries.