### PR TITLE
Ensure `Doorkeeper::Application` AR associations always use `application_id` as their foreign key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-visible changes worth mentioning.
 - [#1343] Fix ruby 2.7 kwargs warning in InvalidTokenResponse.
 - [#1345] Allow to set custom classes for Doorkeeper models, extract reusable AR mixins.
 - [#1346] Refactor `Doorkeeper::Application#to_json` into convenient `#as_json` (fix #1344).
+- [#1349] Fix `Doorkeeper::Application` AR associations using an incorrect foreign key name when using a custom class.
 
 ## 5.2.3
 

--- a/lib/doorkeeper/orm/active_record/mixins/application.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/application.rb
@@ -10,10 +10,12 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
       include ::Doorkeeper::ApplicationMixin
 
       has_many :access_grants,
+               foreign_key: :application_id,
                dependent: :delete_all,
                class_name: Doorkeeper.config.access_grant_class
 
       has_many :access_tokens,
+               foreign_key: :application_id,
                dependent: :delete_all,
                class_name: Doorkeeper.config.access_token_class
 
@@ -28,6 +30,7 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
 
       has_many :authorized_tokens,
                -> { where(revoked_at: nil) },
+               foreign_key: :application_id,
                class_name: Doorkeeper.config.access_token_class
 
       has_many :authorized_applications,


### PR DESCRIPTION
# Summary

This should not be implicit as the application model name can be configured via `Doorkeeper.configuration.application_class`.

### Other Information

Connects to doorkeeper-gem/doorkeeper#1327