### PR TITLE
Strong params fix for Rails forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1298] Slice strong params so doesn't error with Rails forms
 - [#1300] Limiting access to attributes of pre_authorization.
 - [#1296] Adding client_id to strong parameters.
 - [#1293] Move ar specific redirect uri validator to ar orm directory.

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -70,8 +70,12 @@ module Doorkeeper
     end
 
     def pre_auth_params
-      params.permit(:client_id, :response_type, :redirect_uri, :scope, :state,
-                    :code_challenge, :code_challenge_method)
+      params.slice(*pre_auth_param_fields).permit(*pre_auth_param_fields)
+    end
+
+    def pre_auth_param_fields
+      %i[client_id response_type redirect_uri scope state code_challenge
+         code_challenge_method]
     end
 
     def authorization


### PR DESCRIPTION
Fix for part of #1287

As a Rails form will include other params such as a commit, utf_8 and authenticity_token we need to pull out only the params we require or we'll get a strong params exception when running Rails with the setting:

    config.action_controller.action_on_unpermitted_parameters = :raise