### PR TITLE
Refactor: move response_type check in pre_authorization to a method to be easily to override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Your PR short description.
+- [#1326] Move response_type check in pre_authorization to a method to be easily to override
 
 ## 5.2.2
 

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -45,12 +45,11 @@ module Doorkeeper
       end
 
       def error_response
-        is_implicit_flow = response_type == "token"
-
         if error == :invalid_request
-          OAuth::InvalidRequestResponse.from_request(self, response_on_fragment: is_implicit_flow)
+          OAuth::InvalidRequestResponse.from_request(self,
+                                                     response_on_fragment: response_on_fragment?)
         else
-          OAuth::ErrorResponse.from_request(self, response_on_fragment: is_implicit_flow)
+          OAuth::ErrorResponse.from_request(self, response_on_fragment: response_on_fragment?)
         end
       end
 
@@ -121,6 +120,10 @@ module Doorkeeper
       def validate_code_challenge_method
         code_challenge.blank? ||
           (code_challenge_method.present? && code_challenge_method =~ /^plain$|^S256$/)
+      end
+
+      def response_on_fragment?
+        response_type == "token"
       end
 
       def pre_auth_hash


### PR DESCRIPTION
### Summary

This pull request refactors `error_response` method of `pre_authorization` in authorization request.

In Oauth2, `response_on_fragment=true` when `response_type=token` (which is implicit flow).
But OIDC introduces other `response_type` which also define that `response_on_fragment=true` (response_type = `id_token` or `id_token token`...)

I move the response_type check to `response_on_fragment?` method, so it could be easily override this behavior like:
```ruby
def response_on_fragment?
  super || response_type == "id_token"
end
```

### References:
https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthRequest
