### PR TITLE
Fix #1338

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#PR ID] Your PR short description.
+- [#1298] Validate Resource Owner in `PasswordAccessTokenRequest` against `nil` and `false` values.
 
 ## 5.2.3
 

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -42,7 +42,7 @@ module Doorkeeper
       end
 
       def validate_resource_owner
-        !resource_owner.nil?
+        resource_owner.present?
       end
 
       def validate_client

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -274,6 +274,20 @@ describe "Resource Owner Password Credentials Flow" do
         post password_token_endpoint_url(client: @client)
       end.to_not(change { Doorkeeper::AccessToken.count })
     end
+
+    it "should not issue new token if resource_owner_from_credentials returned false or nil" do
+      config_is_set(:resource_owner_from_credentials) { false }
+
+      expect do
+        post password_token_endpoint_url(client: @client)
+      end.to_not(change { Doorkeeper::AccessToken.count })
+
+      config_is_set(:resource_owner_from_credentials) { nil }
+
+      expect do
+        post password_token_endpoint_url(client: @client)
+      end.to_not(change { Doorkeeper::AccessToken.count })
+    end
   end
 
   context "with invalid confidential client credentials" do


### PR DESCRIPTION
Fix #1338

Validate Resource Owner in Password flow against `nil` and `false` values