### PR TITLE
use unshift instead of push for updating LOAD_PATH

### DIFF
--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path("lib", __dir__)
+$LOAD_PATH.unshift File.expand_path("lib", __dir__)
 
 require "doorkeeper/version"
 


### PR DESCRIPTION
When another version is already installed the current implementation will prefer that instead of local version. This means a wrong version of the gem gets added to gemspec file when building from github source repo (for example when creating a debian package).