### PR TITLE
Fix Ruby 2.7 kwargs warning in InvalidTokenResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#1339] Validate Resource Owner in `PasswordAccessTokenRequest` against `nil` and `false` values.
+- [#1343] Fix ruby 2.7 kwargs warning in InvalidTokenResponse.
 
 ## 5.2.3
 

--- a/lib/doorkeeper/oauth/invalid_token_response.rb
+++ b/lib/doorkeeper/oauth/invalid_token_response.rb
@@ -27,8 +27,11 @@ module Doorkeeper
       end
 
       def description
-        scope = { scope: %i[doorkeeper errors messages invalid_token] }
-        @description ||= I18n.translate @reason, scope
+        @description ||=
+          I18n.translate(
+            @reason,
+            scope: %i[doorkeeper errors messages invalid_token]
+          )
       end
 
       protected


### PR DESCRIPTION
I Run specs and found the following warning in Doorkeeper's code itself.

```
lib/doorkeeper/oauth/invalid_token_response.rb:31:
warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
```

Instead of expanding the hash to keyword arguments with
double splat, I have rewritten the hash into keyword arguments.
It's the same as `Doorkeeper::OAuth::InvalidRequestResponse#description`.