### PR TITLE
Fix/enable_polymorphic_resource_owner generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ User-visible changes worth mentioning.
 - [#1354] Add `authorize_resource_owner_for_client` option to authorize the calling user to access an application.
 - [#1355] Allow to enable polymorphic Resource Owner association for Access Token & Grant
   models (`use_polymorphic_resource_owner` configuration option).
+- [#1392] Fix/enable_polymorphic_resource_owner generator.
   
   **[IMPORTANT]** Review your custom patches or extensions for Doorkeeper internals if you
   have such - since now Doorkeeper passes Resource Owner instance to every objects and not

--- a/lib/generators/doorkeeper/templates/enable_polymorphic_resource_owner_migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/enable_polymorphic_resource_owner_migration.rb.erb
@@ -5,7 +5,7 @@ class EnablePolymorphicResourceOwner < ActiveRecord::Migration<%= migration_vers
     add_column :oauth_access_tokens, :resource_owner_type, :string
     add_column :oauth_access_grants, :resource_owner_type, :string, null: false
 
-    add_index :oauth_access_tokens, [:resource_owner_id, :resource_owner_type]
-    add_index :oauth_access_grants, [:resource_owner_id, :resource_owner_type]
+    add_index :oauth_access_tokens, [:resource_owner_id, :resource_owner_type], name: 'polymorphic_owner_oauth_access_tokens'
+    add_index :oauth_access_grants, [:resource_owner_id, :resource_owner_type], name: 'polymorphic_owner_oauth_access_grants'
   end
 end


### PR DESCRIPTION

### Summary

Currently the names generated by the index are too long and trigger an error on migration, this change gives a (to me at least) clear name of the index while not triggering said error.

Error encountered: `ArgumentError: Index name 'index_oauth_access_tokens_on_resource_owner_id_and_resource_owner_type' on table 'oauth_access_tokens' is too long; the limit is 63 characters`

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating CHANGELOG.md file or are asked to update it by reviewers,
please add the changelog entry at the top of the file.

Thanks for contributing to Doorkeeper project!
