### PR TITLE
Use `find_by` instead of `find_by_id` in initializer template

### DIFF
--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -9,7 +9,7 @@ Doorkeeper.configure do
     raise "Please configure doorkeeper resource_owner_authenticator block located in #{__FILE__}"
     # Put your resource owner authentication logic here.
     # Example implementation:
-    #   User.find_by_id(session[:user_id]) || redirect_to(new_user_session_url)
+    #   User.find_by(id: session[:user_id]) || redirect_to(new_user_session_url)
   end
 
   # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb


### PR DESCRIPTION
`find_by_id` style is deprecated.