### PR TITLE
Add option to authorize the calling user to access an Application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1354] Add option to authorize the calling user to access an application.
 - [#1355] Allow to enable polymorphic Resource Owner association for Access Token & Grant
   models (`use_polymorphic_resource_owner` configuration option).
   

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -65,7 +65,11 @@ module Doorkeeper
     end
 
     def pre_auth
-      @pre_auth ||= OAuth::PreAuthorization.new(Doorkeeper.configuration, pre_auth_params)
+      @pre_auth ||= OAuth::PreAuthorization.new(
+        Doorkeeper.configuration,
+        pre_auth_params,
+        current_resource_owner,
+      )
     end
 
     def pre_auth_params

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -280,6 +280,10 @@ module Doorkeeper
            default: {},
            deprecated: { message: "Customize Doorkeeper models instead" }
 
+    # Hook to allow arbitrary user-client authorization
+    option :authorize_resource_owner_for_client,
+           default: ->(_client, _resource_owner) { true }
+
     # Allows to customize OAuth grant flows that +each+ application support.
     # You can configure a custom block (or use a class respond to `#call`) that must
     # return `true` in case Application instance supports requested OAuth grant flow

--- a/lib/doorkeeper/orm/active_record/mixins/application.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/application.rb
@@ -72,6 +72,10 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
         hash
       end
 
+      def authorized_for_resource_owner?(resource_owner)
+        Doorkeeper.configuration.authorize_resource_owner_for_client.call(self, resource_owner)
+      end
+
       private
 
       def generate_uid

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -19,6 +19,7 @@ describe Doorkeeper::OAuth::PreAuthorization do
       response_type: "code",
       redirect_uri: "https://app.com/callback",
       state: "save-this",
+      current_resource_owner: Object.new,
     }
   end
 
@@ -175,6 +176,14 @@ describe Doorkeeper::OAuth::PreAuthorization do
   it "requires a redirect uri" do
     attributes[:redirect_uri] = nil
     expect(subject).not_to be_authorizable
+  end
+
+  context "when resource_owner cannot access client application" do
+    before { allow(Doorkeeper.configuration).to receive(:authorize_resource_owner_for_client).and_return(->(*_) { false }) }
+
+    it "is not authorizable" do
+      expect(subject).not_to be_authorizable
+    end
   end
 
   describe "as_json" do


### PR DESCRIPTION
### Summary

I've added an option to define whether a user can authorize an application.
My specific use case is the following:
- All users belong to an organization
- Each Application belongs to an organization (via a foreign key on Application)
- I don't want users to be able to authorize an application that belongs to a different organization or see that it even exists for privacy reasons.

This is now achievable with the new option:
```
application_access do |resource_owner, application|
  resource_owner.org_id == application.org_id
end
```

When this validation fails the `invalid_client` error is used so it's indistinguishable from a nonexistent Application
<!--
### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating CHANGELOG.md file or are asked to update it by reviewers,
please add the changelog entry at the top of the file.

Thanks for contributing to Doorkeeper project!
-->