### PR TITLE
Add #{before,after}_successful_authorization hooks in Doorkeeper::TokensController 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Add your description here.
+- [#1264] Add :before_successful_authorization and :after_successful_authorization hooks in TokensController
 - [#1263]: Response properly when introspection fails and fix configurations's user guide.
 
 ## 5.2.0.rc1

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -88,7 +88,20 @@ module Doorkeeper
     end
 
     def authorize_response
-      @authorize_response ||= strategy.authorize
+      @authorize_response ||= begin
+        before_successful_authorization
+        auth = strategy.authorize
+        after_successful_authorization unless auth.is_a?(Doorkeeper::OAuth::ErrorResponse)
+        auth
+      end
+    end
+
+    def after_successful_authorization
+      Doorkeeper.configuration.after_successful_authorization.call(self)
+    end
+
+    def before_successful_authorization
+      Doorkeeper.configuration.before_successful_authorization.call(self)
     end
 
     def revocation_error_response


### PR DESCRIPTION
### Summary

Added `#{before,after}_successful_authorization` hooks in `Doorkeeper::TokensController#create`, similar to #1064, as amended in #1075).

### Other Information

For the `#before_successful_authorization` I am not sure how to (pre) authorize like [`Doorkeeper::AuthorizationsController#pre_auth`](https://github.com/doorkeeper-gem/doorkeeper/blob/614ec7d/app/controllers/doorkeeper/authorizations_controller.rb#L84).

The `pre_auth.authorizable?` seems to contradict the hook name. If the `#pre_auth` is `#authorizable?` does it mean that the strategy is going to be successful? 🤔

In any case I decided to keep the names the same. I would appreciate some feedback or a pointer towards the right direction.

Additionally I added specs for `Doorkeeper::TokensController#create`. For some reason they have been disabled in 7f54ac250.