### PR TITLE
Adding client id to strong parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1296] Adding client_id to strong parameters.
 - [#1293] Move ar specific redirect uri validator to ar orm directory.
 - [#1288] Allow to pass attributes to the `Doorkeeper::OAuth::PreAuthorization#as_json` method to customize
   the PreAuthorization response.

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -66,13 +66,11 @@ module Doorkeeper
     end
 
     def pre_auth
-      @pre_auth ||= OAuth::PreAuthorization.new(Doorkeeper.configuration,
-                                                server.client_via_uid,
-                                                pre_auth_params)
+      @pre_auth ||= OAuth::PreAuthorization.new(Doorkeeper.configuration, pre_auth_params)
     end
 
     def pre_auth_params
-      params.permit(:response_type, :redirect_uri, :scope, :state,
+      params.permit(:client_id, :response_type, :redirect_uri, :scope, :state,
                     :code_challenge, :code_challenge_method)
     end
 

--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -58,7 +58,7 @@ module Doorkeeper
 
       def skip_authorization?
         !!instance_exec(
-          [@server.current_resource_owner, @pre_auth.client],
+          [server.current_resource_owner, @pre_auth.client],
           &Doorkeeper.configuration.skip_authorization
         )
       end

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -16,9 +16,9 @@ module Doorkeeper
                     :code_challenge, :code_challenge_method
       attr_writer   :scope
 
-      def initialize(server, client, attrs = {})
+      def initialize(server, attrs = {})
         @server                = server
-        @client                = client
+        @client_id             = attrs[:client_id]
         @response_type         = attrs[:response_type]
         @redirect_uri          = attrs[:redirect_uri]
         @scope                 = attrs[:scope]
@@ -56,7 +56,7 @@ module Doorkeeper
       private
 
       def build_scopes
-        client_scopes = client.application.scopes
+        client_scopes = client.scopes
         if client_scopes.blank?
           server.default_scopes.to_s
         else
@@ -69,7 +69,8 @@ module Doorkeeper
       end
 
       def validate_client
-        client.present?
+        @client = OAuth::Client.find(@client_id)
+        @client.present?
       end
 
       def validate_scopes
@@ -78,7 +79,7 @@ module Doorkeeper
         Helpers::ScopeChecker.valid?(
           scope_str: scope,
           server_scopes: server.scopes,
-          app_scopes: client.application.scopes,
+          app_scopes: client.scopes,
           grant_type: grant_type
         )
       end

--- a/lib/doorkeeper/server.rb
+++ b/lib/doorkeeper/server.rb
@@ -27,10 +27,6 @@ module Doorkeeper
       @client ||= OAuth::Client.authenticate(credentials)
     end
 
-    def client_via_uid
-      @client_via_uid ||= OAuth::Client.find(parameters[:client_id])
-    end
-
     def current_resource_owner
       context.send :current_resource_owner
     end


### PR DESCRIPTION
### Summary

Adding `client_id` parameter to permitted strong parameters.

As the needs of #1287 , in development environment, setting:
```ruby
config.action_controller.action_on_unpermitted_parameters = :raise
```
to raise error if unpermitted parameters are sent to controller.
But currently, at `authorizations_controller`, the required `client_id` parameter is used at `server.client_via_uid`, not included in strong parameter list. So we cannot use above setting.

Solving by:
- passing`client_id` to permitted parameters. Then get client at pre_authorization, not by using `server.client_via_uid`.

Comment:
- This changes makes code base easier to be understand.
- By passing `client_id` to pre_authorization, this PR facilitate the changes make in #1277 : easier to handle when `client_id` parameter is missing (not have to adding more annoying `raise` and `rescue` couple -> decrease the codes change)