### PR TITLE
Make Doorkeeper::Application#read_attribute_for_serialization public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Your PR description.
+- [#1404] Make `Doorkeeper::Application#read_attribute_for_serialization` public
 
 ## 5.4.0.rc2
 

--- a/lib/doorkeeper/orm/active_record/mixins/application.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/application.rb
@@ -88,6 +88,17 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
         Doorkeeper.configuration.authorize_resource_owner_for_client.call(self, resource_owner)
       end
 
+      # We need to hook into this method to allow serializing plan-text secrets
+      # when secrets hashing enabled.
+      #
+      # @param key [String] attribute name
+      #
+      def read_attribute_for_serialization(key)
+        return super unless key.to_s == "secret"
+
+        plaintext_secret || secret
+      end
+
       private
 
       def generate_uid
@@ -133,17 +144,6 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
 
         only -= Array.wrap(opts[:except]).map(&:to_s) if opts.key?(:except)
         only.uniq
-      end
-
-      # We need to hook into this method to allow serializing plan-text secrets
-      # when secrets hashing enabled.
-      #
-      # @param key [String] attribute name
-      #
-      def read_attribute_for_serialization(key)
-        return super unless key.to_s == "secret"
-
-        plaintext_secret || secret
       end
 
       # Collection of attributes that could be serialized for public.


### PR DESCRIPTION
### Summary

Making ` Doorkeeper::Application#read_attribute_for_serialization` public allows for gem users to create their own `ActiveModel::Serializer` implementations.

Otherwise, you run into something like:

```
NoMethodError (private method `read_attribute_for_serialization' called for #<Doorkeeper::Application:0x00007fcdc2844468>
```
