### PR TITLE
Add a Dockerfile for running specs where ruby isn't available

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,13 @@ Fork, then clone the repo:
 
     git clone git@github.com:your-username/doorkeeper.git
 
+### Docker Setup
+
+Build the container image with: `docker build --pull -t doorkeeper:test .`
+Run the tests with: `docker run -it --rm doorkeeper:test`
+
+### Local Setup
+
 Set up Ruby dependencies via Bundler
 
     bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM ruby:2.6.3-alpine3.9
+
+RUN apk add --no-cache \
+  ca-certificates \
+  wget \
+  openssl \ 
+  bash \
+  build-base \
+  git \
+  sqlite-dev \
+  tzdata
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+ENV BUNDLER_VERSION 2.0.1
+RUN gem install bundler -v ${BUNDLER_VERSION} -i /usr/local/lib/ruby/gems/$(ls /usr/local/lib/ruby/gems) --force
+
+WORKDIR /srv
+
+COPY Gemfile doorkeeper.gemspec /srv/
+COPY lib/doorkeeper/version.rb /srv/lib/doorkeeper/version.rb
+
+RUN bundle install
+
+COPY . /srv/
+
+CMD ["rake"]


### PR DESCRIPTION
### Summary

This pull request adds a Dockerfile and instructions for using it when running tests on a system without a suitable ruby installation.