### PR TITLE
Fix issue where redirect_uri is nil

### DIFF
--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -41,7 +41,7 @@ module Doorkeeper
 
       def redirectable?
         name != :invalid_redirect_uri && name != :invalid_client &&
-          !URIChecker.oob_uri?(@redirect_uri)
+          !@redirect_uri.nil? && !URIChecker.oob_uri?(@redirect_uri)
       end
 
       def redirect_uri

--- a/spec/lib/oauth/error_response_spec.rb
+++ b/spec/lib/oauth/error_response_spec.rb
@@ -16,6 +16,13 @@ module Doorkeeper::OAuth
       end
     end
 
+    describe 'the redirect uri' do
+      it 'is not redirectable when redirect uri is nil' do
+        response = ErrorResponse.new(error: :some_error, state: nil)
+        expect(response.redirectable?).to eq(false)
+      end
+    end
+
     describe :from_request do
       it "has the error from request" do
         error = ErrorResponse.from_request double(error: :some_error)

--- a/spec/lib/oauth/error_response_spec.rb
+++ b/spec/lib/oauth/error_response_spec.rb
@@ -16,8 +16,8 @@ module Doorkeeper::OAuth
       end
     end
 
-    describe 'the redirect uri' do
-      it 'is not redirectable when redirect uri is nil' do
+    describe "the redirect uri" do
+      it "is not redirectable when redirect uri is nil" do
         response = ErrorResponse.new(error: :some_error, state: nil)
         expect(response.redirectable?).to eq(false)
       end


### PR DESCRIPTION
Co-authored-by: Kevin Lai <kevin@mavenlink.com>

### Summary

We bumped into an issue with how the `redirect_uri` validation is related to other validations in `PreAuth`. In short, an error response could have been considered redirectable while `@redirect_uri` is nil. This PR patches that issue.

We discovered this issue by writing a test for one of our own Oauth flow endpoints that submitted a request with bad params--specifically, no `state`, no `scope`, no `response_type` and no `redirect_uri`. We discovered that when `PreAuth` is validated, `Doorkeeper::Validations` selects the first error it discovers and submits an `ErrorResponse` object with that validation error as its reason for being invalid. Since it does not check any other case, it assumes that the error response is redirectable even though `redirect_uri` is `nil`.

We have included a spec that exposes this issue, and a simple fix. If there is more that is needed, please let us know and we will be more than happy to contribute.
