### PR TITLE
Handle trying authorization with client credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ User-visible changes worth mentioning.
   custom configured application model.
 - [#1400] Correctly yield the application instance to `allow_grant_flow_for_client?` config
   option (fixes #1398).
+- [#1402] Handle trying authorization with client credentials.
 
 ## 5.4.0.rc1
 - [#1366] Sets expiry of token generated using `refresh_token` to that of original token. (Fixes #1364) 

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -7,13 +7,13 @@ module Doorkeeper
 
       validate :client_id, error: :invalid_request
       validate :client, error: :invalid_client
+      validate :client_supports_grant_flow, error: :unauthorized_client
       validate :resource_owner_authorize_for_client, error: :invalid_client
       validate :redirect_uri, error: :invalid_redirect_uri
       validate :params, error: :invalid_request
       validate :response_type, error: :unsupported_response_type
       validate :scopes, error: :invalid_scope
       validate :code_challenge_method, error: :invalid_code_challenge_method
-      validate :client_supports_grant_flow, error: :unauthorized_client
 
       attr_reader :client, :code_challenge, :code_challenge_method, :missing_param,
                   :redirect_uri, :resource_owner, :response_type, :state

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -77,6 +77,18 @@ describe Doorkeeper::OAuth::PreAuthorization do
     end
   end
 
+  context "when grant flow is client credentials & redirect_uri is nil" do
+    before do
+      allow(server).to receive(:grant_flows).and_return(["client_credentials"])
+      allow(Doorkeeper.configuration).to receive(:allow_grant_flow_for_client?).and_return(false)
+      application.update_column :redirect_uri, nil
+    end
+
+    it "is not authorizable" do
+      expect(subject).not_to be_authorizable
+    end
+  end
+
   context "client application does not restrict valid scopes" do
     it "accepts valid scopes" do
       attributes[:scope] = "public"


### PR DESCRIPTION
When trying to start a new authorization for an application with grant
flow 'client_credentials' (which also has redirect_uri nil), the
following error occurs:

NoMethodError: undefined method `split' for nil:NilClass

lib/doorkeeper/oauth/helpers/uri_checker.rb:66 valid_for_authorization?
lib/doorkeeper/oauth/pre_authorization.rb:89 validate_redirect_uri
lib/doorkeeper/validations.rb:13 block in validate
lib/doorkeeper/validations.rb:12 each
lib/doorkeeper/validations.rb:12 validate
lib/doorkeeper/validations.rb:19 valid?
lib/doorkeeper/oauth/pre_authorization.rb:32 authorizable?
app/controllers/doorkeeper/authorizations_controller.rb:8 new

Moving the validation for supporting grant flows up, prevents this
error from happening (and shows an error message to the user, instead of
a 500 Internal Server Error).