### PR TITLE
Fixes Doorkeeper API mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#PR ID] Your PR description here.
+- [#PR 1308] Fixes doorkeeper api mode
 
 ## 5.2.0
 

--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -4,7 +4,7 @@ module Doorkeeper
   class ApplicationsController < Doorkeeper::ApplicationController
     layout "doorkeeper/admin" unless Doorkeeper.configuration.api_only
 
-    add_flash_types :application_secret
+    add_flash_types :application_secret unless Doorkeeper.configuration.api_only
     before_action :authenticate_admin!
     before_action :set_application, only: %i[show edit update destroy]
 


### PR DESCRIPTION
### Summary

When using `api_only` it will make `Doorkeeper::ApplicationController` inherit from `ActionController::API` which doesn't have `add_flash_types` method. 

Related to https://github.com/doorkeeper-gem/doorkeeper/pull/1305

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating CHANGELOG.md file or are asked to update it by reviewers,
please add the changelog entry at the top of the file.

Thanks for contributing to Doorkeeper project!
