### PR TITLE
Specify case sensitive uniqueness for model validations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#PR] Add your PR description here.
+- [#1249]: Specify case sensitive uniqueness to remove Rails 6 deprecation message
 
 ## 5.1.0
 

--- a/lib/doorkeeper/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/access_grant.rb
@@ -16,7 +16,7 @@ module Doorkeeper
               :redirect_uri,
               presence: true
 
-    validates :token, uniqueness: true
+    validates :token, uniqueness: { case_sensitive: true }
 
     before_validation :generate_token, on: :create
 

--- a/lib/doorkeeper/orm/active_record/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/access_token.rb
@@ -9,8 +9,8 @@ module Doorkeeper
     belongs_to :application, class_name: "Doorkeeper::Application",
                              inverse_of: :access_tokens, optional: true
 
-    validates :token, presence: true, uniqueness: true
-    validates :refresh_token, uniqueness: true, if: :use_refresh_token?
+    validates :token, presence: true, uniqueness: { case_sensitive: true }
+    validates :refresh_token, uniqueness: { case_sensitive: true }, if: :use_refresh_token?
 
     # @attr_writer [Boolean, nil] use_refresh_token
     #   indicates the possibility of using refresh token

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -10,7 +10,7 @@ module Doorkeeper
     has_many :access_tokens, dependent: :delete_all, class_name: "Doorkeeper::AccessToken"
 
     validates :name, :secret, :uid, presence: true
-    validates :uid, uniqueness: true
+    validates :uid, uniqueness: { case_sensitive: true }
     validates :redirect_uri, redirect_uri: true
     validates :confidential, inclusion: { in: [true, false] }
 


### PR DESCRIPTION
### Summary

This removes a MySql adapter deprecation message for Rails 6 - see https://github.com/rails/rails/pull/35350

The deprecation message is:
```
Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1.
To continue case sensitive comparison on the :#{attribute.name} attribute in #{klass} model,
pass `case_sensitive: true` option explicitly to the uniqueness validator.
```
