### PR TITLE
Show application secret in flash after creation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,9 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#PR] Add your PR description here.
 - [#1249]: Specify case sensitive uniqueness to remove Rails 6 deprecation message
+- [#1248] Display the Application Secret after creating a new application even when `hash_application_secrets` is used.
 
 ## 5.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,8 @@ User-visible changes worth mentioning.
 
 - [#PR] Add your PR description here.
 - [#1249]: Specify case sensitive uniqueness to remove Rails 6 deprecation message
-- [#1248] Display the Application Secret after creating a new application even when `hash_application_secrets` is used.
+- [#1248] Display the Application Secret in HTML after creating a new application even when `hash_application_secrets` is used.
+- [#1248] Return the unhashed Application Secret in the JSON response after creating new application even when `hash_application_secrets` is used.
 
 ## 5.1.0
 

--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -4,6 +4,7 @@ module Doorkeeper
   class ApplicationsController < Doorkeeper::ApplicationController
     layout "doorkeeper/admin" unless Doorkeeper.configuration.api_only
 
+    add_flash_types :application_secret
     before_action :authenticate_admin!
     before_action :set_application, only: %i[show edit update destroy]
 
@@ -32,6 +33,7 @@ module Doorkeeper
 
       if @application.save
         flash[:notice] = I18n.t(:notice, scope: %i[doorkeeper flash applications create])
+        flash[:application_secret] = @application.plaintext_secret
 
         respond_to do |format|
           format.html { redirect_to oauth_application_url(@application) }

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -8,7 +8,7 @@
     <p><code class="bg-light" id="application_id"><%= @application.uid %></code></p>
 
     <h4><%= t('.secret') %>:</h4>
-    <p><code class="bg-light" id="secret"><%= @application.plaintext_secret %></code></p>
+    <p><code class="bg-light" id="secret"><%= flash[:application_secret].presence || @application.plaintext_secret %></code></p>
 
     <h4><%= t('.scopes') %>:</h4>
     <p><code class="bg-light" id="scopes"><%= @application.scopes.presence || raw('&nbsp;') %></code></p>

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -60,6 +60,12 @@ module Doorkeeper
       end
     end
 
+    def to_json(options)
+      serializable_hash(except: :secret)
+        .merge(secret: plaintext_secret)
+        .to_json(options)
+    end
+
     private
 
     def generate_uid

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -121,6 +121,50 @@ module Doorkeeper
     end
 
     context "when admin is authenticated" do
+      context "when application secrets are hashed" do
+        before do
+          allow(Doorkeeper.configuration).to receive(:application_secret_strategy).and_return(Doorkeeper::SecretStoring::Sha256Hash)
+        end
+
+        it "shows the application secret after creating a new application" do
+          expect do
+            post :create, params: {
+              doorkeeper_application: {
+                name: "Example",
+                redirect_uri: "https://example.com",
+              },
+            }
+          end.to change { Doorkeeper::Application.count }.by(1)
+
+          application = Application.last
+
+          secret_from_flash = flash[:application_secret]
+          expect(secret_from_flash).not_to be_empty
+          expect(application.secret_matches?(secret_from_flash)).to be_truthy
+          expect(response).to redirect_to(controller.main_app.oauth_application_url(application.id))
+
+          get :show, params: { id: application.id, format: :html }
+
+          # We don't know the application secret here (because its hashed) so we can not assert its text on the page
+          # Instead, we read it from the page and then check if it matches the application secret
+          code_element = %r{<code.*id="secret".*>(.*)<\/code>}.match(response.body)
+          secret_from_page = code_element[1]
+
+          expect(response.body).to have_selector("code#application_id", text: application.uid)
+          expect(response.body).to have_selector("code#secret")
+          expect(secret_from_page).not_to be_empty
+          expect(application.secret_matches?(secret_from_page)).to be_truthy
+        end
+
+        it "does not show an application secret when application did already exist" do
+          application = FactoryBot.create(:application)
+          get :show, params: { id: application.id, format: :html }
+
+          expect(response.body).to have_selector("code#application_id", text: application.uid)
+          expect(response.body).to have_selector("code#secret", text: "")
+        end
+      end
+
       render_views
 
       before do
@@ -149,6 +193,14 @@ module Doorkeeper
         end.to change { Doorkeeper::Application.count }.by(1)
 
         expect(response).to be_redirect
+      end
+
+      it "shows application details" do
+        application = FactoryBot.create(:application)
+        get :show, params: { id: application.id, format: :html }
+
+        expect(response.body).to have_selector("code#application_id", text: application.uid)
+        expect(response.body).to have_selector("code#secret", text: application.plaintext_secret)
       end
 
       it "does not allow mass assignment of uid or secret" do

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -26,6 +26,10 @@ module Doorkeeper
 
         expect(json_response).to include("id", "name", "uid", "secret", "redirect_uri", "scopes")
 
+        application = Application.last
+        secret_from_response = json_response["secret"]
+        expect(application.secret_matches?(secret_from_response)).to be_truthy
+
         expect(json_response["name"]).to eq("Example")
         expect(json_response["redirect_uri"]).to eq("https://example.com")
       end
@@ -162,6 +166,28 @@ module Doorkeeper
 
           expect(response.body).to have_selector("code#application_id", text: application.uid)
           expect(response.body).to have_selector("code#secret", text: "")
+        end
+
+        it "returns the application details in a json response" do
+          expect do
+            post :create, params: {
+              doorkeeper_application: {
+                name: "Example",
+                redirect_uri: "https://example.com",
+              }, format: :json,
+            }
+          end.to(change { Doorkeeper::Application.count })
+
+          expect(response).to be_successful
+
+          expect(json_response).to include("id", "name", "uid", "secret", "redirect_uri", "scopes")
+
+          application = Application.last
+          secret_from_response = json_response["secret"]
+          expect(application.secret_matches?(secret_from_response)).to be_truthy
+
+          expect(json_response["name"]).to eq("Example")
+          expect(json_response["redirect_uri"]).to eq("https://example.com")
         end
       end
 


### PR DESCRIPTION
fixes #1246 

### Summary

If the `hash_application_secrets` option is enabled, it is not possible to show the application secret in the details view because it is hashes.

Currently, there was no way to ever see the application secret when creating an application via the Web Interface when this option is enabled because after creation of the application, the controller redirects to the `show` action for the new application, but that causes the application to be reloaded and thus, the transient `@raw_secret` was empty.

With this change, the application secret is displayed in the flash notices after creating the application.

