### PR TITLE
Response properly when introspection fails and fix configurations's user guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Add your description here.
+- [#1263]: Response properly when introspection fails and fix configurations's user guide.
 
 ## 5.2.0.rc1
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -322,9 +322,10 @@ module Doorkeeper
            end)
 
     # Configure protection of token introspection request.
-    # By default token introspection is allowed only for clients that
-    # introspected token belongs to or if access token been introspected
-    # is a public one (doesn't belong to any client).
+    # By default this configuration allows to introspect a token by
+    # another token of the same application, or to introspect the token
+    # that belongs to authorized client, or access token has been introspected
+    # is a public one (doesn't belong to any client)
     #
     # You can define any custom rule you need or just disable token
     # introspection at all.
@@ -340,9 +341,11 @@ module Doorkeeper
     #   Bearer token used to authorize the request
     #
     option :allow_token_introspection,
-           default: (lambda do |token, authorized_client, _authorized_token|
-             if token.application
-               token.application == authorized_client
+           default: (lambda do |token, authorized_client, authorized_token|
+             if authorized_token
+               authorized_token.application == token&.application
+             elsif token.application
+               authorized_client == token.application
              else
                true
              end

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -167,13 +167,15 @@ describe Doorkeeper::TokensController do
         end
       end
 
-      it "responds with just active: false response" do
+      it "responds with invalid_token error" do
         request.headers["Authorization"] = "Bearer #{access_token.token}"
 
         post :introspect, params: { token: token_for_introspection.token }
 
-        should_have_json "active", false
-        expect(json_response).not_to include("client_id", "token_type", "exp", "iat")
+        response_status_should_be 401
+
+        should_not_have_json "active"
+        should_have_json "error", "invalid_token"
       end
     end
 
@@ -268,15 +270,17 @@ describe Doorkeeper::TokensController do
         expect(json_response).to include("client_id", "token_type", "exp", "iat")
       end
 
-      it "responds with just active status if authorized token doesn't have introspection scope" do
+      it "responds with invalid_token error if authorized token doesn't have introspection scope" do
         access_token.update(scopes: "read write")
 
         request.headers["Authorization"] = "Bearer #{access_token.token}"
 
         post :introspect, params: { token: token_for_introspection.token }
 
-        should_have_json "active", false
-        expect(json_response).not_to include("client_id", "token_type", "exp", "iat")
+        response_status_should_be 401
+
+        should_not_have_json "active"
+        should_have_json "error", "invalid_token"
       end
     end
 
@@ -285,7 +289,7 @@ describe Doorkeeper::TokensController do
         FactoryBot.create(:access_token, application: client, revoked_at: 1.day.ago)
       end
 
-      it "responds with invalid token error" do
+      it "responds with invalid_token error" do
         request.headers["Authorization"] = "Bearer #{access_token.token}"
 
         post :introspect, params: { token: token_for_introspection.token }
@@ -340,13 +344,15 @@ describe Doorkeeper::TokensController do
       end
 
       context "authorized using valid Bearer token" do
-        it "responds with only active state" do
+        it "responds with invalid_token error" do
           request.headers["Authorization"] = "Bearer #{access_token.token}"
 
           post :introspect, params: { token: SecureRandom.hex(16) }
 
-          should_have_json "active", false
-          expect(json_response).not_to include("client_id", "token_type", "exp", "iat")
+          response_status_should_be 401
+
+          should_not_have_json "active"
+          should_have_json "error", "invalid_token"
         end
       end
     end


### PR DESCRIPTION
### Summary

As discuss on https://github.com/doorkeeper-gem/doorkeeper/pull/1262, there are problems with [the use](https://github.com/doorkeeper-gem/doorkeeper/blob/4965eed838cc5bef3f794439fce754bfe22d4bab/lib/doorkeeper/oauth/token_introspection.rb#L169) of current token introspection configuration, so this pull request fix them.

1. NoMethodError for nil class:
I see that `authorized_client` and `authorized_token` parameters could be **nil** depend on the request send to introspection endpoint.
Suggestion: Doorkeeper should _remind_ users when using these instance at this configuration (quite confuse to user!?)
    - check nil before using these two params
    - Or using `authorized_client`,  `authorized_token` with `&`, for examples:
`authorized_client&.protected_resource?` and `authorized_token&.some_method?`
If not using `&`, `NoMethodError - undefined method for nil:NilClass` exception can occur.

2. Introspection Response:
With this configuration, user could config to check scopes of `authorized_token` params. So if `authorized_token` doesn't have sufficient scopes (does not contain sufficient privileges), the response will be 200 status and body is `active: false`. 
But in this case, [here in rfc7662](https://tools.ietf.org/html/rfc7662#section-2.3) states that it returns 401 status code.

 `
 If the protected resource uses an OAuth 2.0 bearer token to authorize
   its call to the introspection endpoint and the token used for
   authorization does not contain sufficient privileges or is otherwise
   invalid for this request, the authorization server responds with an
   HTTP 401 code...
 `

I think we need docs to guide user using this configuration properly. (incase they use both `authorized_client` and `authorized_token`)