### PR TITLE
Fix the broken link for GuardRails badge in README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/doorkeeper-gem/doorkeeper/badge.svg?branch=master)](https://coveralls.io/github/doorkeeper-gem/doorkeeper?branch=master)
 [![Security](https://hakiri.io/github/doorkeeper-gem/doorkeeper/master.svg)](https://hakiri.io/github/doorkeeper-gem/doorkeeper/master)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
-[![GuardRails badge](https://badges.production.guardrails.io/doorkeeper-gem/doorkeeper.svg?token=66768ce8f6995814df81f65a2cff40f739f688492704f973e62809e15599bb62)](https://dashboard.guardrails.io/default/gh/doorkeeper-gem/doorkeeper)
+[![GuardRails badge](https://badges.guardrails.io/doorkeeper-gem/doorkeeper.svg?token=66768ce8f6995814df81f65a2cff40f739f688492704f973e62809e15599bb62)](https://dashboard.guardrails.io/default/gh/doorkeeper-gem/doorkeeper)
 [![Dependabot](https://img.shields.io/badge/dependabot-enabled-success.svg)](https://dependabot.com)
 
 Doorkeeper is a gem (Rails engine) that makes it easy to introduce OAuth 2 provider


### PR DESCRIPTION
### Summary

The link for GuardRails badge in README is broken.

### Other Information
before
<img width="982" alt="スクリーンショット 2020-02-26 12 00 14" src="https://user-images.githubusercontent.com/17407489/75307732-cd878600-588f-11ea-8577-b1aaac054e97.png">

after
<img width="981" alt="スクリーンショット 2020-02-26 12 03 04" src="https://user-images.githubusercontent.com/17407489/75307809-0162ab80-5890-11ea-8993-5ff9a0790cc1.png">
