### PR TITLE
Add comment to explain that the application_id constraint in the oauth_access_tokens table should be optional

### DIFF
--- a/lib/generators/doorkeeper/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/migration.rb.erb
@@ -36,6 +36,9 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
 
     create_table :oauth_access_tokens do |t|
       t.references :resource_owner, index: true
+
+      # Remove `null: false` if you are planning to use Password
+      # Credentials Grant flow that doesn't require an application.
       t.references :application,    null: false
 
       # If you use a custom token generator you may need to change this column


### PR DESCRIPTION
The application_id constraint on the oauth_access_tokens table should be optional. If a developer is trying to set up a Password Credentials Grant flow, the application will trigger a:

`
ActiveRecord::NotNullViolation (PG::NotNullViolation: ERROR:  null value in column "application_id" violates not-null constraint
`

I added a comment to inform developers of the need to comment the foreign key constraint.

