### PR TITLE
Use existing exception response in get_error_response_from_exception

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR] Add your PR description here.
+- [#1253]: Use existing exception response in get_error_response_from_exception.
 - [#1249]: Specify case sensitive uniqueness to remove Rails 6 deprecation message
 - [#1248] Display the Application Secret in HTML after creating a new application even when `hash_application_secrets` is used.
 - [#1248] Return the unhashed Application Secret in the JSON response after creating new application even when `hash_application_secrets` is used.

--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -42,7 +42,11 @@ module Doorkeeper
       end
 
       def get_error_response_from_exception(exception)
-        OAuth::ErrorResponse.new name: exception.type, state: params[:state]
+        if exception.respond_to?(:response)
+          exception.response
+        else
+          OAuth::ErrorResponse.new name: exception.type, state: params[:state]
+        end
       end
 
       def handle_token_exception(exception)


### PR DESCRIPTION
### Summary

This checks whether the exception has a response in `get_error_response_from_exception` before creating a new one via the `OAuth::ErrorResponse` class.

That class is a little limiting and I am not seeing a way to return a custom error description through it.

### Other Information

This limitation was encountered when attempting to return an unauthorized status with a custom error description during authorization, but only if a condition specified in the `before_successful_response` method was not satisfied.

For example:
```
module Doorkeeper
  class CustomSuccessfulStrategy
    def before
      unless user.has_permission?
        response = Doorkeeper::OAuth::InvalidTokenResponse.new(reason: 'my custom reason')
        raise Doorkeeper::Errors::InvalidToken.new(response)
      end
    end
  end
end


Doorkeeper.configure do
  before_successful_strategy_response do |request|
    Doorkeeper::CustomSuccessfulStrategy.new.before
  end
end
 ```

Here is the flow of execution I was tracing to reach `get_error_response_from_exception`:
[tokens_controller.rb#L5](https://github.com/doorkeeper-gem/doorkeeper/blob/master/app/controllers/doorkeeper/tokens_controller.rb#L5)
[tokens_controller.rb#L87](https://github.com/doorkeeper-gem/doorkeeper/blob/master/app/controllers/doorkeeper/tokens_controller.rb#L87)
[base_request.rb#L14](https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib/doorkeeper/oauth/base_request.rb#L14)
[tokens_controller.rb#L10](https://github.com/doorkeeper-gem/doorkeeper/blob/master/app/controllers/doorkeeper/tokens_controller.rb#L10)
[helpers/controller.rb#L47](https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib/doorkeeper/helpers/controller.rb#L47)

This was previously working, but these changes broke it:
https://github.com/doorkeeper-gem/doorkeeper/commit/51b344477e1018a5813bdfd8b3eb0aceb31190b0#diff-8312ad0561ef661716b48d09478362f3R12