### PR TITLE
Fix find_in_batches order warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#PR ID] Your PR short description.
 - [#1326] Move response_type check in pre_authorization to a method to be easily to override
+- [#1329] Fix find_in_batches order warning.
 
 ## 5.2.2
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -191,10 +191,9 @@ module Doorkeeper
       # @return [Doorkeeper::AccessToken] array of matching AccessToken objects
       #
       def authorized_tokens_for(application_id, resource_owner_id)
-        ordered_by(:created_at, :desc)
-          .where(application_id: application_id,
-                 resource_owner_id: resource_owner_id,
-                 revoked_at: nil)
+        where(application_id: application_id,
+              resource_owner_id: resource_owner_id,
+              revoked_at: nil)
       end
 
       # Convenience method for backwards-compatibility, return the last
@@ -209,7 +208,8 @@ module Doorkeeper
       #   nil if nothing was found
       #
       def last_authorized_token_for(application_id, resource_owner_id)
-        authorized_tokens_for(application_id, resource_owner_id).first
+        authorized_tokens_for(application_id, resource_owner_id)
+          .ordered_by(:created_at, :desc).first
       end
 
       ##


### PR DESCRIPTION
### Summary

This PR fix the following warning that appears in the log when using Doorkeeper with Rails 6: 
```
Doorkeeper::AccessToken : Scoped order is ignored, it's forced to be batch order.
```

As mentioned in the [existing comment](https://github.com/doorkeeper-gem/doorkeeper/blob/v5.2.2/lib/doorkeeper/models/access_token_mixin.rb#L93) of that class, ActiveRecord 5.x - 6.x ignores custom ordering so the gem can't perform a database sort by `created_at`.

The fix is to use the sort only where it's needed to avoid the warning in [find_in_batches](https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-find_in_batches).