### PR TITLE
pass auth on after_successful_authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,19 @@ User-visible changes worth mentioning.
 - [#1354] Add option to authorize the calling user to access an application.
 - [#1355] Allow to enable polymorphic Resource Owner association for Access Token & Grant
   models (`use_polymorphic_resource_owner` configuration option).
-  
+
   **[IMPORTANT]** Review your custom patches or extensions for Doorkeeper internals if you
   have such - since now Doorkeeper passes Resource Owner instance to every objects and not
   just it's ID. More info could be found in GitHub PR description.
-  
+
 - [#1356] Remove duplicated scopes from Access Tokens and Grants on attribute assignment.
-- [#1357] Fix `Doorkeeper::OAuth::PreAuthorization#as_json` method causing 
+- [#1357] Fix `Doorkeeper::OAuth::PreAuthorization#as_json` method causing
   `Stack level too deep` error with AMS (fix #1312).
 - [#1358] Deprecate `active_record_options` configuration option.
 - [#1359] Refactor Doorkeeper configuration options DSL to make it easy to reuse it
   in external extensions.
 - [#1360] Increase `matching_token_for` lookup size to 10 000 and make it configurable.
+- [#1368] Pass auth on after_successful_authorization.
 
 ## 5.3.1
 
@@ -41,9 +42,9 @@ User-visible changes worth mentioning.
   If you were relying on access tokens being revoked once the same client
   requested a new access token, reenable it with `revoke_previous_client_credentials_token` in Doorkeeper
   initialization file.
-  
+
 ## 5.2.4
-  
+
 - [#1360] Backport: Increase `matching_token_for` batch lookup size to 10 000 and make it configurable.
 
 ## 5.2.3

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -95,13 +95,13 @@ module Doorkeeper
 
         before_successful_authorization
         auth = strategy.authorize
-        after_successful_authorization
+        after_successful_authorization(auth)
         auth
       end
     end
 
-    def after_successful_authorization
-      Doorkeeper.configuration.after_successful_authorization.call(self)
+    def after_successful_authorization(auth)
+      Doorkeeper.configuration.after_successful_authorization.call(self, auth)
     end
 
     def before_successful_authorization

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -91,13 +91,13 @@ module Doorkeeper
       @authorize_response ||= begin
         before_successful_authorization
         auth = strategy.authorize
-        after_successful_authorization unless auth.is_a?(Doorkeeper::OAuth::ErrorResponse)
+        after_successful_authorization(auth) unless auth.is_a?(Doorkeeper::OAuth::ErrorResponse)
         auth
       end
     end
 
-    def after_successful_authorization
-      Doorkeeper.configuration.after_successful_authorization.call(self)
+    def after_successful_authorization(auth)
+      Doorkeeper.configuration.after_successful_authorization.call(self, auth)
     end
 
     def before_successful_authorization

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -260,14 +260,14 @@ module Doorkeeper
 
     # Hooks for authorization
     option :before_successful_authorization,      default: ->(_context) {}
-    option :after_successful_authorization,       default: ->(_context) {}
+    option :after_successful_authorization,       default: ->(_context, _auth) {}
     # Hooks for strategies responses
     option :before_successful_strategy_response,  default: ->(_request) {}
     option :after_successful_strategy_response,   default: ->(_request, _response) {}
     # Allows to customize Token Introspection response
     option :custom_introspection_response,        default: ->(_token, _context) { {} }
 
-    option :skip_authorization,             default: ->(_routes) {}
+    option :skip_authorization,             default: ->(_context) {}
     option :access_token_expires_in,        default: 7200
     option :custom_access_token_expires_in, default: ->(_context) { nil }
     option :authorization_code_expires_in,  default: 600

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -363,7 +363,7 @@ describe Doorkeeper::AuthorizationsController, "implicit grant flow" do
 
       it "should call :after_successful_authorization callback" do
         expect(Doorkeeper.config)
-          .to receive_message_chain(:after_successful_authorization, :call).with(instance_of(described_class))
+          .to receive_message_chain(:after_successful_authorization, :call).with(instance_of(described_class), instance_of(Doorkeeper::OAuth::CodeResponse))
       end
     end
 
@@ -674,7 +674,7 @@ describe Doorkeeper::AuthorizationsController, "implicit grant flow" do
 
       it "should call :after_successful_authorization callback" do
         expect(Doorkeeper.configuration)
-          .to receive_message_chain(:after_successful_authorization, :call).with(instance_of(described_class))
+          .to receive_message_chain(:after_successful_authorization, :call).with(instance_of(described_class), instance_of(Doorkeeper::OAuth::CodeResponse))
       end
     end
 

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -111,7 +111,7 @@ describe Doorkeeper::TokensController do
 
       it "should call :after_successful_authorization callback" do
         expect(Doorkeeper.configuration)
-          .to receive_message_chain(:after_successful_authorization, :call).with(instance_of(described_class))
+          .to receive_message_chain(:after_successful_authorization, :call).with(instance_of(described_class), instance_of(Doorkeeper::OAuth::TokenResponse))
       end
     end
 


### PR DESCRIPTION
### Summary

I needed to correlate the session_id with an AccessGrant and then copy it to the AccessToken (to support back-channel logout). I added an sid column to both tables, but could not set it's value in 'after_successful_authorization', as the auth objects were not available. This change passes those auth objects to the callback so they can be modified.

### Other Information

An example of using this code to set the sid:

```ruby
after_successful_authorization do |controller, auth|
  case auth
  when Doorkeeper::OAuth::CodeResponse
    access_grant = auth.auth.token
    access_grant.sid = controller.session[:session_id]
    access_grant.save!

  when Doorkeeper::OAuth::TokenResponse
    case grant_type = controller.params[:grant_type]
    when 'authorization_code'
      # Copy the session id from the Doorkeeper::AccessGrant to the
      # Doorkeeper::AccessToken (to support single-sign-out)
      access_grant = controller.send(:strategy).request.grant

      access_token = auth.token
      access_token.sid = access_grant.sid
      access_token.save!
    when 'refresh_token'
      raise 'TODO'
    else
      raise "Not Implemented for grant_type: #{grant_type}"
    end
  else
    raise "Not Implemented for class: #{auth.class}"
  end
end
```