### PR TITLE
Revoke and issue client credentials token in a transaction with a row lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ User-visible changes worth mentioning.
   (for public clients) and `client_secret` (for private clients). Please update your apps to include that
   info in the revocation request payload.
 
+- [#1374] Revoke and issue client credentials token in a transaction with a row lock.
+
 ## 5.3.1
 
 - [#1360] Backport: Increase `matching_token_for` batch lookup size to 10 000 and make it configurable.

--- a/spec/lib/oauth/client_credentials/creator_spec.rb
+++ b/spec/lib/oauth/client_credentials/creator_spec.rb
@@ -18,9 +18,12 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
     end
 
     context "when reuse_access_token is true" do
+      before do
+        allow(Doorkeeper.config).to receive(:reuse_access_token).and_return(true)
+      end
+
       context "when expiration is disabled" do
         it "returns the existing valid token" do
-          allow(Doorkeeper.config).to receive(:reuse_access_token).and_return(true)
           existing_token = subject.call(client, scopes)
 
           result = subject.call(client, scopes)
@@ -34,7 +37,6 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
         let!(:existing_token) { subject.call(client, scopes, expires_in: 1000) }
 
         before do
-          allow(Doorkeeper.config).to receive(:reuse_access_token).and_return(true)
           allow(Doorkeeper.config).to receive(:token_reuse_limit).and_return(50)
           allow_any_instance_of(Doorkeeper::AccessToken).to receive(:expires_in_seconds).and_return(600)
         end
@@ -46,7 +48,7 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
           expect(result).to eq(existing_token)
         end
 
-        context "and when revoke_previous_client_credentials_token is true" do
+        context "and when revoke_previous_client_credentials_token is false" do
           before do
             allow(Doorkeeper.config).to receive(:revoke_previous_client_credentials_token).and_return(false)
           end
@@ -60,7 +62,6 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
 
       context "when existing token has crossed token_reuse_limit" do
         it "returns a new token" do
-          allow(Doorkeeper.config).to receive(:reuse_access_token).and_return(true)
           allow(Doorkeeper.config).to receive(:token_reuse_limit).and_return(50)
           existing_token = subject.call(client, scopes, expires_in: 1000)
 
@@ -74,7 +75,6 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
 
       context "when existing token has been expired" do
         it "returns a new token" do
-          allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(true)
           allow(Doorkeeper.configuration).to receive(:token_reuse_limit).and_return(50)
           existing_token = subject.call(client, scopes, expires_in: 1000)
 
@@ -88,8 +88,11 @@ class Doorkeeper::OAuth::ClientCredentialsRequest
     end
 
     context "when reuse_access_token is false" do
+      before do
+        allow(Doorkeeper.config).to receive(:reuse_access_token).and_return(false)
+      end
+
       it "returns a new token" do
-        allow(Doorkeeper.configuration).to receive(:reuse_access_token).and_return(false)
         existing_token = subject.call(client, scopes)
 
         result = subject.call(client, scopes)


### PR DESCRIPTION
### Summary

It's possible for concurrent requests for client credentials tokens to result in undefined behaviour when using `revoke_previous_client_credentials_token`. I've adapted the work in #712 to apply to client credentials tokens as well. This wraps the revocation and subsequent token creation in a transaction with a row lock on the old token.