### PR TITLE
Fix revoked_on_use with hashed secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#1339] Validate Resource Owner in `PasswordAccessTokenRequest` against `nil` and `false` values.
+- [#1341] Fix `refresh_token_revoked_on_use` with `hash_token_secrets` enabled.
 - [#1343] Fix ruby 2.7 kwargs warning in InvalidTokenResponse.
 - [#1345] Allow to set custom classes for Doorkeeper models, extract reusable AR mixins.
 - [#1346] Refactor `Doorkeeper::Application#to_json` into convenient `#as_json` (fix #1344).

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -40,6 +40,20 @@ module Doorkeeper
         find_by_plaintext_token(:refresh_token, refresh_token)
       end
 
+      # Returns an instance of the Doorkeeper::AccessToken
+      # with specific token value
+      #
+      # @param previous_refresh_token [#to_s]
+      #   previous refresh token value (any object that reponds to `#to_s`)
+      #
+      # @return [Doorkeeper::AccessToken, nil] AccessToken object or nil
+      #   if there is no record with such refresh token
+      def find_previous_refresh_token(previous_refresh_token)
+        token = previous_refresh_token.to_s
+
+        find_by(:refresh_token => token) 
+      end
+
       # Revokes AccessToken records that have not been revoked and associated
       # with the specific Application and Resource Owner.
       #

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -51,7 +51,7 @@ module Doorkeeper
       def find_previous_refresh_token(previous_refresh_token)
         token = previous_refresh_token.to_s
 
-        find_by(:refresh_token => token) 
+        find_by(refresh_token: token)
       end
 
       # Revokes AccessToken records that have not been revoked and associated

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -39,8 +39,10 @@ module Doorkeeper
       #   Access Token record or nil if nothing found
       #
       def old_refresh_token
+        plaintext_previous_refresh_token = Doorkeeper.config.token_secret_strategy.restore_secret(self, :previous_refresh_token)
+
         @old_refresh_token ||=
-          Doorkeeper.config.access_token_model.by_refresh_token(previous_refresh_token)
+          Doorkeeper.config.access_token_model.by_refresh_token(plaintext_previous_refresh_token)
       end
 
       def refresh_token_revoked_on_use?

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -39,12 +39,12 @@ module Doorkeeper
       #   Access Token record or nil if nothing found
       #
       def old_refresh_token
-        if Doorkeeper.config.token_secret_strategy.allows_restoring_secrets?
-          plaintext_previous_refresh_token =
+        plaintext_previous_refresh_token =
+          if Doorkeeper.config.token_secret_strategy.allows_restoring_secrets?
             Doorkeeper.config.token_secret_strategy.restore_secret(self, :previous_refresh_token)
-        else
-          plaintext_previous_refresh_token = previous_refresh_token
-        end
+          else
+            previous_refresh_token
+          end
 
         @old_refresh_token ||=
           Doorkeeper.config.access_token_model.by_refresh_token(plaintext_previous_refresh_token)

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -39,15 +39,8 @@ module Doorkeeper
       #   Access Token record or nil if nothing found
       #
       def old_refresh_token
-        plaintext_previous_refresh_token =
-          if Doorkeeper.config.token_secret_strategy.allows_restoring_secrets?
-            Doorkeeper.config.token_secret_strategy.restore_secret(self, :previous_refresh_token)
-          else
-            previous_refresh_token
-          end
-
         @old_refresh_token ||=
-          Doorkeeper.config.access_token_model.by_refresh_token(plaintext_previous_refresh_token)
+          Doorkeeper.config.access_token_model.find_previous_refresh_token(previous_refresh_token)
       end
 
       def refresh_token_revoked_on_use?

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -39,8 +39,12 @@ module Doorkeeper
       #   Access Token record or nil if nothing found
       #
       def old_refresh_token
-        plaintext_previous_refresh_token = 
-          Doorkeeper.config.token_secret_strategy.restore_secret(self, :previous_refresh_token)
+        if Doorkeeper.config.token_secret_strategy.allows_restoring_secrets?
+          plaintext_previous_refresh_token =
+            Doorkeeper.config.token_secret_strategy.restore_secret(self, :previous_refresh_token)
+        else
+          plaintext_previous_refresh_token = previous_refresh_token
+        end
 
         @old_refresh_token ||=
           Doorkeeper.config.access_token_model.by_refresh_token(plaintext_previous_refresh_token)

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -19,33 +19,6 @@ module Doorkeeper
       def revoked?
         !!(revoked_at && revoked_at <= Time.now.utc)
       end
-
-      # Revokes token with `:refresh_token` equal to `:previous_refresh_token`
-      # and clears `:previous_refresh_token` attribute.
-      #
-      def revoke_previous_refresh_token!
-        return unless refresh_token_revoked_on_use?
-
-        old_refresh_token&.revoke
-        update_attribute :previous_refresh_token, ""
-      end
-
-      private
-
-      # Searches for Access Token record with `:refresh_token` equal to
-      # `:previous_refresh_token` value.
-      #
-      # @return [Doorkeeper::AccessToken, nil]
-      #   Access Token record or nil if nothing found
-      #
-      def old_refresh_token
-        @old_refresh_token ||=
-          Doorkeeper.config.access_token_model.find_previous_refresh_token(previous_refresh_token)
-      end
-
-      def refresh_token_revoked_on_use?
-        Doorkeeper.config.access_token_model.refresh_token_revoked_on_use?
-      end
     end
   end
 end

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -39,7 +39,8 @@ module Doorkeeper
       #   Access Token record or nil if nothing found
       #
       def old_refresh_token
-        plaintext_previous_refresh_token = Doorkeeper.config.token_secret_strategy.restore_secret(self, :previous_refresh_token)
+        plaintext_previous_refresh_token = 
+          Doorkeeper.config.token_secret_strategy.restore_secret(self, :previous_refresh_token)
 
         @old_refresh_token ||=
           Doorkeeper.config.access_token_model.by_refresh_token(plaintext_previous_refresh_token)


### PR DESCRIPTION
### Summary

Revocation of tokens on first use doesn't work with enabled `hash_token_secrets`.