### PR TITLE
Invalidate duplicated scopes for Access Tokens/Grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#PR ID] Your PR short description here.
+- [#1356] Invalidate duplicated scopes for Access Tokens and Grants in database.
 
 ## 5.3.0
 

--- a/lib/doorkeeper/models/concerns/scopes.rb
+++ b/lib/doorkeeper/models/concerns/scopes.rb
@@ -8,7 +8,11 @@ module Doorkeeper
       end
 
       def scopes=(value)
-        super Array(value).join(" ")
+        if value.is_a?(Array)
+          super(Doorkeeper::OAuth::Scopes.from_array(value).to_s)
+        else
+          super(Doorkeeper::OAuth::Scopes.from_string(value.to_s).to_s)
+        end
       end
 
       def scopes_string

--- a/spec/lib/models/scopes_spec.rb
+++ b/spec/lib/models/scopes_spec.rb
@@ -33,6 +33,14 @@ describe "Doorkeeper::Models::Scopes" do
       subject.scopes = %w[private admin]
       expect(subject.scopes_string).to eq("private admin")
     end
+
+    it "ignores duplicated scopes" do
+      subject.scopes = %w[private admin admin]
+      expect(subject.scopes_string).to eq("private admin")
+
+      subject.scopes = "private admin admin"
+      expect(subject.scopes_string).to eq("private admin")
+    end
   end
 
   describe :scopes_string do


### PR DESCRIPTION
Don't store tokens with duplicated scopes 