### PR TITLE
Make revocation of access tokens optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ User-visible changes worth mentioning.
 - [#1345] Allow to set custom classes for Doorkeeper models, extract reusable AR mixins.
 - [#1346] Refactor `Doorkeeper::Application#to_json` into convenient `#as_json` (fix #1344).
 - [#1349] Fix `Doorkeeper::Application` AR associations using an incorrect foreign key name when using a custom class.
+- [#1318] Optimize fetching of tokens for `reuse_access_token` and revocation of
+  old access tokens
 
 ## 5.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ requested a new access token, reenable it with `revoke_previous_client_credentia
 
 - [#1270] Find matching tokens in batches for `reuse_access_token` option (fix #1193).
 - [#1271] Reintroduce existing token revocation for client credentials.
+
+**[IMPORTANT]** If you rely on being able to fetch multiple access tokens from the same
+client using client credentials flow, you should skip to version 5.3, where this behaviour
+is deactivated by default.
+
 - [#1269] Update initializer template documentation.
 - [#1266] Use strong parameters within pre-authorization.
 - [#1264] Add :before_successful_authorization and :after_successful_authorization hooks in TokensController

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ User-visible changes worth mentioning.
 - [#1345] Allow to set custom classes for Doorkeeper models, extract reusable AR mixins.
 - [#1346] Refactor `Doorkeeper::Application#to_json` into convenient `#as_json` (fix #1344).
 - [#1349] Fix `Doorkeeper::Application` AR associations using an incorrect foreign key name when using a custom class.
+- [#1318] Make existing token revocation for client credentials optional and disable it by default
+
+**[IMPORTANT]** This is a change compared to the behaviour of version 5.2.
+If you were relying on access tokens being revoked once the same client
+requested a new access token, reenable it with `revoke_previous_client_credentials_token`.
+
 - [#1318] Optimize fetching of tokens for `reuse_access_token` and revocation of
   old access tokens
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -144,6 +144,13 @@ module Doorkeeper
         @config.instance_variable_set(:@token_reuse_limit, percentage)
       end
 
+      # Only allow one valid access token obtained via client credentials
+      # per client. If a new access token is obtained before the old one
+      # expired, the old one gets revoked (disabled by default)
+      def revoke_previous_client_credentials_token
+        @config.instance_variable_set(:@revoke_previous_client_credentials_token, true)
+      end
+
       # Use an API mode for applications generated with --api argument
       # It will skip applications controller, disable forgery protection
       def api_only
@@ -442,6 +449,10 @@ module Doorkeeper
 
     def token_reuse_limit
       @token_reuse_limit ||= 100
+    end
+
+    def revoke_previous_client_credentials_token
+      @revoke_previous_client_credentials_token || false
     end
 
     def resolve_controller(name)

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -5,13 +5,11 @@ module Doorkeeper
     class ClientCredentialsRequest < BaseRequest
       class Creator
         def call(client, scopes, attributes = {})
-          existing_token = existing_token_for(client, scopes)
+          existing_token = existing_token_for(client, scopes) if needs_existing_token?
 
-          if Doorkeeper.configuration.reuse_access_token && existing_token&.reusable?
-            return existing_token
-          end
+          return existing_token if config.reuse_access_token && existing_token&.reusable?
 
-          existing_token&.revoke
+          existing_token&.revoke if config.revoke_previous_client_credentials_token
 
           Doorkeeper.config.access_token_model.find_or_create_for(
             client, nil, scopes, attributes[:expires_in],
@@ -21,8 +19,16 @@ module Doorkeeper
 
         private
 
+        def needs_existing_token?
+          config.reuse_access_token || config.revoke_previous_client_credentials_token
+        end
+
         def existing_token_for(client, scopes)
           Doorkeeper.config.access_token_model.matching_token_for client, nil, scopes
+        end
+
+        def config
+          Doorkeeper.configuration
         end
       end
     end

--- a/lib/doorkeeper/orm/active_record/mixins/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/access_token.rb
@@ -22,6 +22,8 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
       before_validation :generate_token, on: :create
       before_validation :generate_refresh_token,
                         on: :create, if: :use_refresh_token?
+
+      scope :created_since, ->(time) { where("created_at > ?", time) }
     end
 
     class_methods do

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -127,6 +127,16 @@ Doorkeeper.configure do
   #
   # token_reuse_limit 100
 
+  # Only allow one valid access token obtained via client credentials
+  # per client. If a new access token is obtained before the old one
+  # expired, the old one gets revoked (disabled by default)
+  #
+  # When enabling this option, make sure that you do not expect multiple processes
+  # using the same credentials at the same time (e.g. web servers spanning
+  # multiple machines and/or processes).
+  #
+  # revoke_previous_client_credentials_token
+
   # Hash access and refresh tokens before persisting them.
   # This will disable the possibility to use +reuse_access_token+
   # since plain values can no longer be retrieved.


### PR DESCRIPTION
### Summary

As discussed in #1314, the automatic revocation of old access tokens can lead to problems when multiple physical machines (clients) share the same set of credentials (e.g. multiple web servers behind a load balancer).

However, the revocation was implemented, to make the fetching of tokens more efficient, since it did not perform well for large amounts of tokens.

Therefore this pull request implements two changes:
* filtering by the TTL of a token when fetching tokens from the database (thus also reducing the number of fetched tokens)
* making the automatic revocation introduced in #1271 optional (disabled by default)

### Considerations

I decided to disable automatic revocation by default. My reasoning:
* It was a breaking change introduced in 5.2, so it was a surprise for anyone upgrading from 5.1 and below
* I am not sure if there is real _demand_ for that feature or whether it was purely out of performance considerations... But I can at least imagine the demand

Fetching based on TTL is not working when you set a `custom_access_token_expires_in`, since we could not guarantee that the tokens being filtered out would be considered as expired by the custom strategy. I am pretty sad about introducing this piece of "works different depending on configuration" and I am not sure whether we should at least point it out in the documentation.
