### PR TITLE
Use strong parameters within pre-authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Add your description here.
+- [#1266]: Use strong parameters within pre-authorization.
 - [#1264] Add :before_successful_authorization and :after_successful_authorization hooks in TokensController
 - [#1263]: Response properly when introspection fails and fix configurations's user guide.
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -68,7 +68,12 @@ module Doorkeeper
     def pre_auth
       @pre_auth ||= OAuth::PreAuthorization.new(Doorkeeper.configuration,
                                                 server.client_via_uid,
-                                                params)
+                                                pre_auth_params)
+    end
+
+    def pre_auth_params
+      params.permit(:response_type, :redirect_uri, :scope, :state,
+                    :code_challenge, :code_challenge_method)
     end
 
     def authorization

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -524,4 +524,17 @@ describe Doorkeeper::AuthorizationsController, "implicit grant flow" do
       post :create
     end
   end
+
+  describe "strong parameters" do
+    it "ignores non-scalar scope parameter" do
+      get :new, params: {
+        client_id: client.uid,
+        response_type: "token",
+        redirect_uri: client.redirect_uri,
+        scope: { "0" => "profile" },
+      }
+
+      expect(response).to be_successful
+    end
+  end
 end


### PR DESCRIPTION
### Summary

It uses strong parameters within `Doorkeeper::OAuth::PreAuthorization`, in order to gracefully ignore non-scalar values passed as `scope` parameter for instance, instead of raising the things like:

> NoMethodError: undefined method `split' for #<ActionController::Parameters:0x...>