### PR TITLE
Allow Doorkeeper::Application#to_json to work without arguments 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PD ID] Your PR short description.
+- [#1309] Allow Doorkeeper::Application#to_json to work without arguments
 
 ## 5.2.1
 

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -60,7 +60,7 @@ module Doorkeeper
       end
     end
 
-    def to_json(options)
+    def to_json(options = nil)
       serializable_hash(except: :secret)
         .merge(secret: plaintext_secret)
         .to_json(options)


### PR DESCRIPTION
### Summary
We can use ActiveRecord::Base#to_json without argument, but Doorkeeper::Application#to_json does not work without arguments after 5.2.0.rc1.

```rb
# ===== Greater than or equal to 5.2.0.rc1 =====
# ArgumentError occurs
[1] pry(main)> Doorkeeper::Application.new.to_json
ArgumentError: wrong number of arguments (given 0, expected 1)
from /Users/yuji/mf/erp_web/.bundle/gems/doorkeeper-5.2.1/lib/doorkeeper/orm/active_record/application.rb:63:in `to_json'`

# =====  Under 5.2.0.rc1 =====
# Exception no occurs
[1] pry(main)> Doorkeeper::Application.new.to_json
=> "{\"id\":null,\"name\":null,\"uid\":null,\"secret\":null,\"redirect_uri\":null,\"scopes\":[],\"confidential\":true,\"created_at\":null,\"updated_at\":null}"
```
### Other Information
Doorkeeper has overridden ActiveRecord::Base by this commit.
https://github.com/doorkeeper-gem/doorkeeper/commit/e59b25f6a26f01efd6339c8884dc06e7ab284b22

But original behavior allow us to execute without arguments by given nil as default value.
https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/core_ext/object/json.rb#L36-L44}
