### PR TITLE
Deprecate active_record_options config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ User-visible changes worth mentioning.
 - [#1356] Invalidate duplicated scopes for Access Tokens and Grants in database.
 - [#1357] Fix `Doorkeeper::OAuth::PreAuthorization#as_json` method causing 
   `Stack level too deep` error with AMS (fix #1312).
+- [#1358] Deprecate `active_record_options` configuration option.
 - [#1359] Refactor Doorkeeper configuration options DSL to make it easy to reuse it
   in external extensions.
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -267,9 +267,12 @@ module Doorkeeper
     option :authorization_code_expires_in,  default: 600
     option :orm,                            default: :active_record
     option :native_redirect_uri,            default: "urn:ietf:wg:oauth:2.0:oob", deprecated: true
-    option :active_record_options,          default: {}
     option :grant_flows,                    default: %w[authorization_code client_credentials]
     option :handle_auth_errors,             default: :render
+
+    option :active_record_options,
+           default: {},
+           deprecated: { message: "Customize Doorkeeper models instead" }
 
     # Allows to customize OAuth grant flows that +each+ application support.
     # You can configure a custom block (or use a class respond to `#call`) that must

--- a/lib/doorkeeper/config/option.rb
+++ b/lib/doorkeeper/config/option.rb
@@ -42,20 +42,23 @@ module Doorkeeper
             remove_method name
           end
 
-          if options[:deprecated]
-            define_method name do |*_, &_|
-              Kernel.warn "[DOORKEEPER] #{name} has been deprecated and will soon be removed"
-            end
-          else
-            define_method name do |*args, &block|
-              value = if attribute_builder
-                        attribute_builder.new(&block).build
-                      else
-                        block || args.first
-                      end
+          define_method name do |*args, &block|
+            if (deprecation_opts = options[:deprecated])
+              warning = "[DOORKEEPER] #{name} has been deprecated and will soon be removed"
+              if deprecation_opts.is_a?(Hash)
+                warning = "#{warning}\n#{deprecation_opts.fetch(:message)}"
+              end
 
-              @config.instance_variable_set(:"@#{attribute}", value)
+              Kernel.warn(warning)
             end
+
+            value = if attribute_builder
+                      attribute_builder.new(&block).build
+                    else
+                      block || args.first
+                    end
+
+            @config.instance_variable_set(:"@#{attribute}", value)
           end
         end
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -565,6 +565,10 @@ describe Doorkeeper, "configuration" do
           expect(model).to receive(:establish_connection)
         end
 
+        expect(Kernel).to receive(:warn).with(
+          /\[DOORKEEPER\] active_record_options has been deprecated and will soon be removed/,
+        )
+
         Doorkeeper.configure do
           orm DOORKEEPER_ORM
           active_record_options(


### PR DESCRIPTION
Since we can customize models now from Doorkeeper 5.3 this option has no sense