### PR TITLE
Require params using configured application model's param key

### DIFF
--- a/app/views/doorkeeper/applications/_form.html.erb
+++ b/app/views/doorkeeper/applications/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for application, url: doorkeeper_submit_path(application), html: { role: 'form' } do |f| %>
+<%= form_for application, url: doorkeeper_submit_path(application), as: :doorkeeper_application, html: { role: 'form' } do |f| %>
   <% if application.errors.any? %>
     <div class="alert alert-danger" data-alert><p><%= t('doorkeeper.applications.form.error') %></p></div>
   <% end %>


### PR DESCRIPTION
### Summary

In https://github.com/doorkeeper-gem/doorkeeper/pull/1371 controllers are updated to use the configured models. In my app I have configured a custom application model named `Api::Application`. This causes the application forms to render their input fields with names such as `api_application[name]` instead of the default `doorkeeper_application[name]`. However, the application controller still tries to require the `:doorkeeper_application` param, which in my case causes an ActionController::ParameterMissing exception to be raised when I try to submit an application form.

This PR fixes this by fixing the application form's input field prefix using form_for's `:as` option.  

### Other Information

I haven't updated CHANGELOG.md because I guess this change really belongs to https://github.com/doorkeeper-gem/doorkeeper/pull/1371, which already adds a proper CHANGELOG entry.

### Workaround

I worked around the issue by overriding my application model's `.model_name` class method to return `Doorkeeper::Application.model_name`. But this might not be an option for everyone.

Your review would be appreciated, thanks!
