### PR TITLE
Strong params fix for Rails forms

### DIFF
--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -70,8 +70,9 @@ module Doorkeeper
     end
 
     def pre_auth_params
-      params.permit(:client_id, :response_type, :redirect_uri, :scope, :state,
-                    :code_challenge, :code_challenge_method)
+      fields = [:client_id, :response_type, :redirect_uri, :scope, :state, 
+                :code_challenge, :code_challenge_method]
+      params.slice(*fields).permit(*fields)
     end
 
     def authorization

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -70,8 +70,8 @@ module Doorkeeper
     end
 
     def pre_auth_params
-      fields = [:client_id, :response_type, :redirect_uri, :scope, :state, 
-                :code_challenge, :code_challenge_method]
+      fields = %i(client_id response_type redirect_uri scope state 
+                  code_challenge code_challenge_method)
       params.slice(*fields).permit(*fields)
     end
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -70,8 +70,8 @@ module Doorkeeper
     end
 
     def pre_auth_params
-      fields = %i(client_id response_type redirect_uri scope state 
-                  code_challenge code_challenge_method)
+      fields = %i[client_id response_type redirect_uri scope state 
+                  code_challenge code_challenge_method]
       params.slice(*fields).permit(*fields)
     end
 


### PR DESCRIPTION
Fix for part of https://github.com/doorkeeper-gem/doorkeeper/issues/1287

As a Rails form will include other params such as a commit, utf_8 and authenticity_token we need to pull out only the params we require or we'll get a strong params exception when running Rails with the setting:

    config.action_controller.action_on_unpermitted_parameters = :raise