### PR TITLE
Do not try to store token if not found by fallback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#1220] Drop Rails 4.2 & Ruby < 2.4 support.
 - [#1223] Update Hound/Rubocop rules, correct Doorkeeper codebase to follow style-guides.
+- [#1224] Do not try to store token if not found by fallback hashing strategy.
 
 ## 5.1.0.rc2
 

--- a/lib/doorkeeper/models/concerns/secret_storable.rb
+++ b/lib/doorkeeper/models/concerns/secret_storable.rb
@@ -66,6 +66,8 @@ module Doorkeeper
           # Use the previous strategy to look up
           stored_token = fallback_secret_strategy.transform_secret(plain_secret)
           find_by(attr => stored_token).tap do |resource|
+            return nil unless resource
+
             upgrade_fallback_value resource, attr, plain_secret
           end
         end

--- a/spec/lib/models/secret_storable_spec.rb
+++ b/spec/lib/models/secret_storable_spec.rb
@@ -64,35 +64,59 @@ describe "SecretStorable" do
     end
 
     context "if a fallback strategy is defined" do
-      let(:resource) { double("Token model") }
       before do
         allow(clazz).to receive(:fallback_secret_strategy).and_return(fallback)
       end
 
-      it "calls the strategy for lookup" do
-        expect(clazz)
-          .to receive(:find_by)
-          .with("attr" => "fallback")
-          .and_return(resource)
+      context "if a resource is defined" do
+        let(:resource) { double("Token model") }
 
-        expect(fallback)
-          .to receive(:transform_secret)
-          .with("input")
-          .and_return("fallback")
+        it "calls the strategy for lookup" do
+          expect(clazz)
+            .to receive(:find_by)
+            .with("attr" => "fallback")
+            .and_return(resource)
 
-        # store_secret will call the resource
-        expect(resource)
-          .to receive(:attr=)
-          .with("new value")
+          expect(fallback)
+            .to receive(:transform_secret)
+            .with("input")
+            .and_return("fallback")
 
-        # It will upgrade the secret automtically using the current strategy
-        expect(strategy)
-          .to receive(:transform_secret)
-          .with("input")
-          .and_return("new value")
+          # store_secret will call the resource
+          expect(resource)
+            .to receive(:attr=)
+            .with("new value")
 
-        expect(resource).to receive(:update).with("attr" => "new value")
-        expect(subject).to eq resource
+          # It will upgrade the secret automtically using the current strategy
+          expect(strategy)
+            .to receive(:transform_secret)
+            .with("input")
+            .and_return("new value")
+
+          expect(resource).to receive(:update).with("attr" => "new value")
+          expect(subject).to eq resource
+        end
+      end
+
+      context "if a resource is not defined" do
+        before do
+          allow(clazz).to receive(:fallback_secret_strategy).and_return(fallback)
+        end
+
+        it "returns nil" do
+          expect(clazz)
+            .to receive(:find_by)
+            .with("attr" => "fallback")
+            .and_return(nil)
+
+          expect(fallback)
+            .to receive(:transform_secret)
+            .with("input")
+            .and_return("fallback")
+
+          # It does not find a token even with the fallback method
+          expect(subject).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

This fixes the bug outlined in #1224. There is an added guard clause in `#find_by_fallback_token` which ensures that the token is found before attempting to store it.