### PR TITLE
avoid setting flash type so it does not define extra methods/unexpect…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Your PR short description.
+- [#1334] Remove `application_secret` flash helper and `redirect_to` keyword
 - [#1331] Move redirect_uri_validator to where it is used
 - [#1326] Move response_type check in pre_authorization to a method to be easily to override
 

--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -4,7 +4,6 @@ module Doorkeeper
   class ApplicationsController < Doorkeeper::ApplicationController
     layout "doorkeeper/admin" unless Doorkeeper.configuration.api_only
 
-    add_flash_types :application_secret unless Doorkeeper.configuration.api_only
     before_action :authenticate_admin!
     before_action :set_application, only: %i[show edit update destroy]
 


### PR DESCRIPTION
…ed redirect keys

 - gem is not using the redirect keyword argument
 - gem is not using the defined application_secret method ... which has a very misleading name

partially reverts http://github.com/doorkeeper-gem/doorkeeper/pull/1248 ... which added the flash without needing to afaik