### PR TITLE
Make it easier to reset an application secret

### DIFF
--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -46,6 +46,18 @@ module Doorkeeper
       AccessGrant.revoke_all_for(id, resource_owner)
     end
 
+    # Generates (or regenerates) the secret for this application.
+    #
+    # @param allow_overwrite [Boolean]
+    #   whether to allow overwriting an existing secret
+    #
+    def generate_secret(allow_overwrite = false)
+      return unless secret.blank? || allow_overwrite
+
+      @raw_secret = UniqueToken.generate
+      secret_strategy.store_secret(self, :secret, @raw_secret)
+    end
+
     # We keep a volatile copy of the raw secret for initial communication
     # The stored refresh_token may be mapped and not available in cleartext.
     #
@@ -70,13 +82,6 @@ module Doorkeeper
 
     def generate_uid
       self.uid = UniqueToken.generate if uid.blank?
-    end
-
-    def generate_secret
-      return unless secret.blank?
-
-      @raw_secret = UniqueToken.generate
-      secret_strategy.store_secret(self, :secret, @raw_secret)
     end
 
     def scopes_match_configured


### PR DESCRIPTION
### Summary

I wanted the ability to regenerate my application secrets when needed (e.g. recurring rotation or in case of compromise).

Currently, it's not easy, even in a `rails console`. You have to run the following:

```ruby
app = Doorkeeper::Application.find_by(uid: "abcdef...")
app.secret = nil
app.send(:generate_secret)
app.save
```

With this change, you can do it like so:

```ruby
app = Doorkeeper::Application.find_by(uid: "abcdef...")
app.generate_secret(true)
app.save
```

By making this method public, application authors can now more easily expose this functionality in controllers, without having to worry as much that the interface will change.

Let me know if you think that exposing this in a controller should be included in this PR. In my opinion, that could be done in a future PR. At least this change removes the need to use `send` to invoke a private method.

Fixes https://github.com/doorkeeper-gem/doorkeeper/issues/770.

### Other Information

I'm considering changing the code to the following. Please let me know what you think the interface should be.

```ruby
    # Resets the secret for this application.
    #
    def reset_secret!
      @raw_secret = UniqueToken.generate
      secret_strategy.store_secret(self, :secret, @raw_secret)
    end

    [...]

    private

    def generate_secret
      return unless secret.blank?
      reset_secret!
    end

```
