### PR TITLE
Sets expiry of token generated using refresh_token to that of original token [Fixes #1364]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ upgrade guides.
 User-visible changes worth mentioning.
 
 ## master
-
+- [#1366] Sets expiry of token generated using `refresh_token` to that of original token. (Fixes #1364) 
 - [#1354] Add option to authorize the calling user to access an application.
 - [#1355] Allow to enable polymorphic Resource Owner association for Access Token & Grant
   models (`use_polymorphic_resource_owner` configuration option).

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -57,7 +57,7 @@ module Doorkeeper
         attrs = {
           application_id: refresh_token.application_id,
           scopes: scopes.to_s,
-          expires_in: access_token_expires_in,
+          expires_in: refresh_token.expires_in,
           use_refresh_token: true,
         }
 
@@ -72,15 +72,6 @@ module Doorkeeper
             attributes[:previous_refresh_token] = refresh_token.refresh_token
           end
         end
-      end
-
-      def access_token_expires_in
-        context = Authorization::Token.build_context(
-          client,
-          Doorkeeper::OAuth::REFRESH_TOKEN,
-          scopes,
-        )
-        Authorization::Token.access_token_expires_in(server, context)
       end
 
       def validate_token_presence


### PR DESCRIPTION
This PR aims to fix #1364 .

See the following example:
### Doorkeeper Configuration
```
Doorkeeper.configure do
  # ...
  access_token_expires_in 3.hours

  custom_access_token_expires_in do |context|
     if context.grant_type == Doorkeeper::OAuth::PASSWORD
        1.hour
     elsif context.grant_type == Doorkeeper::OAuth::AUTHORIZATION_CODE
        2.hours
     end

  end

  use_refresh_token do |context|
     true
  end
  
# ...
end

```

### Behavior without this fix:

- When refreshing a token(originally created using authorization_code flow having the expiry of 2 hours), the new token will have an expiry of 3 hours.

- When refreshing a token(originally created using password flow having the expiry of 1 hour), the new token will have an expiry of 3 hours.

### Behavior after this fix:

- When refreshing a token(originally created using authorization_code flow having the expiry of 2 hours), the new token will also have an expiry of 2 hours.

- When refreshing a token(originally created using password flow having the expiry of 1 hour), the new token will also have an expiry of 1 hour.


