### PR TITLE
Properly memoize `current_resource_owner` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#PR ID] Your PR description.
+- [#1410] Properly memoize `current_resource_owner` value (consider `nil` and `false` values).
 
 ## 5.4.0
 

--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -16,6 +16,8 @@ module Doorkeeper
 
       # :doc:
       def current_resource_owner
+        return @current_resource_owner if defined?(@current_resource_owner)
+
         @current_resource_owner ||= begin
           instance_eval(&Doorkeeper.config.authenticate_resource_owner)
         end


### PR DESCRIPTION
Properly memoize `current_resource_owner` value (consider `nil` and `false` values).