### PR TITLE
Allow PreAuthorization#as_json method to take optional attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1288] Allow to pass attributes to the `Doorkeeper::OAuth::PreAuthorization#as_json` method to customize
+  the PreAuthorization response.
 - [#1283] Allow to customize base class for `Doorkeeper::ApplicationMetalController` (new configuration
   option called `base_metal_controller` (fix #1273).
 

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -42,16 +42,10 @@ module Doorkeeper
         OAuth::ErrorResponse.from_request(self)
       end
 
-      def as_json(_options)
-        {
-          client_id: client.uid,
-          redirect_uri: redirect_uri,
-          state: state,
-          response_type: response_type,
-          scope: scope,
-          client_name: client.name,
-          status: I18n.t("doorkeeper.pre_authorization.status"),
-        }
+      def as_json(attributes = {})
+        return pre_auth_hash.merge(attributes.to_h) if attributes.respond_to?(:to_h)
+
+        pre_auth_hash
       end
 
       private
@@ -100,6 +94,18 @@ module Doorkeeper
       def validate_code_challenge_method
         code_challenge.blank? ||
           (code_challenge_method.present? && code_challenge_method =~ /^plain$|^S256$/)
+      end
+
+      def pre_auth_hash
+        {
+          client_id: client.uid,
+          redirect_uri: redirect_uri,
+          state: state,
+          response_type: response_type,
+          scope: scope,
+          client_name: client.name,
+          status: I18n.t("doorkeeper.pre_authorization.status"),
+        }
       end
     end
   end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -182,18 +182,44 @@ module Doorkeeper::OAuth
         allow(client).to receive(:name).and_return client_name
       end
 
-      let(:json) { subject.as_json({}) }
-
       it { is_expected.to respond_to :as_json }
 
-      it "returns correct values" do
-        expect(json[:client_id]).to eq client_id
-        expect(json[:redirect_uri]).to eq subject.redirect_uri
-        expect(json[:state]).to eq subject.state
-        expect(json[:response_type]).to eq subject.response_type
-        expect(json[:scope]).to eq subject.scope
-        expect(json[:client_name]).to eq client_name
-        expect(json[:status]).to eq I18n.t("doorkeeper.pre_authorization.status")
+      shared_examples "returns the pre authorization" do
+        it "returns the pre authorization" do
+          expect(json[:client_id]).to eq client_id
+          expect(json[:redirect_uri]).to eq subject.redirect_uri
+          expect(json[:state]).to eq subject.state
+          expect(json[:response_type]).to eq subject.response_type
+          expect(json[:scope]).to eq subject.scope
+          expect(json[:client_name]).to eq client_name
+          expect(json[:status]).to eq I18n.t("doorkeeper.pre_authorization.status")
+        end
+      end
+
+      context "when attributes param is not passed" do
+        let(:json) { subject.as_json }
+
+        include_examples "returns the pre authorization"
+      end
+
+      context "when attributes param is passed" do
+        context "when attributes is a hash" do
+          let(:custom_attributes) { { custom_id: "1234", custom_name: "a pretty good name" } }
+          let(:json) { subject.as_json(custom_attributes) }
+
+          include_examples "returns the pre authorization"
+
+          it "merges the attributes in params" do
+            expect(json[:custom_id]).to eq custom_attributes[:custom_id]
+            expect(json[:custom_name]).to eq custom_attributes[:custom_name]
+          end
+        end
+
+        context "when attributes is not a hash" do
+          let(:json) { subject.as_json(nil) }
+
+          include_examples "returns the pre authorization"
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

This PR renames `PreAuthorization#as_json`'s `_options` param to `attributes`.
If a hash is passed in this param, it will merge its data to the pre authorization payload.
If no param is passed, the value defaults to `{}` which allows the call of `as_json` without params.
If a non-hash param is passed, only the original pre authorization payload is returned

_Original message:_
>The `PreAuthorization#as_json` method takes a single param (`_options`) which is unused. Yet, this param is required. This PR sets a default value to this `_options` param: an empty hash.
>
>Is there a reason to not add this default value ?
