### PR TITLE
Ignore PKCE params for non-PKCE grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#1410] Properly memoize `current_resource_owner` value (consider `nil` and `false` values).
+- [#1415] Ignore PKCE params for non-PKCE grants.
 
 ## 5.4.0
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,7 +93,6 @@ en:
         invalid_request:
           unknown: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
           missing_param: 'Missing required parameter: %{value}.'
-          not_support_pkce: 'Invalid code_verifier parameter. Server does not support pkce.'
           request_not_authorized: 'Request need to be authorized. Required parameter for authorizing request is missing or invalid.'
         invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
         unauthorized_client: 'The client is not authorized to perform this request using this method.'

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -117,6 +117,8 @@ module Doorkeeper
       end
 
       def validate_code_challenge_method
+        return true unless Doorkeeper.config.access_grant_model.pkce_supported?
+
         code_challenge.blank? ||
           (code_challenge_method.present? && code_challenge_method =~ /^plain$|^S256$/)
       end

--- a/spec/lib/oauth/invalid_request_response_spec.rb
+++ b/spec/lib/oauth/invalid_request_response_spec.rb
@@ -30,20 +30,6 @@ RSpec.describe Doorkeeper::OAuth::InvalidRequestResponse do
       end
     end
 
-    context "when server doesn't support PKCE" do
-      let(:request) { double(invalid_request_reason: :not_support_pkce) }
-
-      it "sets a description" do
-        expect(response.description).to eq(
-          I18n.t(:not_support_pkce, scope: %i[doorkeeper errors messages invalid_request]),
-        )
-      end
-
-      it "sets the reason" do
-        expect(response.reason).to eq(:not_support_pkce)
-      end
-    end
-
     context "when request is not authorized" do
       let(:request) { double(invalid_request_reason: :request_not_authorized) }
 

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -227,4 +227,49 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
       include_examples "returns the pre authorization"
     end
   end
+
+  context "when using PKCE params" do
+    context "when PKCE is supported" do
+      before do
+        allow(Doorkeeper::AccessGrant).to receive(:pkce_supported?).and_return(true)
+      end
+
+      it "accepts a blank code_challenge" do
+        attributes[:code_challenge] = " "
+
+        expect(pre_auth).to be_authorizable
+      end
+
+      it "accepts a code_challenge with a known code_challenge_method" do
+        attributes[:code_challenge] = "a45a9fea-0676-477e-95b1-a40f72ac3cfb"
+        attributes[:code_challenge_method] = "plain"
+
+        expect(pre_auth).to be_authorizable
+
+        attributes[:code_challenge_method] = "S256"
+
+        expect(pre_auth).to be_authorizable
+      end
+
+      it "rejects unknown values for code_challenge_method" do
+        attributes[:code_challenge] = "a45a9fea-0676-477e-95b1-a40f72ac3cfb"
+        attributes[:code_challenge_method] = "unknown"
+
+        expect(pre_auth).not_to be_authorizable
+      end
+    end
+
+    context "when PKCE is not supported" do
+      before do
+        allow(Doorkeeper::AccessGrant).to receive(:pkce_supported?).and_return(false)
+      end
+
+      it "accepts unknown values for code_challenge_method" do
+        attributes[:code_challenge] = "a45a9fea-0676-477e-95b1-a40f72ac3cfb"
+        attributes[:code_challenge_method] = "unknown"
+
+        expect(pre_auth).to be_authorizable
+      end
+    end
+  end
 end

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -223,13 +223,7 @@ feature "Authorization Code Flow" do
         visit authorization_endpoint_url(client: @client)
         click_on "Authorize"
 
-        authorization_code = current_params["code"]
-        create_access_token authorization_code, @client, code_verifier
-
-        expect(json_response).to match(
-          "error" => "invalid_grant",
-          "error_description" => translated_error_message(:invalid_grant),
-        )
+        url_should_have_param("code", Doorkeeper::AccessGrant.first.token)
       end
 
       scenario "mobile app requests an access token with authorization code and plain code challenge method" do


### PR DESCRIPTION
# Summary

This aligns the behavior with sections 3.1 and 3.2 from RFC 6749:

> The authorization server MUST ignore unrecognized request parameters.

https://tools.ietf.org/html/rfc6749#section-3.1
https://tools.ietf.org/html/rfc6749#section-3.2

### Other Information

Closes https://github.com/doorkeeper-gem/doorkeeper/issues/1411