### PR TITLE
Add constraint configurations when using client authentication on introspection endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#PR] Add your PR description here.
+- [#1257] Add constraint configuration when using client authentication on introspection endpoint.
 - [#1252] Returning `unauthorized` when the revocation of the token should not be performed due to wrong permissions.
 - [#1249]: Specify case sensitive uniqueness to remove Rails 6 deprecation message
 - [#1248] Display the Application Secret in HTML after creating a new application even when `hash_application_secrets` is used.

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -321,6 +321,20 @@ module Doorkeeper
                grant_flows.exclude?("implicit")
            end)
 
+    # When using client credentials to authenticate at introspection endpoint,
+    # Allow introspection if
+    #   the inspected token to be connected to the same client,
+    #   OR token doesn't belong to any client (public token).
+    #
+    option :allow_token_introspection,
+           default: (lambda do |token, client|
+             if token.application
+               token.application == client
+             else
+               true
+             end
+           end)
+
     attr_reader :api_only,
                 :enforce_content_type,
                 :reuse_access_token,

--- a/lib/doorkeeper/oauth/token_introspection.rb
+++ b/lib/doorkeeper/oauth/token_introspection.rb
@@ -150,7 +150,7 @@ module Doorkeeper
       #
       def active?
         if authorized_client
-          valid_token? && authorized_for_client?
+          valid_token? && allow_token_introspection?
         else
           valid_token?
         end
@@ -166,14 +166,12 @@ module Doorkeeper
         authorized_token.token == @token&.token
       end
 
-      # If token doesn't belong to some client, then it is public.
-      # Otherwise in it required for token to be connected to the same client.
-      def authorized_for_client?
-        if @token.application
-          @token.application == authorized_client.application
-        else
-          true
-        end
+      # config constraints for introspection in Doorkeeper.configuration.allow_token_introspection
+      def allow_token_introspection?
+        !!Doorkeeper.configuration.allow_token_introspection.call(
+          @token,
+          authorized_client.application
+        )
       end
 
       # Allows to customize introspection response.

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -314,6 +314,33 @@ Doorkeeper.configure do
   #   client.superapp? or resource_owner.admin?
   # end
 
+  # Implement constraints in case you use Client Credentials to authenticate
+  # the introspection endpoint.
+  # By default allow introspection if the introspected token belongs to authorized client,
+  # OR token doesn't belong to any client (public token). Otherwise disallow.
+  #
+  # Params:
+  # `token` - the token to be introspected (see Doorkeeper::AccessToken)
+  # `client` - the client application authorized for the endpoint (see Doorkeeper::Application)
+  #
+  # You can completely ignore it:
+  # allow_token_introspection do |_token, _client|
+  #   false
+  # end
+  #
+  # Or you can define your custom check:
+  #   Adding `protected_resource` boolean column to applications table
+  #   to allow protected_resource client introspect the token of normal client.
+  #   In this case, protected_resource client must be confidential.
+  #
+  # allow_token_introspection do |token, client|
+  #   if token.application
+  #     token.application == client || client.protected_resource?
+  #   else
+  #     true
+  #   end
+  # end
+
   # WWW-Authenticate Realm (default "Doorkeeper").
   #
   # realm "Doorkeeper"

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -107,6 +107,33 @@ Doorkeeper.configure do
   #   client.superapp? or resource_owner.admin?
   # end
 
+  # Implement constraints in case you use Client Credentials to authenticate
+  # the introspection endpoint.
+  # By default allow introspection if the introspected token belongs to authorized client,
+  # OR token doesn't belong to any client (public token). Otherwise disallow.
+  #
+  # Params:
+  # `token` - the token to be introspected (see Doorkeeper::AccessToken)
+  # `client` - the client application authorized for the endpoint (see Doorkeeper::Application)
+  #
+  # You can completely ignore it:
+  # allow_token_introspection do |_token, _client|
+  #   false
+  # end
+  #
+  # Or you can define your custom check:
+  #   Adding `protected_resource` boolean column to applications table
+  #   to allow protected_resource client introspect the token of normal client.
+  #   In this case, protected resource client must be confidential.
+  #
+  # allow_token_introspection do |token, client|
+  #   if token.application
+  #     token.application == client || client.protected_resource?
+  #   else
+  #     true
+  #   end
+  # end
+
   # WWW-Authenticate Realm (default "Doorkeeper").
   realm "Doorkeeper"
 end


### PR DESCRIPTION
### Summary
As discuss by @ZilvinasKucinskas at #1195, this pull request add configuration when using Client Credentials to authenticated for introspection endpoint. 

#### Problem
Current implementation of doorkeeper only allows `client credentials that token is issued for` introspect token, which make any other client can not introspect that token.
Protected resource does not own the token, but as [RFC7662](https://tools.ietf.org/html/rfc7662): `introspection endpoint is used by protected resource to introspect token information.`
#### Solving
Adding constraint configuration when using client authentication on introspection endpoint.
```ruby
# config.rb
option :allow_token_introspection,
       default: (lambda do |token, client|
         if token.application
           token.application == client
         else
           true
         end
       end)
```
By default this configuration allow a client can only introspect the token issued to it, OR token doesn't belong to any client (public token). Otherwise disallow.

#### Customize
Configuration customize example:  adding protected_resource check or checking application scopes
```ruby
# adding protected_resource check (add `protected_resource` using migrations)
Doorkeeper.configure do
  allow_token_introspection do |token, client|
    if token.application
      token.application == client || client.protected_resource?
    else
      true
    end
  end
end
```