### PR TITLE
Explaining foreign key options for resource owner in a single place

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1241] Explaining foreign key options for resource owner in a single place
 - [#1237] Allow to set blank redirect URI if Doorkeeper configured to use redirect URI-less grant flows.
 - [#1234] Fix `StaleRecordsCleaner` to properly work with big amount of records.
 - [#1228] Allow to explicitly set non-expiring tokens in `custom_access_token_expires_in` configuration

--- a/lib/generators/doorkeeper/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/migration.rb.erb
@@ -1,9 +1,9 @@
 class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :oauth_applications do |t|
-      t.string  :name,         null: false
-      t.string  :uid,          null: false
-      t.string  :secret,       null: false
+      t.string  :name,    null: false
+      t.string  :uid,     null: false
+      t.string  :secret,  null: false
 
       # Remove `null: false` if you are planning to use grant flows
       # that doesn't require redirect URI to be used during authorization
@@ -36,20 +36,20 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
 
     create_table :oauth_access_tokens do |t|
       t.references :resource_owner, index: true
-      t.references :application
+      t.references :application,    null: false
 
       # If you use a custom token generator you may need to change this column
       # from string to text, so that it accepts tokens larger than 255
       # characters. More info on custom token generators in:
       # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
       #
-      # t.text     :token,             null: false
-      t.string   :token,                  null: false
+      # t.text :token, null: false
+      t.string :token, null: false
 
       t.string   :refresh_token
       t.integer  :expires_in
       t.datetime :revoked_at
-      t.datetime :created_at,             null: false
+      t.datetime :created_at, null: false
       t.string   :scopes
 
       # If there is a previous_refresh_token column,
@@ -68,5 +68,9 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
       :oauth_applications,
       column: :application_id
     )
+
+    # Uncomment below to ensure a valid reference to the resource owner's table
+    # add_foreign_key :oauth_access_grants, <model>, column: :resource_owner_id
+    # add_foreign_key :oauth_access_tokens, <model>, column: :resource_owner_id
   end
 end


### PR DESCRIPTION
### Summary

1. Add bit better explanation on how to add foreign keys to users on initial migration
2. Change resource_owner to `references`
3. Add non-null application reference in access_tokens