### PR TITLE
Allow to configure Doorkeeper models

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,7 +50,7 @@ Style/DoubleNegation:
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 Layout/DotPosition:
   EnforcedStyle: leading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#1339] Validate Resource Owner in `PasswordAccessTokenRequest` against `nil` and `false` values.
 - [#1343] Fix ruby 2.7 kwargs warning in InvalidTokenResponse.
+- [#1345] Allow to set custom classes for Doorkeeper models, extract reusable AR mixins.
 
 ## 5.2.3
 

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -40,11 +40,11 @@ module Doorkeeper
       #
       def old_refresh_token
         @old_refresh_token ||=
-          AccessToken.by_refresh_token(previous_refresh_token)
+          Doorkeeper.config.access_token_model.by_refresh_token(previous_refresh_token)
       end
 
       def refresh_token_revoked_on_use?
-        AccessToken.refresh_token_revoked_on_use?
+        Doorkeeper.config.access_token_model.refresh_token_revoked_on_use?
       end
     end
   end

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -12,7 +12,7 @@ module Doorkeeper
         end
 
         def issue_token
-          @token ||= AccessGrant.create!(access_grant_attributes)
+          @token ||= Doorkeeper.config.access_grant_model.create!(access_grant_attributes)
         end
 
         def oob_redirect
@@ -47,7 +47,7 @@ module Doorkeeper
         # Ensures firstly, if migration with additional PKCE columns was
         # generated and migrated
         def pkce_supported?
-          Doorkeeper::AccessGrant.pkce_supported?
+          Doorkeeper.config.access_grant_model.pkce_supported?
         end
       end
     end

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -54,7 +54,7 @@ module Doorkeeper
             Doorkeeper::OAuth::IMPLICIT,
             pre_auth.scopes
           )
-          @token ||= AccessToken.find_or_create_for(
+          @token ||= Doorkeeper.config.access_token_model.find_or_create_for(
             pre_auth.client,
             resource_owner.id,
             pre_auth.scopes,

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -82,7 +82,7 @@ module Doorkeeper
         return false unless grant.pkce_supported?
 
         if grant.code_challenge_method == "S256"
-          grant.code_challenge == AccessGrant.generate_code_challenge(code_verifier)
+          grant.code_challenge == Doorkeeper.config.access_grant_model.generate_code_challenge(code_verifier)
         elsif grant.code_challenge_method == "plain"
           grant.code_challenge == code_verifier
         else

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -36,7 +36,7 @@ module Doorkeeper
 
       def find_or_create_access_token(client, resource_owner_id, scopes, server)
         context = Authorization::Token.build_context(client, grant_type, scopes)
-        @access_token = AccessToken.find_or_create_for(
+        @access_token = Doorkeeper.config.access_token_model.find_or_create_for(
           client,
           resource_owner_id,
           scopes,

--- a/lib/doorkeeper/oauth/client.rb
+++ b/lib/doorkeeper/oauth/client.rb
@@ -11,13 +11,13 @@ module Doorkeeper
         @application = application
       end
 
-      def self.find(uid, method = Application.method(:by_uid))
+      def self.find(uid, method = Doorkeeper.config.application_model.method(:by_uid))
         if (application = method.call(uid))
           new(application)
         end
       end
 
-      def self.authenticate(credentials, method = Application.method(:by_uid_and_secret))
+      def self.authenticate(credentials, method = Doorkeeper.config.application_model.method(:by_uid_and_secret))
         return if credentials.blank?
 
         if (application = method.call(credentials.uid, credentials.secret))

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -13,7 +13,7 @@ module Doorkeeper
 
           existing_token&.revoke
 
-          AccessToken.find_or_create_for(
+          Doorkeeper.config.access_token_model.find_or_create_for(
             client, nil, scopes, attributes[:expires_in],
             attributes[:use_refresh_token]
           )
@@ -22,7 +22,7 @@ module Doorkeeper
         private
 
         def existing_token_for(client, scopes)
-          Doorkeeper::AccessToken.matching_token_for client, nil, scopes
+          Doorkeeper.config.access_token_model.matching_token_for client, nil, scopes
         end
       end
     end

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -18,7 +18,7 @@ module Doorkeeper
 
   # For backward compatibility with old rubies
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5.0")
-    IPAddr.send(:include, Doorkeeper::IPAddrLoopback)
+    IPAddr.include Doorkeeper::IPAddrLoopback
   end
 
   module OAuth

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -27,7 +27,7 @@ module Doorkeeper
       private
 
       def load_client(credentials)
-        Application.by_uid_and_secret(credentials.uid, credentials.secret)
+        Doorkeeper.config.application_model.by_uid_and_secret(credentials.uid, credentials.secret)
       end
 
       def before_successful_response
@@ -42,7 +42,7 @@ module Doorkeeper
       end
 
       def refresh_token_revoked_on_use?
-        Doorkeeper::AccessToken.refresh_token_revoked_on_use?
+        Doorkeeper.config.access_token_model.refresh_token_revoked_on_use?
       end
 
       def default_scopes
@@ -50,7 +50,7 @@ module Doorkeeper
       end
 
       def create_access_token
-        @access_token = AccessToken.create!(access_token_attributes)
+        @access_token = Doorkeeper.config.access_token_model.create!(access_token_attributes)
       end
 
       def access_token_attributes

--- a/lib/doorkeeper/oauth/token.rb
+++ b/lib/doorkeeper/oauth/token.rb
@@ -14,7 +14,7 @@ module Doorkeeper
 
         def authenticate(request, *methods)
           if (token = from_request(request, *methods))
-            access_token = AccessToken.by_token(token)
+            access_token = Doorkeeper.config.access_token_model.by_token(token)
             refresh_token_enabled = Doorkeeper.configuration.refresh_token_enabled?
             if access_token.present? && refresh_token_enabled
               access_token.revoke_previous_refresh_token!

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -33,7 +33,7 @@ module Doorkeeper
         lazy_load do
           require "doorkeeper/models/concerns/ownership"
 
-          Doorkeeper::Application.send :include, Doorkeeper::Models::Ownership
+          Doorkeeper.config.application_model.send :include, Doorkeeper::Models::Ownership
         end
       end
 

--- a/lib/doorkeeper/orm/active_record/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/access_grant.rb
@@ -1,48 +1,9 @@
 # frozen_string_literal: true
 
+require "doorkeeper/orm/active_record/mixins/access_grant"
+
 module Doorkeeper
-  class AccessGrant < ActiveRecord::Base
-    self.table_name = "#{table_name_prefix}oauth_access_grants#{table_name_suffix}"
-
-    include AccessGrantMixin
-
-    belongs_to :application, class_name: "Doorkeeper::Application",
-                             optional: true, inverse_of: :access_grants
-
-    validates :resource_owner_id,
-              :application_id,
-              :token,
-              :expires_in,
-              :redirect_uri,
-              presence: true
-
-    validates :token, uniqueness: { case_sensitive: true }
-
-    before_validation :generate_token, on: :create
-
-    # We keep a volatile copy of the raw token for initial communication
-    # The stored refresh_token may be mapped and not available in cleartext.
-    #
-    # Some strategies allow restoring stored secrets (e.g. symmetric encryption)
-    # while hashing strategies do not, so you cannot rely on this value
-    # returning a present value for persisted tokens.
-    def plaintext_token
-      if secret_strategy.allows_restoring_secrets?
-        secret_strategy.restore_secret(self, :token)
-      else
-        @raw_token
-      end
-    end
-
-    private
-
-    # Generates token value with UniqueToken class.
-    #
-    # @return [String] token value
-    #
-    def generate_token
-      @raw_token = UniqueToken.generate
-      secret_strategy.store_secret(self, :token, @raw_token)
-    end
+  class AccessGrant < ::ActiveRecord::Base
+    include Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant
   end
 end

--- a/lib/doorkeeper/orm/active_record/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/access_token.rb
@@ -1,40 +1,9 @@
 # frozen_string_literal: true
 
+require "doorkeeper/orm/active_record/mixins/access_token"
+
 module Doorkeeper
-  class AccessToken < ActiveRecord::Base
-    self.table_name = "#{table_name_prefix}oauth_access_tokens#{table_name_suffix}"
-
-    include AccessTokenMixin
-
-    belongs_to :application, class_name: "Doorkeeper::Application",
-                             inverse_of: :access_tokens, optional: true
-
-    validates :token, presence: true, uniqueness: { case_sensitive: true }
-    validates :refresh_token, uniqueness: { case_sensitive: true }, if: :use_refresh_token?
-
-    # @attr_writer [Boolean, nil] use_refresh_token
-    #   indicates the possibility of using refresh token
-    attr_writer :use_refresh_token
-
-    before_validation :generate_token, on: :create
-    before_validation :generate_refresh_token,
-                      on: :create, if: :use_refresh_token?
-
-    # Searches for not revoked Access Tokens associated with the
-    # specific Resource Owner.
-    #
-    # @param resource_owner [ActiveRecord::Base]
-    #   Resource Owner model instance
-    #
-    # @return [ActiveRecord::Relation]
-    #   active Access Tokens for Resource Owner
-    #
-    def self.active_for(resource_owner)
-      where(resource_owner_id: resource_owner.id, revoked_at: nil)
-    end
-
-    def self.refresh_token_revoked_on_use?
-      column_names.include?("previous_refresh_token")
-    end
+  class AccessToken < ::ActiveRecord::Base
+    include Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
   end
 end

--- a/lib/doorkeeper/orm/active_record/application.rb
+++ b/lib/doorkeeper/orm/active_record/application.rb
@@ -1,102 +1,10 @@
 # frozen_string_literal: true
 
 require "doorkeeper/orm/active_record/redirect_uri_validator"
+require "doorkeeper/orm/active_record/mixins/application"
 
 module Doorkeeper
-  class Application < ActiveRecord::Base
-    self.table_name = "#{table_name_prefix}oauth_applications#{table_name_suffix}"
-
-    include ApplicationMixin
-
-    has_many :access_grants, dependent: :delete_all, class_name: "Doorkeeper::AccessGrant"
-    has_many :access_tokens, dependent: :delete_all, class_name: "Doorkeeper::AccessToken"
-
-    validates :name, :secret, :uid, presence: true
-    validates :uid, uniqueness: { case_sensitive: true }
-    validates :redirect_uri, "doorkeeper/redirect_uri": true
-    validates :confidential, inclusion: { in: [true, false] }
-
-    validate :scopes_match_configured, if: :enforce_scopes?
-
-    before_validation :generate_uid, :generate_secret, on: :create
-
-    has_many :authorized_tokens, -> { where(revoked_at: nil) }, class_name: "AccessToken"
-    has_many :authorized_applications, through: :authorized_tokens, source: :application
-
-    # Returns Applications associated with active (not revoked) Access Tokens
-    # that are owned by the specific Resource Owner.
-    #
-    # @param resource_owner [ActiveRecord::Base]
-    #   Resource Owner model instance
-    #
-    # @return [ActiveRecord::Relation]
-    #   Applications authorized for the Resource Owner
-    #
-    def self.authorized_for(resource_owner)
-      resource_access_tokens = AccessToken.active_for(resource_owner)
-      where(id: resource_access_tokens.select(:application_id).distinct)
-    end
-
-    # Revokes AccessToken and AccessGrant records that have not been revoked and
-    # associated with the specific Application and Resource Owner.
-    #
-    # @param resource_owner [ActiveRecord::Base]
-    #   instance of the Resource Owner model
-    #
-    def self.revoke_tokens_and_grants_for(id, resource_owner)
-      AccessToken.revoke_all_for(id, resource_owner)
-      AccessGrant.revoke_all_for(id, resource_owner)
-    end
-
-    # Generates a new secret for this application, intended to be used
-    # for rotating the secret or in case of compromise.
-    #
-    def renew_secret
-      @raw_secret = UniqueToken.generate
-      secret_strategy.store_secret(self, :secret, @raw_secret)
-    end
-
-    # We keep a volatile copy of the raw secret for initial communication
-    # The stored refresh_token may be mapped and not available in cleartext.
-    #
-    # Some strategies allow restoring stored secrets (e.g. symmetric encryption)
-    # while hashing strategies do not, so you cannot rely on this value
-    # returning a present value for persisted tokens.
-    def plaintext_secret
-      if secret_strategy.allows_restoring_secrets?
-        secret_strategy.restore_secret(self, :secret)
-      else
-        @raw_secret
-      end
-    end
-
-    def to_json(options = nil)
-      serializable_hash(except: :secret)
-        .merge(secret: plaintext_secret)
-        .to_json(options)
-    end
-
-    private
-
-    def generate_uid
-      self.uid = UniqueToken.generate if uid.blank?
-    end
-
-    def generate_secret
-      return unless secret.blank?
-      renew_secret
-    end
-
-    def scopes_match_configured
-      if scopes.present? &&
-         !ScopeChecker.valid?(scope_str: scopes.to_s,
-                              server_scopes: Doorkeeper.configuration.scopes)
-        errors.add(:scopes, :not_match_configured)
-      end
-    end
-
-    def enforce_scopes?
-      Doorkeeper.configuration.enforce_configured_scopes?
-    end
+  class Application < ::ActiveRecord::Base
+    include ::Doorkeeper::Orm::ActiveRecord::Mixins::Application
   end
 end

--- a/lib/doorkeeper/orm/active_record/mixins/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/access_grant.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Doorkeeper::Orm::ActiveRecord::Mixins
+  module AccessGrant
+    extend ActiveSupport::Concern
+
+    included do
+      self.table_name = "#{table_name_prefix}oauth_access_grants#{table_name_suffix}"
+
+      include ::Doorkeeper::AccessGrantMixin
+
+      belongs_to :application, class_name: Doorkeeper.configuration.application_class,
+                               optional: true, inverse_of: :access_grants
+
+      validates :resource_owner_id,
+                :application_id,
+                :token,
+                :expires_in,
+                :redirect_uri,
+                presence: true
+
+      validates :token, uniqueness: { case_sensitive: true }
+
+      before_validation :generate_token, on: :create
+
+      # We keep a volatile copy of the raw token for initial communication
+      # The stored refresh_token may be mapped and not available in cleartext.
+      #
+      # Some strategies allow restoring stored secrets (e.g. symmetric encryption)
+      # while hashing strategies do not, so you cannot rely on this value
+      # returning a present value for persisted tokens.
+      def plaintext_token
+        if secret_strategy.allows_restoring_secrets?
+          secret_strategy.restore_secret(self, :token)
+        else
+          @raw_token
+        end
+      end
+
+      private
+
+      # Generates token value with UniqueToken class.
+      #
+      # @return [String] token value
+      #
+      def generate_token
+        @raw_token = Doorkeeper::OAuth::Helpers::UniqueToken.generate
+        secret_strategy.store_secret(self, :token, @raw_token)
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/orm/active_record/mixins/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/access_token.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Doorkeeper::Orm::ActiveRecord::Mixins
+  module AccessToken
+    extend ActiveSupport::Concern
+
+    included do
+      self.table_name = "#{table_name_prefix}oauth_access_tokens#{table_name_suffix}"
+
+      include ::Doorkeeper::AccessTokenMixin
+
+      belongs_to :application, class_name: Doorkeeper.configuration.application_class,
+                               inverse_of: :access_tokens, optional: true
+
+      validates :token, presence: true, uniqueness: { case_sensitive: true }
+      validates :refresh_token, uniqueness: { case_sensitive: true }, if: :use_refresh_token?
+
+      # @attr_writer [Boolean, nil] use_refresh_token
+      #   indicates the possibility of using refresh token
+      attr_writer :use_refresh_token
+
+      before_validation :generate_token, on: :create
+      before_validation :generate_refresh_token,
+                        on: :create, if: :use_refresh_token?
+    end
+
+    class_methods do
+      # Searches for not revoked Access Tokens associated with the
+      # specific Resource Owner.
+      #
+      # @param resource_owner [ActiveRecord::Base]
+      #   Resource Owner model instance
+      #
+      # @return [ActiveRecord::Relation]
+      #   active Access Tokens for Resource Owner
+      #
+      def active_for(resource_owner)
+        where(resource_owner_id: resource_owner.id, revoked_at: nil)
+      end
+
+      def refresh_token_revoked_on_use?
+        column_names.include?("previous_refresh_token")
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/orm/active_record/mixins/application.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/application.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Doorkeeper::Orm::ActiveRecord::Mixins
+  module Application
+    extend ActiveSupport::Concern
+
+    included do
+      self.table_name = "#{table_name_prefix}oauth_applications#{table_name_suffix}"
+
+      include ::Doorkeeper::ApplicationMixin
+
+      has_many :access_grants,
+               dependent: :delete_all,
+               class_name: Doorkeeper.config.access_grant_class
+
+      has_many :access_tokens,
+               dependent: :delete_all,
+               class_name: Doorkeeper.config.access_token_class
+
+      validates :name, :secret, :uid, presence: true
+      validates :uid, uniqueness: { case_sensitive: true }
+      validates :redirect_uri, "doorkeeper/redirect_uri": true
+      validates :confidential, inclusion: { in: [true, false] }
+
+      validate :scopes_match_configured, if: :enforce_scopes?
+
+      before_validation :generate_uid, :generate_secret, on: :create
+
+      has_many :authorized_tokens,
+               -> { where(revoked_at: nil) },
+               class_name: Doorkeeper.config.access_token_class
+
+      has_many :authorized_applications,
+               through: :authorized_tokens,
+               source: :application
+
+      # Generates a new secret for this application, intended to be used
+      # for rotating the secret or in case of compromise.
+      #
+      def renew_secret
+        @raw_secret = Doorkeeper::OAuth::Helpers::UniqueToken.generate
+        secret_strategy.store_secret(self, :secret, @raw_secret)
+      end
+
+      # We keep a volatile copy of the raw secret for initial communication
+      # The stored refresh_token may be mapped and not available in cleartext.
+      #
+      # Some strategies allow restoring stored secrets (e.g. symmetric encryption)
+      # while hashing strategies do not, so you cannot rely on this value
+      # returning a present value for persisted tokens.
+      def plaintext_secret
+        if secret_strategy.allows_restoring_secrets?
+          secret_strategy.restore_secret(self, :secret)
+        else
+          @raw_secret
+        end
+      end
+
+      def to_json(options = nil)
+        serializable_hash(except: :secret)
+          .merge(secret: plaintext_secret)
+          .to_json(options)
+      end
+
+      private
+
+      def generate_uid
+        self.uid = Doorkeeper::OAuth::Helpers::UniqueToken.generate if uid.blank?
+      end
+
+      def generate_secret
+        return unless secret.blank?
+
+        renew_secret
+      end
+
+      def scopes_match_configured
+        if scopes.present? && !Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
+          scope_str: scopes.to_s,
+          server_scopes: Doorkeeper.configuration.scopes
+        )
+          errors.add(:scopes, :not_match_configured)
+        end
+      end
+
+      def enforce_scopes?
+        Doorkeeper.config.enforce_configured_scopes?
+      end
+    end
+
+    class_methods do
+      # Returns Applications associated with active (not revoked) Access Tokens
+      # that are owned by the specific Resource Owner.
+      #
+      # @param resource_owner [ActiveRecord::Base]
+      #   Resource Owner model instance
+      #
+      # @return [ActiveRecord::Relation]
+      #   Applications authorized for the Resource Owner
+      #
+      def authorized_for(resource_owner)
+        resource_access_tokens = Doorkeeper.config.access_token_model.active_for(resource_owner)
+        where(id: resource_access_tokens.select(:application_id).distinct)
+      end
+
+      # Revokes AccessToken and AccessGrant records that have not been revoked and
+      # associated with the specific Application and Resource Owner.
+      #
+      # @param resource_owner [ActiveRecord::Base]
+      #   instance of the Resource Owner model
+      #
+      def revoke_tokens_and_grants_for(id, resource_owner)
+        Doorkeeper.config.access_token_model.revoke_all_for(id, resource_owner)
+        Doorkeeper.config.access_grant_model.revoke_all_for(id, resource_owner)
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -17,7 +17,7 @@ module Doorkeeper
       end
 
       def self.install!
-        ActionDispatch::Routing::Mapper.send :include, Doorkeeper::Rails::Routes::Helper
+        ActionDispatch::Routing::Mapper.include Doorkeeper::Rails::Routes::Helper
       end
 
       attr_reader :routes

--- a/lib/doorkeeper/rake/db.rake
+++ b/lib/doorkeeper/rake/db.rake
@@ -19,7 +19,7 @@ namespace :doorkeeper do
 
       desc "Removes expired (TTL passed) access tokens"
       task expired_tokens: "doorkeeper:setup" do
-        expirable_tokens = Doorkeeper::AccessToken.where(refresh_token: nil)
+        expirable_tokens = Doorkeeper.config.access_token_model.where(refresh_token: nil)
         cleaner = Doorkeeper::StaleRecordsCleaner.new(expirable_tokens)
         cleaner.clean_expired(Doorkeeper.configuration.access_token_expires_in)
       end

--- a/lib/doorkeeper/request/authorization_code.rb
+++ b/lib/doorkeeper/request/authorization_code.rb
@@ -19,7 +19,7 @@ module Doorkeeper
       def grant
         raise Errors::MissingRequiredParameter, :code if parameters[:code].blank?
 
-        AccessGrant.by_token(parameters[:code])
+        Doorkeeper.config.access_grant_model.by_token(parameters[:code])
       end
     end
   end

--- a/lib/doorkeeper/request/refresh_token.rb
+++ b/lib/doorkeeper/request/refresh_token.rb
@@ -6,7 +6,7 @@ module Doorkeeper
       delegate :credentials, :parameters, to: :server
 
       def refresh_token
-        AccessToken.by_refresh_token(parameters[:refresh_token])
+        Doorkeeper.config.access_token_model.by_refresh_token(parameters[:refresh_token])
       end
 
       def request

--- a/lib/doorkeeper/version.rb
+++ b/lib/doorkeeper/version.rb
@@ -8,8 +8,8 @@ module Doorkeeper
   module VERSION
     # Semantic versioning
     MAJOR = 5
-    MINOR = 2
-    TINY = 3
+    MINOR = 3
+    TINY = 0
     PRE = nil
 
     # Full version number

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -29,6 +29,35 @@ Doorkeeper.configure do
   #   end
   # end
 
+  # You can use your own model classes if you need to extend (or even override) default
+  # Doorkeeper models such as `Application`, `AccessToken` and `AccessGrant.
+  #
+  # Be default Doorkeeper ActiveRecord ORM uses it's own classes:
+  #
+  # access_token_class "Doorkeeper::AccessToken"
+  # access_grant_class "Doorkeeper::AccessGrant"
+  # application_class "Doorkeeper::Application"
+  #
+  # Don't forget to include Doorkeeper ORM mixins into your custom models:
+  #
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken - for access token
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant - for access grant
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::Application - for application (OAuth2 clients)
+  #
+  # For example:
+  #
+  # access_token_class "MyAccessToken"
+  #
+  # class MyAccessToken < ApplicationRecord
+  #   include ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
+  #
+  #   self.table_name = "hey_i_wanna_my_name"
+  #
+  #   def destroy_me!
+  #     destroy
+  #   end
+  # end
+
   # If you are planning to use Doorkeeper in Rails 5 API-only application, then you might
   # want to use API mode that will skip all the views management and change the way how
   # Doorkeeper responds to a requests.

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -549,6 +549,8 @@ describe Doorkeeper, "configuration" do
   end
 
   if DOORKEEPER_ORM == :active_record
+    class FakeCustomModel; end
+
     describe "active_record_options" do
       let(:models) { [Doorkeeper::AccessGrant, Doorkeeper::AccessToken, Doorkeeper::Application] }
 
@@ -569,6 +571,57 @@ describe Doorkeeper, "configuration" do
             establish_connection: Rails.configuration.database_configuration[Rails.env]
           )
         end
+      end
+    end
+
+    describe "access_token_class" do
+      it "uses default doorkeeper value" do
+        expect(subject.access_token_class).to eq("Doorkeeper::AccessToken")
+        expect(subject.access_token_model).to be(Doorkeeper::AccessToken)
+      end
+
+      it "can change the value" do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          access_token_class "FakeCustomModel"
+        end
+
+        expect(subject.access_token_class).to eq("FakeCustomModel")
+        expect(subject.access_token_model).to be(FakeCustomModel)
+      end
+    end
+
+    describe "access_grant_class" do
+      it "uses default doorkeeper value" do
+        expect(subject.access_grant_class).to eq("Doorkeeper::AccessGrant")
+        expect(subject.access_grant_model).to be(Doorkeeper::AccessGrant)
+      end
+
+      it "can change the value" do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          access_grant_class "FakeCustomModel"
+        end
+
+        expect(subject.access_grant_class).to eq("FakeCustomModel")
+        expect(subject.access_grant_model).to be(FakeCustomModel)
+      end
+    end
+
+    describe "application_class" do
+      it "uses default doorkeeper value" do
+        expect(subject.application_class).to eq("Doorkeeper::Application")
+        expect(subject.application_model).to be(Doorkeeper::Application)
+      end
+
+      it "can change the value" do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          application_class "FakeCustomModel"
+        end
+
+        expect(subject.application_class).to eq("FakeCustomModel")
+        expect(subject.application_model).to be(FakeCustomModel)
       end
     end
   end

--- a/spec/models/doorkeeper/access_grant_spec.rb
+++ b/spec/models/doorkeeper/access_grant_spec.rb
@@ -67,7 +67,7 @@ describe Doorkeeper::AccessGrant do
               application_id: grant.application_id,
               redirect_uri: grant.redirect_uri,
               expires_in: grant.expires_in,
-              scopes: grant.scopes,
+              scopes: grant.scopes
             )
 
           # Will find subsequently by hashing the token
@@ -77,13 +77,11 @@ describe Doorkeeper::AccessGrant do
               application_id: grant.application_id,
               redirect_uri: grant.redirect_uri,
               expires_in: grant.expires_in,
-              scopes: grant.scopes,
+              scopes: grant.scopes
             )
 
           # Not all the ORM support :id PK
-          if grant.respond_to?(:id)
-            expect(clazz.by_token(plain_text_token).id).to eq(grant.id)
-          end
+          expect(clazz.by_token(plain_text_token).id).to eq(grant.id) if grant.respond_to?(:id)
 
           # And it modifies the token value
           grant.reload

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -77,7 +77,7 @@ module Doorkeeper
                 .to have_attributes(
                   resource_owner_id: access_token.resource_owner_id,
                   application_id: access_token.application_id,
-                  scopes: access_token.scopes,
+                  scopes: access_token.scopes
                 )
 
               # Will find subsequently by hashing the token
@@ -85,7 +85,7 @@ module Doorkeeper
                 .to have_attributes(
                   resource_owner_id: access_token.resource_owner_id,
                   application_id: access_token.application_id,
-                  scopes: access_token.scopes,
+                  scopes: access_token.scopes
                 )
 
               # Not all the ORM support :id PK
@@ -327,7 +327,7 @@ module Doorkeeper
                 .to have_attributes(
                   token: access_token.token,
                   resource_owner_id: access_token.resource_owner_id,
-                  application_id: access_token.application_id,
+                  application_id: access_token.application_id
                 )
 
               # Will find subsequently by hashing the token
@@ -335,7 +335,7 @@ module Doorkeeper
                 .to have_attributes(
                   token: access_token.token,
                   resource_owner_id: access_token.resource_owner_id,
-                  application_id: access_token.application_id,
+                  application_id: access_token.application_id
                 )
 
               # Not all the ORM support :id PK

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ Doorkeeper::RSpec.print_configuration_info
 
 require "support/orm/#{DOORKEEPER_ORM}"
 
-Dir["#{File.dirname(__FILE__)}/support/{dependencies,helpers,shared}/*.rb"].each { |file| require file }
+Dir["#{File.dirname(__FILE__)}/support/{dependencies,helpers,shared}/*.rb"].sort.each { |file| require file }
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
Allow Doorkeeper models to be configurable in order to make it easy to extend or override them.

* Extract AR mixins for reuse
* Add config options to define own models
* Define specs
* Add description to initializer template

Fixes #1327