### PR TITLE
Call configured authenticate_resource_owner block once per request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Your PR short description.
+- [#1320] Call configured authenticate_resource_owner method once per request.
 - [#1315] Allow generation of new secret with `Doorkeeper::Application#renew_secret`.
 - [#1309] Allow `Doorkeeper::Application#to_json` to work without arguments.
 

--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -16,7 +16,9 @@ module Doorkeeper
 
       # :doc:
       def current_resource_owner
-        instance_eval(&Doorkeeper.configuration.authenticate_resource_owner)
+        @current_resource_owner ||= begin
+          instance_eval(&Doorkeeper.configuration.authenticate_resource_owner)
+        end
       end
 
       def resource_owner_from_credentials

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -28,7 +28,9 @@ describe Doorkeeper::AuthorizationsController, "implicit grant flow" do
     end
 
     allow(Doorkeeper.configuration).to receive(:grant_flows).and_return(["implicit"])
-    allow(controller).to receive(:current_resource_owner).and_return(user)
+    allow(Doorkeeper.configuration).to receive(:authenticate_resource_owner).and_return(->(_) { authenticator_method })
+    allow(controller).to receive(:authenticator_method).and_return(user)
+    expect(controller).to receive(:authenticator_method).at_most(:once)
   end
 
   describe "POST #create" do


### PR DESCRIPTION
### Summary

The block configured for `authenticate_resource_owner` is called 2-3 times per request. If that block performs more complex logic or database queries, it unnecessarily reexecutes that logic.

This PR memoizes to execute only one time.
