### PR TITLE
Limiting access to attributes of pre_authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1300] Limiting access to attributes of pre_authorization.
 - [#1296] Adding client_id to strong parameters.
 - [#1293] Move ar specific redirect uri validator to ar orm directory.
 - [#1288] Allow to pass attributes to the `Doorkeeper::OAuth::PreAuthorization#as_json` method to customize

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -12,9 +12,8 @@ module Doorkeeper
       validate :code_challenge_method, error: :invalid_code_challenge_method
       validate :client_supports_grant_flow, error: :unauthorized_client
 
-      attr_accessor :server, :client, :response_type, :redirect_uri, :state,
-                    :code_challenge, :code_challenge_method
-      attr_writer   :scope
+      attr_reader :server, :client, :client_id, :response_type, :redirect_uri,
+                  :state, :code_challenge, :code_challenge_method
 
       def initialize(server, attrs = {})
         @server                = server
@@ -69,7 +68,7 @@ module Doorkeeper
       end
 
       def validate_client
-        @client = OAuth::Client.find(@client_id)
+        @client = OAuth::Client.find(client_id)
         @client.present?
       end
 

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -6,8 +6,7 @@ module Doorkeeper::OAuth
   describe PreAuthorization do
     let(:server) do
       server = Doorkeeper.configuration
-      allow(server).to receive(:default_scopes).and_return(Scopes.new)
-      allow(server).to receive(:scopes).and_return(Scopes.from_string("public profile"))
+      allow(server).to receive(:default_scopes).and_return(Scopes.from_string("public profile"))
       server
     end
 
@@ -32,25 +31,25 @@ module Doorkeeper::OAuth
     end
 
     it "accepts code as response type" do
-      subject.response_type = "code"
+      attributes[:response_type] = "code"
       expect(subject).to be_authorizable
     end
 
     it "accepts token as response type" do
       allow(server).to receive(:grant_flows).and_return(["implicit"])
-      subject.response_type = "token"
+      attributes[:response_type] = "token"
       expect(subject).to be_authorizable
     end
 
     context "when using default grant flows" do
       it 'accepts "code" as response type' do
-        subject.response_type = "code"
+        attributes[:response_type] = "code"
         expect(subject).to be_authorizable
       end
 
       it 'accepts "token" as response type' do
         allow(server).to receive(:grant_flows).and_return(["implicit"])
-        subject.response_type = "token"
+        attributes[:response_type] = "token"
         expect(subject).to be_authorizable
       end
     end
@@ -61,7 +60,7 @@ module Doorkeeper::OAuth
       end
 
       it 'does not accept "code" as response type' do
-        subject.response_type = "code"
+        attributes[:response_type] = "code"
         expect(subject).not_to be_authorizable
       end
     end
@@ -72,31 +71,31 @@ module Doorkeeper::OAuth
       end
 
       it 'does not accept "token" as response type' do
-        subject.response_type = "token"
+        attributes[:response_type] = "token"
         expect(subject).not_to be_authorizable
       end
     end
 
     context "client application does not restrict valid scopes" do
       it "accepts valid scopes" do
-        subject.scope = "public"
+        attributes[:scope] = "public"
         expect(subject).to be_authorizable
       end
 
       it "rejects (globally) non-valid scopes" do
-        subject.scope = "invalid"
+        attributes[:scope] = "invalid"
         expect(subject).not_to be_authorizable
       end
 
       it "accepts scopes which are permitted for grant_type" do
         allow(server).to receive(:scopes_by_grant_type).and_return(authorization_code: [:public])
-        subject.scope = "public"
+        attributes[:scope] = "public"
         expect(subject).to be_authorizable
       end
 
       it "rejects scopes which are not permitted for grant_type" do
         allow(server).to receive(:scopes_by_grant_type).and_return(authorization_code: [:profile])
-        subject.scope = "public"
+        attributes[:scope] = "public"
         expect(subject).not_to be_authorizable
       end
     end
@@ -107,43 +106,43 @@ module Doorkeeper::OAuth
       end
 
       it "accepts valid scopes" do
-        subject.scope = "public"
+        attributes[:scope] = "public"
         expect(subject).to be_authorizable
       end
 
       it "rejects (globally) non-valid scopes" do
-        subject.scope = "invalid"
+        attributes[:scope] = "invalid"
         expect(subject).not_to be_authorizable
       end
 
       it "rejects (application level) non-valid scopes" do
-        subject.scope = "profile"
+        attributes[:scope] = "profile"
         expect(subject).to_not be_authorizable
       end
 
       it "accepts scopes which are permitted for grant_type" do
         allow(server).to receive(:scopes_by_grant_type).and_return(authorization_code: [:public])
-        subject.scope = "public"
+        attributes[:scope] = "public"
         expect(subject).to be_authorizable
       end
 
       it "rejects scopes which are not permitted for grant_type" do
         allow(server).to receive(:scopes_by_grant_type).and_return(authorization_code: [:profile])
-        subject.scope = "public"
+        attributes[:scope] = "public"
         expect(subject).not_to be_authorizable
       end
     end
 
     it "uses default scopes when none is required" do
       allow(server).to receive(:default_scopes).and_return(Scopes.from_string("default"))
-      subject.scope = nil
-      subject.client = client
+      attributes[:scope] = nil
+      expect(subject).to be_authorizable
       expect(subject.scope).to eq("default")
       expect(subject.scopes).to eq(Scopes.from_string("default"))
     end
 
     it "matches the redirect uri against client's one" do
-      subject.redirect_uri = "http://nothesame.com"
+      attributes[:redirect_uri] = "http://nothesame.com"
       expect(subject).not_to be_authorizable
     end
 
@@ -152,7 +151,7 @@ module Doorkeeper::OAuth
     end
 
     it "rejects if response type is not allowed" do
-      subject.response_type = "whops"
+      attributes[:response_type] = "whops"
       expect(subject).not_to be_authorizable
     end
 
@@ -162,12 +161,12 @@ module Doorkeeper::OAuth
     end
 
     it "requires a redirect uri" do
-      subject.redirect_uri = nil
+      attributes[:redirect_uri] = nil
       expect(subject).not_to be_authorizable
     end
 
     describe "as_json" do
-      before { subject.client = client }
+      before { subject.authorizable? }
 
       it { is_expected.to respond_to :as_json }
 


### PR DESCRIPTION
### Summary

#### Problem
At `pre_authorization.rb`, I see that current code use `attr_accessor` and `attr_writer` with attributes to enable writer (attr_writer) for those attributes. These writers are for using at `pre_authorization_spec.rb` test only. I think this exposure is unnecessary.

#### What does this PR do?
Because `pre_authorization` is built from parameters passed to it, we can use `attributes[:param_name] =` instead of `subject.param_name =` writer at `pre_authorization_spec.rb` test. 
And I also limit the access to pre_authorization's attributes: `attr_accessor` -> `attr_reader`, delete `attr_writer`.

#### (UDPDATE) Additionally
I have noticed that there are bunch of unnecessary exposures at other class in project, not only at pre_authorization. Some of those exposures are used for test, other used for nothing (just change to `attr_reader` and code work normally)
