### PR TITLE
Reintroduce existing token revocation for client credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Add your description here.
+- [#1271] Reintroduce existing token revocation for client credentials.
 - [#1269] Update initializer template documentation.
 - [#1266]: Use strong parameters within pre-authorization.
 - [#1264] Add :before_successful_authorization and :after_successful_authorization hooks in TokensController

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -5,10 +5,24 @@ module Doorkeeper
     class ClientCredentialsRequest < BaseRequest
       class Creator
         def call(client, scopes, attributes = {})
+          existing_token = existing_token_for(client, scopes)
+
+          if Doorkeeper.configuration.reuse_access_token && existing_token&.reusable?
+            return existing_token
+          end
+
+          existing_token&.revoke
+
           AccessToken.find_or_create_for(
             client, nil, scopes, attributes[:expires_in],
             attributes[:use_refresh_token]
           )
+        end
+
+        private
+
+        def existing_token_for(client, scopes)
+          Doorkeeper::AccessToken.matching_token_for client, nil, scopes
         end
       end
     end

--- a/spec/lib/oauth/client_credentials/creator_spec.rb
+++ b/spec/lib/oauth/client_credentials/creator_spec.rb
@@ -55,6 +55,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
 
           expect(Doorkeeper::AccessToken.count).to eq(2)
           expect(result).not_to eq(existing_token)
+          expect(existing_token.reload).to be_revoked
         end
       end
 
@@ -69,6 +70,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
 
           expect(Doorkeeper::AccessToken.count).to eq(2)
           expect(result).not_to eq(existing_token)
+          expect(existing_token.reload).to be_revoked
         end
       end
     end
@@ -82,6 +84,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
 
         expect(Doorkeeper::AccessToken.count).to eq(2)
         expect(result).not_to eq(existing_token)
+        expect(existing_token.reload).to be_revoked
       end
     end
 


### PR DESCRIPTION
### Summary

This is related to #1193 and #1270.

Doorkeeper assumes that old tokens will have a revoked_at time set on them. This is usually enforced via `RefreshTokenRequest#before_successful_response`.  `ClientCredentialsRequest` did have revocation behaviour in it but it was removed in https://github.com/doorkeeper-gem/doorkeeper/commit/23bc9a0a0a93be35e40dd44d87417b16339efde5. This pull request adds that behaviour back in while also being careful to honour reusability settings.

### Other Information

I ended up needing to copy some of the implementation of `AccessToken.find_or_create_for` as I needed to run code when the token was found vs created. I don't love the duplication but the code is all using public interfaces.  Feedback welcome!