### PR TITLE
Better support for native apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-visible changes worth mentioning.
 - [#1249]: Specify case sensitive uniqueness to remove Rails 6 deprecation message
 - [#1248] Display the Application Secret in HTML after creating a new application even when `hash_application_secrets` is used.
 - [#1248] Return the unhashed Application Secret in the JSON response after creating new application even when `hash_application_secrets` is used.
+- [#1238] Better support for native app with support for custom scheme and localhost redirection.
 
 ## 5.1.0
 

--- a/app/views/doorkeeper/applications/_form.html.erb
+++ b/app/views/doorkeeper/applications/_form.html.erb
@@ -20,12 +20,6 @@
         <%= t('doorkeeper.applications.help.redirect_uri') %>
       </span>
 
-      <% if Doorkeeper.configuration.native_redirect_uri %>
-          <span class="form-text text-secondary">
-            <%= raw t('doorkeeper.applications.help.native_redirect_uri', native_redirect_uri: content_tag(:code, class: 'bg-light') { Doorkeeper.configuration.native_redirect_uri }) %>
-          </span>
-      <% end %>
-
       <% if Doorkeeper.configuration.allow_blank_redirect_uri?(application) %>
         <span class="form-text text-secondary">
           <%= t('doorkeeper.applications.help.blank_redirect_uri') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
             redirect_uri:
               fragment_present: 'cannot contain a fragment.'
               invalid_uri: 'must be a valid URI.'
+              unspecified_scheme: 'must specify a scheme.'
               relative_uri: 'must be an absolute URI.'
               secured_uri: 'must be an HTTPS/SSL URI.'
               forbidden_uri: 'is forbidden by the server.'
@@ -33,7 +34,6 @@ en:
         confidential: 'Application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are considered non-confidential.'
         redirect_uri: 'Use one line per URI'
         blank_redirect_uri: "Leave it blank if you configured your provider to use Client Credentials, Resource Owner Password Credentials or any other grant type that doesn't require redirect URI."
-        native_redirect_uri: 'Use %{native_redirect_uri} if you want to add localhost URIs for development purposes'
         scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
       edit:
         title: 'Edit application'

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -52,6 +52,7 @@ require "doorkeeper/oauth/token"
 require "doorkeeper/oauth/token_introspection"
 require "doorkeeper/oauth/invalid_token_response"
 require "doorkeeper/oauth/forbidden_token_response"
+require "doorkeeper/oauth/nonstandard"
 
 require "doorkeeper/secret_storing/base"
 require "doorkeeper/secret_storing/plain"

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -254,7 +254,7 @@ module Doorkeeper
     option :custom_access_token_expires_in, default: ->(_context) { nil }
     option :authorization_code_expires_in,  default: 600
     option :orm,                            default: :active_record
-    option :native_redirect_uri,            default: "urn:ietf:wg:oauth:2.0:oob"
+    option :native_redirect_uri,            default: "urn:ietf:wg:oauth:2.0:oob", deprecated: true
     option :active_record_options,          default: {}
     option :grant_flows,                    default: %w[authorization_code client_credentials]
     option :handle_auth_errors,             default: :render

--- a/lib/doorkeeper/config/option.rb
+++ b/lib/doorkeeper/config/option.rb
@@ -38,14 +38,20 @@ module Doorkeeper
 
         Builder.instance_eval do
           remove_method name if method_defined?(name)
-          define_method name do |*args, &block|
-            value = if attribute_builder
-                      attribute_builder.new(&block).build
-                    else
-                      block || args.first
-                    end
+          if options[:deprecated]
+            define_method name do |*_, &_|
+              Kernel.warn "[DOORKEEPER] #{name} has been deprecated and will soon be removed"
+            end
+          else
+            define_method name do |*args, &block|
+              value = if attribute_builder
+                        attribute_builder.new(&block).build
+                      else
+                        block || args.first
+                      end
 
-            @config.instance_variable_set(:"@#{attribute}", value)
+              @config.instance_variable_set(:"@#{attribute}", value)
+            end
           end
         end
 

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -15,7 +15,7 @@ module Doorkeeper
           @token ||= AccessGrant.create!(access_grant_attributes)
         end
 
-        def native_redirect
+        def oob_redirect
           { action: :show, code: token.plaintext_token }
         end
 

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -63,7 +63,7 @@ module Doorkeeper
           )
         end
 
-        def native_redirect
+        def oob_redirect
           {
             controller: controller,
             action: :show,

--- a/lib/doorkeeper/oauth/code_response.rb
+++ b/lib/doorkeeper/oauth/code_response.rb
@@ -18,8 +18,8 @@ module Doorkeeper
       end
 
       def redirect_uri
-        if URIChecker.native_uri? pre_auth.redirect_uri
-          auth.native_redirect
+        if URIChecker.oob_uri? pre_auth.redirect_uri
+          auth.oob_redirect
         elsif response_on_fragment
           Authorization::URIBuilder.uri_with_fragment(
             pre_auth.redirect_uri,

--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -41,7 +41,7 @@ module Doorkeeper
 
       def redirectable?
         name != :invalid_redirect_uri && name != :invalid_client &&
-          !URIChecker.native_uri?(@redirect_uri)
+          !URIChecker.oob_uri?(@redirect_uri)
       end
 
       def redirect_uri

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -25,10 +25,10 @@ module Doorkeeper
     module Helpers
       module URIChecker
         def self.valid?(url)
-          return true if native_uri?(url)
+          return true if oob_uri?(url)
 
           uri = as_uri(url)
-          uri.fragment.nil? && !uri.host.nil? && !uri.scheme.nil?
+          valid_scheme?(uri) && iff_host?(uri) && uri.fragment.nil? && uri.opaque.nil?
         rescue URI::InvalidURIError
           false
         end
@@ -78,8 +78,22 @@ module Doorkeeper
           client_query.split("&").sort == query.split("&").sort
         end
 
-        def self.native_uri?(url)
-          url == Doorkeeper.configuration.native_redirect_uri
+        def self.valid_scheme?(uri)
+          return false if uri.scheme.nil?
+
+          %w[localhost].include?(uri.scheme) == false
+        end
+
+        def self.hypertext_scheme?(uri)
+          %w[http https].include?(uri.scheme)
+        end
+
+        def self.iff_host?(uri)
+          !(hypertext_scheme?(uri) && uri.host.nil?)
+        end
+
+        def self.oob_uri?(uri)
+          NonStandard::IETF_WG_OAUTH2_OOB_METHODS.include?(uri)
         end
       end
     end

--- a/lib/doorkeeper/oauth/nonstandard.rb
+++ b/lib/doorkeeper/oauth/nonstandard.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    class NonStandard
+      # These are not part of the OAuth 2 specification but are still in use by Google
+      # and in some other implementations. Native applications should use one of the
+      # approaches discussed in RFC8252. OOB is 'Out of Band'
+
+      # This value signals to the Google Authorization Server that the authorization
+      # code should be returned in the title bar of the browser, with the page text
+      # prompting the user to copy the code and paste it in the application.
+      # This is useful when the client (such as a Windows application) cannot listen
+      # on an HTTP port without significant client configuration.
+
+      # When you use this value, your application can then detect that the page has loaded, and can
+      # read the title of the HTML page to obtain the authorization code. It is then up to your
+      # application to close the browser window if you want to ensure that the user never sees the
+      # page that contains the authorization code. The mechanism for doing this varies from platform
+      # to platform.
+      #
+      # If your platform doesn't allow you to detect that the page has loaded or read the title of
+      # the page, you can have the user paste the code back to your application, as prompted by the
+      # text in the confirmation page that the OAuth 2.0 server generates.
+      IETF_WG_OAUTH2_OOB = "urn:ietf:wg:oauth:2.0:oob"
+
+      # This is identical to urn:ietf:wg:oauth:2.0:oob, but the text in the confirmation page that
+      # the OAuth 2.0 server generates won't instruct the user to copy the authorization code, but
+      # instead will simply ask the user to close the window.
+      #
+      # This is useful when your application reads the title of the HTML page (by checking window
+      # titles on the desktop, for example) to obtain the authorization code, but can't close the
+      # page on its own.
+      IETF_WG_OAUTH2_OOB_AUTO = "urn:ietf:wg:oauth:2.0:oob:auto"
+
+      IETF_WG_OAUTH2_OOB_METHODS = [IETF_WG_OAUTH2_OOB, IETF_WG_OAUTH2_OOB_AUTO].freeze
+    end
+  end
+end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -196,15 +196,6 @@ Doorkeeper.configure do
   #
   # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
 
-  # Change the native redirect uri for client apps
-  # When clients register with the following redirect uri, they won't be redirected to
-  # any server and the authorizationcode will be displayed within the provider
-  # The value can be any string. Use nil to disable this feature. When disabled, clients
-  # must providea valid URL
-  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
-  #
-  # native_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
-
   # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
   # by default in non-development environments). OAuth2 delegates security in
   # communication to the HTTPS protocol so it is wise to keep this enabled.

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -48,6 +48,21 @@ module Doorkeeper
         expect(json_response).to include("errors")
       end
 
+      it "returns validations on wrong create params (unspecified scheme)" do
+        expect do
+          post :create, params: {
+            doorkeeper_application: {
+              name: "Example",
+              redirect_uri: "app.com:80",
+            }, format: :json,
+          }
+        end.not_to(change { Doorkeeper::Application.count })
+
+        expect(response).to have_http_status(422)
+
+        expect(json_response).to include("errors")
+      end
+
       it "returns application info" do
         application = FactoryBot.create(:application, name: "Change me")
 

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -65,15 +65,6 @@ Doorkeeper.configure do
   # Check out the wiki for more information on customization
   # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
 
-  # Change the native redirect uri for client apps
-  # When clients register with the following redirect uri, they won't be redirected to any server and
-  # the authorization code will be displayed within the provider
-  # The value can be any string. Use nil to disable this feature.
-  # When disabled, clients must provide a valid URL
-  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
-  #
-  # native_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
-
   # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
   # by default in non-development environments). OAuth2 delegates security in
   # communication to the HTTPS protocol so it is wise to keep this enabled.

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -694,4 +694,15 @@ describe Doorkeeper, "configuration" do
       end
     end
   end
+
+  describe "options deprecation" do
+    it "prints a warning message when an option is deprecated" do
+      expect(Kernel).to receive(:warn).with(
+        "[DOORKEEPER] native_redirect_uri has been deprecated and will soon be removed"
+      )
+      Doorkeeper.configure do
+        native_redirect_uri "urn:ietf:wg:oauth:2.0:oob"
+      end
+    end
+  end
 end

--- a/spec/lib/oauth/helpers/uri_checker_spec.rb
+++ b/spec/lib/oauth/helpers/uri_checker_spec.rb
@@ -40,13 +40,28 @@ module Doorkeeper::OAuth::Helpers
         expect(URIChecker.valid?(uri)).to be_falsey
       end
 
+      it "is invalid if localhost is resolved as as scheme (no scheme specified)" do
+        uri = "localhost:8080"
+        expect(URIChecker.valid?(uri)).to be_falsey
+      end
+
+      it "is invalid if scheme is missing #2" do
+        uri = "app.co:80"
+        expect(URIChecker.valid?(uri)).to be_falsey
+      end
+
       it "is invalid if is not an uri" do
         uri = "   "
         expect(URIChecker.valid?(uri)).to be_falsey
       end
 
-      it "is valid for native uris" do
-        uri = "urn:ietf:wg:oauth:2.0:oob"
+      it "is valid for custom schemes" do
+        uri = "com.example.app:/test"
+        expect(URIChecker.valid?(uri)).to be_truthy
+      end
+
+      it "is valid for custom schemes with authority marker (common misconfiguration)" do
+        uri = "com.example.app://test"
         expect(URIChecker.valid?(uri)).to be_truthy
       end
     end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -149,21 +149,6 @@ module Doorkeeper::OAuth
       expect(subject.scopes).to eq(Scopes.from_string("default"))
     end
 
-    context "with native redirect uri" do
-      let(:native_redirect_uri) { "urn:ietf:wg:oauth:2.0:oob" }
-
-      it "accepts redirect_uri when it matches with the client" do
-        subject.redirect_uri = native_redirect_uri
-        allow(subject.client).to receive(:redirect_uri) { native_redirect_uri }
-        expect(subject).to be_authorizable
-      end
-
-      it "invalidates redirect_uri when it does'n match with the client" do
-        subject.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
-        expect(subject).not_to be_authorizable
-      end
-    end
-
     it "matches the redirect uri against client's one" do
       subject.redirect_uri = "http://nothesame.com"
       expect(subject).not_to be_authorizable

--- a/spec/validators/redirect_uri_validator_spec.rb
+++ b/spec/validators/redirect_uri_validator_spec.rb
@@ -18,7 +18,7 @@ describe RedirectUriValidator do
   #
   # @see https://www.oauth.com/oauth2-servers/redirect-uris/redirect-uris-native-apps/
   it "is valid when the uri is custom native URI" do
-    subject.redirect_uri = "myapp://callback"
+    subject.redirect_uri = "myapp:/callback"
     expect(subject).to be_valid
   end
 
@@ -27,33 +27,48 @@ describe RedirectUriValidator do
     expect(subject).to be_valid
   end
 
-  it "accepts native redirect uri" do
+  it "accepts nonstandard oob redirect uri" do
     subject.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
     expect(subject).to be_valid
   end
 
-  it "rejects if test uri is disabled" do
-    allow(RedirectUriValidator).to receive(:native_redirect_uri).and_return(nil)
-    subject.redirect_uri = "urn:some:test"
-    expect(subject).not_to be_valid
+  it "accepts nonstandard oob:auto redirect uri" do
+    subject.redirect_uri = "urn:ietf:wg:oauth:2.0:oob:auto"
+    expect(subject).to be_valid
   end
 
   it "is invalid when the uri is not a uri" do
     subject.redirect_uri = "]"
     expect(subject).not_to be_valid
-    expect(subject.errors[:redirect_uri].first).to eq("must be a valid URI.")
+    expect(subject.errors[:redirect_uri].first).to eq(I18n.t("activerecord.errors.models.doorkeeper/application.attributes.redirect_uri.invalid_uri"))
   end
 
   it "is invalid when the uri is relative" do
     subject.redirect_uri = "/abcd"
     expect(subject).not_to be_valid
-    expect(subject.errors[:redirect_uri].first).to eq("must be an absolute URI.")
+    expect(subject.errors[:redirect_uri].first).to eq(I18n.t("activerecord.errors.models.doorkeeper/application.attributes.redirect_uri.relative_uri"))
   end
 
   it "is invalid when the uri has a fragment" do
     subject.redirect_uri = "https://example.com/abcd#xyz"
     expect(subject).not_to be_valid
-    expect(subject.errors[:redirect_uri].first).to eq("cannot contain a fragment.")
+    expect(subject.errors[:redirect_uri].first).to eq(I18n.t("activerecord.errors.models.doorkeeper/application.attributes.redirect_uri.fragment_present"))
+  end
+
+  it "is invalid when scheme resolves to localhost (needs an explict scheme)" do
+    subject.redirect_uri = "localhost:80"
+    expect(subject).to be_invalid
+    expect(subject.errors[:redirect_uri].first).to eq(I18n.t("activerecord.errors.models.doorkeeper/application.attributes.redirect_uri.unspecified_scheme"))
+  end
+
+  it "is invalid if an ip address" do
+    subject.redirect_uri = "127.0.0.1:8080"
+    expect(subject).to be_invalid
+  end
+
+  it "accepts an ip address based URI if a scheme is specified" do
+    subject.redirect_uri = "https://127.0.0.1:8080"
+    expect(subject).to be_valid
   end
 
   context "force secured uri" do
@@ -62,13 +77,23 @@ describe RedirectUriValidator do
       expect(subject).to be_valid
     end
 
-    it "accepts native redirect uri" do
-      subject.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
+    it "accepts custom scheme redirect uri (as per rfc8252 section 7.1)" do
+      subject.redirect_uri = "com.example.app:/oauth/callback"
       expect(subject).to be_valid
     end
 
-    it "accepts app redirect uri" do
-      subject.redirect_uri = "some-awesome-app://oauth/callback"
+    it "accepts custom scheme redirect uri (as per rfc8252 section 7.1) #2" do
+      subject.redirect_uri = "com.example.app:/test"
+      expect(subject).to be_valid
+    end
+
+    it "accepts custom scheme redirect uri (common misconfiguration we have decided to allow)" do
+      subject.redirect_uri = "com.example.app://oauth/callback"
+      expect(subject).to be_valid
+    end
+
+    it "accepts custom scheme redirect uri (common misconfiguration we have decided to allow) #2" do
+      subject.redirect_uri = "com.example.app://test"
       expect(subject).to be_valid
     end
 
@@ -118,7 +143,7 @@ describe RedirectUriValidator do
       subject.redirect_uri = "http://example.com/callback"
       expect(subject).not_to be_valid
       error = subject.errors[:redirect_uri].first
-      expect(error).to eq("must be an HTTPS/SSL URI.")
+      expect(error).to eq(I18n.t("activerecord.errors.models.doorkeeper/application.attributes.redirect_uri.secured_uri"))
     end
   end
 


### PR DESCRIPTION
This PR relates to the discussion [here](https://github.com/doorkeeper-gem/doorkeeper/issues/1221) and [here](https://github.com/doorkeeper-gem/doorkeeper/pull/1229)

I have loosened the validation to allow native apps to present a custom scheme. The old Google style OOB method is still supported (backwards compatible). 

I have removed the `native_redirect_url` functionality but I don't know how you would like to deprecate it formally. My opinion is to keep the config for a while but print a deprecation warning (so upgraders do not break their app keeping their configuration from previously). The configuration has no impact on the workings of doorkeeper in this PR. 