### PR TITLE
Add support of grant flows per application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#1288] Allow to pass attributes to the `Doorkeeper::OAuth::PreAuthorization#as_json` method to customize
   the PreAuthorization response.
+- [#1286] Add ability to customize grant flows per application (OAuth client) (#1245 , #1207)
 - [#1283] Allow to customize base class for `Doorkeeper::ApplicationMetalController` (new configuration
   option called `base_metal_controller` (fix #1273).
 

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -50,10 +50,10 @@ module Doorkeeper
     TokenGeneratorNotFound = Class.new(DoorkeeperError)
     NoOrmCleaner = Class.new(DoorkeeperError)
 
-    InvalidToken = Class.new BaseResponseError
-    TokenExpired = Class.new InvalidToken
-    TokenRevoked = Class.new InvalidToken
-    TokenUnknown = Class.new InvalidToken
-    TokenForbidden = Class.new InvalidToken
+    InvalidToken = Class.new(BaseResponseError)
+    TokenExpired = Class.new(InvalidToken)
+    TokenRevoked = Class.new(InvalidToken)
+    TokenUnknown = Class.new(InvalidToken)
+    TokenForbidden = Class.new(InvalidToken)
   end
 end

--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -45,7 +45,7 @@ module Doorkeeper
         if exception.respond_to?(:response)
           exception.response
         else
-          OAuth::ErrorResponse.new name: exception.type, state: params[:state]
+          OAuth::ErrorResponse.new(name: exception.type, state: params[:state])
         end
       end
 

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -19,14 +19,10 @@ module Doorkeeper
           { action: :show, code: token.plaintext_token }
         end
 
-        def configuration
-          Doorkeeper.configuration
-        end
-
         private
 
         def authorization_code_expires_in
-          configuration.authorization_code_expires_in
+          Doorkeeper.configuration.authorization_code_expires_in
         end
 
         def access_grant_attributes

--- a/lib/doorkeeper/oauth/client_credentials/validation.rb
+++ b/lib/doorkeeper/oauth/client_credentials/validation.rb
@@ -8,6 +8,7 @@ module Doorkeeper
         include OAuth::Helpers
 
         validate :client, error: :invalid_client
+        validate :client_supports_grant_flow, error: :unauthorized_client
         validate :scopes, error: :invalid_scope
 
         def initialize(server, request)
@@ -22,6 +23,13 @@ module Doorkeeper
 
         def validate_client
           @client.present?
+        end
+
+        def validate_client_supports_grant_flow
+          Doorkeeper.configuration.allow_grant_flow_for_client?(
+            Doorkeeper::OAuth::CLIENT_CREDENTIALS,
+            @client
+          )
         end
 
         def validate_scopes

--- a/lib/doorkeeper/oauth/code_request.rb
+++ b/lib/doorkeeper/oauth/code_request.rb
@@ -15,16 +15,19 @@ module Doorkeeper
         if pre_auth.authorizable?
           auth = Authorization::Code.new(pre_auth, resource_owner)
           auth.issue_token
-          @response = CodeResponse.new pre_auth, auth
+          @response = CodeResponse.new(pre_auth, auth)
         else
-          @response = ErrorResponse.from_request pre_auth
+          @response = ErrorResponse.from_request(pre_auth)
         end
       end
 
       def deny
         pre_auth.error = :access_denied
-        ErrorResponse.from_request pre_auth,
-                                   redirect_uri: pre_auth.redirect_uri
+
+        ErrorResponse.from_request(
+          pre_auth,
+          redirect_uri: pre_auth.redirect_uri
+        )
       end
     end
   end

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -5,9 +5,10 @@ module Doorkeeper
     class PasswordAccessTokenRequest < BaseRequest
       include OAuth::Helpers
 
-      validate :client,         error: :invalid_client
+      validate :client, error: :invalid_client
+      validate :client_supports_grant_flow, error: :unauthorized_client
       validate :resource_owner, error: :invalid_grant
-      validate :scopes,         error: :invalid_scope
+      validate :scopes, error: :invalid_scope
 
       attr_accessor :server, :client, :resource_owner, :parameters,
                     :access_token
@@ -46,6 +47,10 @@ module Doorkeeper
 
       def validate_client
         !parameters[:client_id] || client.present?
+      end
+
+      def validate_client_supports_grant_flow
+        Doorkeeper.configuration.allow_grant_flow_for_client?(grant_type, client)
       end
     end
   end

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -10,6 +10,7 @@ module Doorkeeper
       validate :scopes, error: :invalid_scope
       validate :redirect_uri, error: :invalid_redirect_uri
       validate :code_challenge_method, error: :invalid_code_challenge_method
+      validate :client_supports_grant_flow, error: :unauthorized_client
 
       attr_accessor :server, :client, :response_type, :redirect_uri, :state,
                     :code_challenge, :code_challenge_method
@@ -28,6 +29,10 @@ module Doorkeeper
 
       def authorizable?
         valid?
+      end
+
+      def validate_client_supports_grant_flow
+        Doorkeeper.configuration.allow_grant_flow_for_client?(grant_type, client.application)
       end
 
       def scopes
@@ -60,7 +65,7 @@ module Doorkeeper
       end
 
       def validate_response_type
-        server.authorization_response_types.include? response_type
+        server.authorization_response_types.include?(response_type)
       end
 
       def validate_client

--- a/lib/doorkeeper/oauth/token_request.rb
+++ b/lib/doorkeeper/oauth/token_request.rb
@@ -14,9 +14,7 @@ module Doorkeeper
         if pre_auth.authorizable?
           auth = Authorization::Token.new(pre_auth, resource_owner)
           auth.issue_token
-          @response = CodeResponse.new pre_auth,
-                                       auth,
-                                       response_on_fragment: true
+          @response = CodeResponse.new(pre_auth, auth, response_on_fragment: true)
         else
           @response = error_response
         end
@@ -30,9 +28,11 @@ module Doorkeeper
       private
 
       def error_response
-        ErrorResponse.from_request pre_auth,
-                                   redirect_uri: pre_auth.redirect_uri,
-                                   response_on_fragment: true
+        ErrorResponse.from_request(
+          pre_auth,
+          redirect_uri: pre_auth.redirect_uri,
+          response_on_fragment: true
+        )
       end
     end
   end

--- a/lib/doorkeeper/server.rb
+++ b/lib/doorkeeper/server.rb
@@ -10,12 +10,12 @@ module Doorkeeper
 
     def authorization_request(strategy)
       klass = Request.authorization_strategy strategy
-      klass.new self
+      klass.new(self)
     end
 
     def token_request(strategy)
       klass = Request.token_strategy strategy
-      klass.new self
+      klass.new(self)
     end
 
     # TODO: context should be the request

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -281,6 +281,37 @@ Doorkeeper.configure do
   #
   # grant_flows %w[authorization_code client_credentials]
 
+  # Allows to customize OAuth grant flows that +each+ application support.
+  # You can configure a custom block (or use a class respond to `#call`) that must
+  # return `true` in case Application instance supports requested OAuth grant flow
+  # during the authorization request to the server. This configuration +doesn't+
+  # set flows per application, it only allows to check if application supports
+  # specific grant flow.
+  #
+  # For example you can add an additional database column to `oauth_applications` table,
+  # say `t.array :grant_flows, default: []`, and store allowed grant flows that can
+  # be used with this application there. Then when authorization requested Doorkeeper
+  # will call this block to check if specific Application (passed with client_id and/or
+  # client_secret) is allowed to perform the request for the specific grant type
+  # (authorization, password, client_credentials, etc).
+  #
+  # Example of the block:
+  #
+  #   ->(flow, client) { client.grant_flows.include?(flow) }
+  #
+  # In case this option invocation result is `false`, Doorkeeper server returns
+  # :unauthorized_client error and stops the request.
+  #
+  # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
+  # @return [Boolean] `true` if allow or `false` if forbid the request
+  #
+  # allow_grant_flow_for_client do |grant_flow, client|
+  #   # `grant_flows` is an Array column with grant
+  #   # flows that application supports
+  #
+  #   client.grant_flows.include?(grant_flow)
+  # end
+
   # Hook into the strategies' request & response life-cycle in case your
   # application needs advanced customization or logging:
   #

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -166,7 +166,7 @@ describe "doorkeeper authorize filter" do
       it "it renders a custom JSON response", token: :invalid do
         get :index, params: { access_token: token_string }
         expect(response.status).to eq 401
-        expect(response.content_type).to eq("application/json")
+        expect(response.content_type).to include("application/json")
         expect(response.header["WWW-Authenticate"]).to match(/^Bearer/)
 
         expect(json_response).not_to be_nil
@@ -196,7 +196,7 @@ describe "doorkeeper authorize filter" do
       it "it renders a custom text response", token: :invalid do
         get :index, params: { access_token: token_string }
         expect(response.status).to eq 401
-        expect(response.content_type).to eq("text/plain")
+        expect(response.content_type).to include("text/plain")
         expect(response.header["WWW-Authenticate"]).to match(/^Bearer/)
         expect(response.body).to eq("Unauthorized")
       end
@@ -246,7 +246,7 @@ describe "doorkeeper authorize filter" do
       it "renders a custom JSON response" do
         get :index, params: { access_token: token_string }
         expect(response.header).to_not include("WWW-Authenticate")
-        expect(response.content_type).to eq("application/json")
+        expect(response.content_type).to include("application/json")
         expect(response.status).to eq 403
 
         expect(json_response).not_to be_nil

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -23,7 +23,7 @@ module Doorkeeper::OAuth
     end
 
     subject do
-      AuthorizationCodeRequest.new server, grant, client, params
+      AuthorizationCodeRequest.new(server, grant, client, params)
     end
 
     it "issues a new token for the client" do

--- a/spec/requests/flows/implicit_grant_spec.rb
+++ b/spec/requests/flows/implicit_grant_spec.rb
@@ -34,7 +34,7 @@ feature "Implicit Grant Flow (feature spec)" do
       expect(token.scopes).to be_empty
     end
 
-    scenario "access token has scopes which are common in application scopees and default scopes" do
+    scenario "access token has scopes which are common in application scopes and default scopes" do
       default_scopes_exist :public, :write
       visit authorization_endpoint_url(client: @client, response_type: "token")
       click_on "Authorize"

--- a/spec/support/helpers/request_spec_helper.rb
+++ b/spec/support/helpers/request_spec_helper.rb
@@ -54,7 +54,7 @@ module RequestSpecHelper
   end
 
   def with_header(header, value)
-    page.driver.header header, value
+    page.driver.header(header, value)
   end
 
   def basic_auth_header_for_client(client)
@@ -86,8 +86,12 @@ module RequestSpecHelper
     i_should_see translated_error_message(key)
   end
 
+  def i_should_not_see_translated_error_message(key)
+    i_should_not_see translated_error_message(key)
+  end
+
   def translated_error_message(key)
-    I18n.translate key, scope: %i[doorkeeper errors messages]
+    I18n.translate(key, scope: %i[doorkeeper errors messages])
   end
 
   def response_status_should_be(status)


### PR DESCRIPTION
Allows to forbid (or allow) OAuth2 grant flows per client (application).

Implements #1245 , #1207 

```ruby
# Allows to customize OAuth grant flows that +each+ application support.
# You can configure a custom block (or use a class respond to `#call`) that must
# return `true` in case Application instance supports requested OAuth grant flow
# during the authorization request to the server. This configuration +doesn't+
# set flows per application, it only allows to check if application supports
# specific grant flow.
#
# For example you can add an additional database column to `oauth_applications` table,
# say `t.array :grant_flows, default: []`, and store allowed grant flows that can
# be used with this application there. Then when authorization requested Doorkeeper
# will call this block to check if specific Application (passed with client_id and/or
# client_secret) is allowed to perform the request for the specific grant type
# (authorization, password, client_credentials, etc).
#
# Example of the block:
#
#   ->(flow, client) { client.grant_flows.include?(flow) }
#
# In case this option invocation result is `false`, Doorkeeper server returns
# :unauthorized_client error and stops the request.
#
# @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
# @return [Boolean] `true if allow or `false` if forbid the request
#
option :allow_grant_flow_for_client,    default: ->(_grant_flow, _client) { }
```

/cc @phlegx , @alexpil