### PR TITLE
Fix #1312: Remove attributes merging of PreAuthorization#as_json method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#1356] Invalidate duplicated scopes for Access Tokens and Grants in database.
+- [#1357] Fix `Doorkeeper::OAuth::PreAuthorization#as_json` method causing `Stack level too deep` error with AMS (fix #1312).
 
 ## 5.3.0
 

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -55,9 +55,7 @@ module Doorkeeper
         end
       end
 
-      def as_json(attributes = {})
-        return pre_auth_hash.merge(attributes.to_h) if attributes.respond_to?(:to_h)
-
+      def as_json(_options = nil)
         pre_auth_hash
       end
 

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -194,30 +194,16 @@ describe Doorkeeper::OAuth::PreAuthorization do
       end
     end
 
-    context "when attributes param is not passed" do
+    context "when called without params" do
       let(:json) { subject.as_json }
 
       include_examples "returns the pre authorization"
     end
 
-    context "when attributes param is passed" do
-      context "when attributes is a hash" do
-        let(:custom_attributes) { { custom_id: "1234", custom_name: "a pretty good name" } }
-        let(:json) { subject.as_json(custom_attributes) }
+    context "when called with params" do
+      let(:json) { subject.as_json(foo: "bar") }
 
-        include_examples "returns the pre authorization"
-
-        it "merges the attributes in params" do
-          expect(json[:custom_id]).to eq custom_attributes[:custom_id]
-          expect(json[:custom_name]).to eq custom_attributes[:custom_name]
-        end
-      end
-
-      context "when attributes is not a hash" do
-        let(:json) { subject.as_json(nil) }
-
-        include_examples "returns the pre authorization"
-      end
+      include_examples "returns the pre authorization"
     end
   end
 end


### PR DESCRIPTION
### Summary

Fixes #1312 
This PR removes the attributes merging from the PreAuthorization#as_json method and adds a default value to the `_options` param.
Merging the attributes with the `pre_auth_hash` was causing a Stack level too deep due to an incompatibility with Active Model Serializers (introduced in https://github.com/doorkeeper-gem/doorkeeper/pull/1288/).

