### PR TITLE
Add `token_lookup_batch_size` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ User-visible changes worth mentioning.
 - [#1358] Deprecate `active_record_options` configuration option.
 - [#1359] Refactor Doorkeeper configuration options DSL to make it easy to reuse it
   in external extensions.
+- [#1360] Increase `matching_token_for` lookup size to 10 000 and make it configurable.
 
 ## 5.3.0
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -275,6 +275,7 @@ module Doorkeeper
     option :native_redirect_uri,            default: "urn:ietf:wg:oauth:2.0:oob", deprecated: true
     option :grant_flows,                    default: %w[authorization_code client_credentials]
     option :handle_auth_errors,             default: :render
+    option :token_lookup_batch_size,        default: 10_000
 
     option :active_record_options,
            default: {},

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -122,8 +122,9 @@ module Doorkeeper
         return nil unless relation
 
         matching_tokens = []
+        batch_size = Doorkeeper.configuration.token_lookup_batch_size
 
-        find_access_token_in_batches(relation) do |batch|
+        find_access_token_in_batches(relation, batch_size: batch_size) do |batch|
           tokens = batch.select do |token|
             scopes_match?(token.scopes, scopes, application.try(:scopes))
           end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -134,6 +134,14 @@ Doorkeeper.configure do
   #
   # reuse_access_token
 
+  # In case you enabled `reuse_access_token` option Doorkeeper will try to find matching
+  # token using `matching_token_for` Access Token API that searches for valid records
+  # in batches in order not to pollute the memory with all the database records. By default
+  # Doorkeeper uses batch size of 10 000 records. You can increase or decrease this value
+  # depending on your needs and server capabilities.
+  #
+  # token_lookup_batch_size 10_000
+
   # Set a limit for token_reuse if using reuse_access_token option
   #
   # This option limits token_reusability to some extent.

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -645,6 +645,21 @@ describe Doorkeeper, "configuration" do
     end
   end
 
+  describe "token_lookup_batch_size" do
+    it "uses default doorkeeper value" do
+      expect(subject.token_lookup_batch_size).to eq(10_000)
+    end
+
+    it "can change the value" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        token_lookup_batch_size 100_000
+      end
+
+      expect(subject.token_lookup_batch_size).to eq(100_000)
+    end
+  end
+
   describe "strict_content_type" do
     it "is false by default" do
       expect(subject.enforce_content_type).to eq(false)

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -525,7 +525,7 @@ RSpec.describe Doorkeeper::AccessToken do
 
     it "returns only one token" do
       token = FactoryBot.create :access_token, default_attributes
-      last_token = described_class.matching_token_for(application, resource_owner_id, scopes)
+      last_token = described_class.matching_token_for(application, resource_owner, scopes)
       expect(last_token).to eq(token)
     end
 


### PR DESCRIPTION
In case you enabled `reuse_access_token` option Doorkeeper will try to find matching
token using `matching_token_for` Access Token API that searches for valid records
in batches in order not to pollute the memory with all the database records. By default
Doorkeeper uses batch size of 10 000 records. You can increase or decrease this value
depending on your needs and server capabilities.

```ruby
token_lookup_batch_size 10_000
```