### PR TITLE
Add AccessToken#create_for and use in RefreshTokenRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ User-visible changes worth mentioning.
 - [#1373] Make Doorkeeper routes mapper reusable in extensions.
 - [#1374] Revoke and issue client credentials token in a transaction with a row lock.
 - [#1384] Add context object with auth/pre_auth for authorization hooks.
+- [#1387] Add `AccessToken#create_for` and use in `RefreshTokenRequest`.
 
 ## 5.3.1
 

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -58,11 +58,11 @@ module Doorkeeper
           )
 
           @token = Doorkeeper.config.access_token_model.find_or_create_for(
-            pre_auth.client,
-            resource_owner,
-            pre_auth.scopes,
-            self.class.access_token_expires_in(Doorkeeper.config, context),
-            false,
+            application: pre_auth.client,
+            resource_owner: resource_owner,
+            scopes: pre_auth.scopes,
+            expires_in: self.class.access_token_expires_in(Doorkeeper.config, context),
+            use_refresh_token: false,
           )
         end
 

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -35,11 +35,11 @@ module Doorkeeper
       def find_or_create_access_token(client, resource_owner, scopes, server)
         context = Authorization::Token.build_context(client, grant_type, scopes)
         @access_token = server_config.access_token_model.find_or_create_for(
-          client,
-          resource_owner,
-          scopes,
-          Authorization::Token.access_token_expires_in(server, context),
-          Authorization::Token.refresh_token_enabled?(server, context),
+          application: client,
+          resource_owner: resource_owner,
+          scopes: scopes,
+          expires_in: Authorization::Token.access_token_expires_in(server, context),
+          use_refresh_token: Authorization::Token.refresh_token_enabled?(server, context),
         )
       end
 

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -14,8 +14,10 @@ module Doorkeeper
 
           with_revocation(existing_token: existing_token) do
             server_config.access_token_model.find_or_create_for(
-              client, nil, scopes, attributes[:expires_in],
-              attributes[:use_refresh_token],
+              application: client,
+              resource_owner: nil,
+              scopes: scopes,
+              **attributes,
             )
           end
         end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -49,28 +49,27 @@ module Doorkeeper
       end
 
       def create_access_token
-        @access_token = server_config.access_token_model.create!(access_token_attributes)
-      end
+        attributes = {}
 
-      def access_token_attributes
-        attrs = {
-          application_id: refresh_token.application_id,
-          scopes: scopes.to_s,
+        resource_owner =
+          if Doorkeeper.config.polymorphic_resource_owner?
+            refresh_token.resource_owner
+          else
+            refresh_token.resource_owner_id
+          end
+
+        if refresh_token_revoked_on_use?
+          attributes[:previous_refresh_token] = refresh_token.refresh_token
+        end
+
+        @access_token = server_config.access_token_model.create_for(
+          application: refresh_token.application,
+          resource_owner: resource_owner,
+          scopes: scopes,
           expires_in: refresh_token.expires_in,
           use_refresh_token: true,
-        }
-
-        if Doorkeeper.config.polymorphic_resource_owner?
-          attrs[:resource_owner] = refresh_token.resource_owner
-        else
-          attrs[:resource_owner_id] = refresh_token.resource_owner_id
-        end
-
-        attrs.tap do |attributes|
-          if refresh_token_revoked_on_use?
-            attributes[:previous_refresh_token] = refresh_token.refresh_token
-          end
-        end
+          **attributes,
+        )
       end
 
       def validate_token_presence


### PR DESCRIPTION
### Summary

I've extracted this refactor out of #1382.

`RefreshTokenRequest` is the only place in doorkeeper where tokens are created outside of `AccessToken#find_or_create_for`. I've fixed that in this PR.

Context: I looked through the commit history on lib/doorkeeper/oauth/refresh_token_request.rb and it seems to have a different form only because it was that way from the creation of the file. I didn't see any specific intent behind it being different.

Closes #1382.