### PR TITLE
Add ability to register custom Grant Flows

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Exclude:
     - spec/dummy/db/**/*
+Style/CaseEquality:
+  Exclude:
+    - lib/doorkeeper/grant_flow/flow.rb
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 Style/StringLiteralsInInterpolation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Layout/DotPosition:
 Layout/LineLength:
   Exclude:
     - spec/**/*
-  Max: 100
+  Max: 120 # Remove after we migration to 0.84
 Metrics/BlockLength:
   Exclude:
     - spec/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ User-visible changes worth mentioning.
 - [#1416] Don't add introspection route if token introspection completely disabled.
 - [#1410] Properly memoize `current_resource_owner` value (consider `nil` and `false` values).
 - [#1415] Ignore PKCE params for non-PKCE grants.
+- [#1418] Add ability to register custom OAuth Grant Flows based on certain rules.
 
 ## 5.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ User-visible changes worth mentioning.
 - [#1416] Don't add introspection route if token introspection completely disabled.
 - [#1410] Properly memoize `current_resource_owner` value (consider `nil` and `false` values).
 - [#1415] Ignore PKCE params for non-PKCE grants.
-- [#1418] Add ability to register custom OAuth Grant Flows based on certain rules.
+- [#1418] Add ability to register custom OAuth Grant Flows.
 
 ## 5.4.0
 

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -7,6 +7,7 @@ require "doorkeeper/engine"
 #
 module Doorkeeper
   autoload :Errors, "doorkeeper/errors"
+  autoload :GrantFlow, "doorkeeper/grant_flow"
   autoload :OAuth, "doorkeeper/oauth"
   autoload :Rake, "doorkeeper/rake"
   autoload :Request, "doorkeeper/request"

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -558,15 +558,11 @@ module Doorkeeper
       @token_grant_flows ||= calculate_token_grant_flows
     end
 
-    # [NOTE]: deprecated and will be removed soon
     def authorization_response_types
-      ::Kernel.warn "##{__method__} no more supported, use #authorization_response_flows instead"
       authorization_response_flows.map(&:response_type_matches)
     end
 
-    # [NOTE]: deprecated and will be removed soon
     def token_grant_types
-      ::Kernel.warn "##{__method__} no more supported, use #authorization_response_flows instead"
       token_grant_flows.map(&:grant_type_matches)
     end
 
@@ -606,7 +602,7 @@ module Doorkeeper
 
     def calculate_grant_flows
       flows = grant_flows.map(&:to_s) - aliased_grant_flows.keys.map(&:to_s)
-      flows.concat(aliased_grant_flows.values).flatten
+      flows.concat(aliased_grant_flows.values).flatten.uniq
     end
 
     def aliased_grant_flows

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -567,6 +567,22 @@ module Doorkeeper
       @token_grant_flows ||= calculate_token_grant_flows
     end
 
+    def calculate_authorization_response_types
+      ::Kernel.warn <<~WARNING
+        #{__method__} was removed and now you need to register your custom grant flows
+        using `Doorkeeper::GrantFlow.register(name, **options)`.
+      WARNING
+      []
+    end
+
+    def calculate_token_grant_types
+      ::Kernel.warn <<~WARNING
+        #{__method__} was removed and now you need to register your custom grant flows
+        using `Doorkeeper::GrantFlow.register(name, **options)`.
+      WARNING
+      []
+    end
+
     def allow_blank_redirect_uri?(application = nil)
       if allow_blank_redirect_uri.respond_to?(:call)
         allow_blank_redirect_uri.call(grant_flows, application)
@@ -595,7 +611,7 @@ module Doorkeeper
 
     def calculate_token_grant_flows
       flows = enabled_grant_flows.select(&:handles_grant_type?)
-      flows << GrantFlow.get("refresh_token") if refresh_token_enabled?
+      flows << Doorkeeper::GrantFlow.get("refresh_token") if refresh_token_enabled?
       flows
     end
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -546,7 +546,7 @@ module Doorkeeper
     end
 
     def enabled_grant_flows
-      @enabled_grant_flows ||= grant_flows.map { |name| Doorkeeper::GrantFlow.get(name) }.compact
+      @enabled_grant_flows ||= calculate_grant_flows.map { |name| Doorkeeper::GrantFlow.get(name) }.compact
     end
 
     def authorization_response_flows
@@ -602,6 +602,15 @@ module Doorkeeper
       types = grant_flows - ["implicit"]
       types << "refresh_token" if refresh_token_enabled?
       types
+    end
+
+    def calculate_grant_flows
+      flows = grant_flows.map(&:to_s) - aliased_grant_flows.keys.map(&:to_s)
+      flows.concat(aliased_grant_flows.values).flatten
+    end
+
+    def aliased_grant_flows
+      Doorkeeper::GrantFlow.aliases
     end
 
     def allow_blank_redirect_uri?(application = nil)

--- a/lib/doorkeeper/config/validations.rb
+++ b/lib/doorkeeper/config/validations.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  class Config
+    # Doorkeeper configuration validator.
+    #
+    module Validations
+      # Validates configuration options to be set properly.
+      #
+      def validate!
+        validate_reuse_access_token_value
+        validate_token_reuse_limit
+        validate_secret_strategies
+      end
+
+      private
+
+      # Determine whether +reuse_access_token+ and a non-restorable
+      # +token_secret_strategy+ have both been activated.
+      #
+      # In that case, disable reuse_access_token value and warn the user.
+      def validate_reuse_access_token_value
+        strategy = token_secret_strategy
+        return if !reuse_access_token || strategy.allows_restoring_secrets?
+
+        ::Rails.logger.warn(
+          "You have configured both reuse_access_token " \
+          "AND strategy strategy '#{strategy}' that cannot restore tokens. " \
+          "This combination is unsupported. reuse_access_token will be disabled",
+        )
+        @reuse_access_token = false
+      end
+
+      # Validate that the provided strategies are valid for
+      # tokens and applications
+      def validate_secret_strategies
+        token_secret_strategy.validate_for(:token)
+        application_secret_strategy.validate_for(:application)
+      end
+
+      def validate_token_reuse_limit
+        return if !reuse_access_token ||
+                  (token_reuse_limit > 0 && token_reuse_limit <= 100)
+
+        ::Rails.logger.warn(
+          "You have configured an invalid value for token_reuse_limit option. " \
+          "It will be set to default 100",
+        )
+        @token_reuse_limit = 100
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/grant_flow.rb
+++ b/lib/doorkeeper/grant_flow.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "doorkeeper/grant_flow/flow"
+require "doorkeeper/grant_flow/fallback_flow"
+require "doorkeeper/grant_flow/registry"
+
+module Doorkeeper
+  module GrantFlow
+    extend Registry
+
+    register(
+      :implicit,
+      response_type_matches: "token",
+      response_type_strategy: Doorkeeper::Request::Token,
+    )
+
+    register(
+      :authorization_code,
+      response_type_matches: "code",
+      response_type_strategy: Doorkeeper::Request::Code,
+      grant_type_matches: "authorization_code",
+      grant_type_strategy: Doorkeeper::Request::AuthorizationCode,
+    )
+
+    register(
+      :client_credentials,
+      grant_type_matches: "client_credentials",
+      grant_type_strategy: Doorkeeper::Request::ClientCredentials,
+    )
+
+    register(
+      :password,
+      grant_type_matches: "password",
+      grant_type_strategy: Doorkeeper::Request::Password,
+    )
+
+    register(
+      :refresh_token,
+      grant_type_matches: "refresh_token",
+      grant_type_strategy: Doorkeeper::Request::RefreshToken,
+    )
+  end
+end

--- a/lib/doorkeeper/grant_flow/fallback_flow.rb
+++ b/lib/doorkeeper/grant_flow/fallback_flow.rb
@@ -2,20 +2,12 @@
 
 module Doorkeeper
   module GrantFlow
-    class FallbackFlow
+    class FallbackFlow < Flow
       def handles_grant_type?
         false
       end
 
       def handles_response_type?
-        false
-      end
-
-      def matches_grant_type?(_value)
-        false
-      end
-
-      def matches_response_type?(_value)
         false
       end
     end

--- a/lib/doorkeeper/grant_flow/fallback_flow.rb
+++ b/lib/doorkeeper/grant_flow/fallback_flow.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module GrantFlow
+    class FallbackFlow
+      def handles_grant_type?
+        false
+      end
+
+      def handles_response_type?
+        false
+      end
+
+      def matches_grant_type?(_value)
+        false
+      end
+
+      def matches_response_type?(_value)
+        false
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/grant_flow/flow.rb
+++ b/lib/doorkeeper/grant_flow/flow.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module GrantFlow
+    class Flow
+      attr_reader :name, :grant_type_matches, :grant_type_strategy,
+                  :response_type_matches, :response_type_strategy
+
+      def initialize(name, **options)
+        @name = name
+        @grant_type_matches = options[:grant_type_matches]
+        @grant_type_strategy = options[:grant_type_strategy]
+        @response_type_matches = options[:response_type_matches]
+        @response_type_strategy = options[:response_type_strategy]
+      end
+
+      def handles_grant_type?
+        grant_type_matches.present?
+      end
+
+      def handles_response_type?
+        response_type_matches.present?
+      end
+
+      def matches_grant_type?(value)
+        grant_type_matches === value
+      end
+
+      def matches_response_type?(value)
+        response_type_matches === value
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/grant_flow/registry.rb
+++ b/lib/doorkeeper/grant_flow/registry.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module GrantFlow
+    module Registry
+      mattr_accessor :flows
+      self.flows = {}
+
+      # Only for retro-compatibility, will be removed soon
+      FALLBACK_FLOW = FallbackFlow.new
+
+      def register(name_or_flow, **options)
+        unless name_or_flow.is_a?(Doorkeeper::GrantFlow::Flow)
+          name_or_flow = Flow.new(name_or_flow, **options)
+        end
+
+        flows[name_or_flow.name.to_sym] = name_or_flow
+      end
+
+      def get(name)
+        flows.fetch(name.to_sym, FALLBACK_FLOW)
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/grant_flow/registry.rb
+++ b/lib/doorkeeper/grant_flow/registry.rb
@@ -6,9 +6,6 @@ module Doorkeeper
       mattr_accessor :flows
       self.flows = {}
 
-      # Only for retro-compatibility, will be removed soon
-      FALLBACK_FLOW = FallbackFlow.new
-
       def register(name_or_flow, **options)
         unless name_or_flow.is_a?(Doorkeeper::GrantFlow::Flow)
           name_or_flow = Flow.new(name_or_flow, **options)
@@ -17,8 +14,9 @@ module Doorkeeper
         flows[name_or_flow.name.to_sym] = name_or_flow
       end
 
+      # [NOTE]: make it to use #fetch after removing fallbacks
       def get(name)
-        flows.fetch(name.to_sym, FALLBACK_FLOW)
+        flows[name.to_sym]
       end
     end
   end

--- a/lib/doorkeeper/grant_flow/registry.rb
+++ b/lib/doorkeeper/grant_flow/registry.rb
@@ -21,11 +21,11 @@ module Doorkeeper
       end
 
       # Allows to register aliases that could be used in `grant_flows`
-      # configuration option and then exposed to single or multiple other flows
-      # under the hood.
+      # configuration option. It is possible to have aliases like 1:1 or
+      # 1:N, i.e. "implicit_oidc" => ['token', 'id_token', 'id_token token'].
       #
-      def register_alias(alias_name, *flows)
-        aliases[alias_name.to_sym] = flows
+      def register_alias(alias_name, **options)
+        aliases[alias_name.to_sym] = Array.wrap(options.fetch(:as))
       end
 
       # [NOTE]: make it to use #fetch after removing fallbacks

--- a/lib/doorkeeper/grant_flow/registry.rb
+++ b/lib/doorkeeper/grant_flow/registry.rb
@@ -6,12 +6,26 @@ module Doorkeeper
       mattr_accessor :flows
       self.flows = {}
 
+      mattr_accessor :aliases
+      self.aliases = {}
+
+      # Allows to register custom OAuth grant flow so that Doorkeeper
+      # could recognize and process it.
+      #
       def register(name_or_flow, **options)
         unless name_or_flow.is_a?(Doorkeeper::GrantFlow::Flow)
           name_or_flow = Flow.new(name_or_flow, **options)
         end
 
         flows[name_or_flow.name.to_sym] = name_or_flow
+      end
+
+      # Allows to register aliases that could be used in `grant_flows`
+      # configuration option and then exposed to single or multiple other flows
+      # under the hood.
+      #
+      def register_alias(alias_name, *flows)
+        aliases[alias_name.to_sym] = flows
       end
 
       # [NOTE]: make it to use #fetch after removing fallbacks

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -104,7 +104,9 @@ module Doorkeeper
       end
 
       def validate_response_type
-        server.authorization_response_types.include?(response_type)
+        server.authorization_response_flows.any? do |flow|
+          flow.matches_response_type?(response_type)
+        end
       end
 
       def validate_scopes

--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -15,7 +15,7 @@ module Doorkeeper
           # For retro-compatibility only
           fallback_strategy = build_fallback_strategy_class(response_type)
 
-          Kernel.warn <<~WARNING
+          ::Kernel.warn <<~WARNING
             [DOORKEEPER] #{fallback_strategy} found using fallback, it must be
             registered using `Doorkeeper::GrantFlow.register(name, **options)`.
             This functionality will be remove in a newer versions of Doorkeeper.

--- a/lib/doorkeeper/request.rb
+++ b/lib/doorkeeper/request.rb
@@ -4,30 +4,50 @@ module Doorkeeper
   module Request
     class << self
       def authorization_strategy(response_type)
-        build_strategy_class(response_type)
+        grant_flow = authorization_flows.detect do |flow|
+          flow.matches_response_type?(response_type)
+        end
+
+        if grant_flow
+          grant_flow.response_type_strategy
+        else
+          # [NOTE]: this will be removed in a newer versions of Doorkeeper.
+          # For retro-compatibility only
+          fallback_strategy = build_fallback_strategy_class(response_type)
+
+          Kernel.warn <<~WARNING
+            [DOORKEEPER] #{fallback_strategy} found using fallback, it must be
+            registered using `Doorkeeper::GrantFlow.register(name, **options)`.
+            This functionality will be remove in a newer versions of Doorkeeper.
+          WARNING
+
+          fallback_strategy
+        end
       end
 
       def token_strategy(grant_type)
         raise Errors::MissingRequiredParameter, :grant_type if grant_type.blank?
 
-        get_strategy(grant_type, token_grant_types)
-      rescue NameError
-        raise Errors::InvalidTokenStrategy
-      end
+        grant_flow = token_flows.detect do |flow|
+          flow.matches_grant_type?(grant_type)
+        end
 
-      def get_strategy(grant_type, available)
-        raise NameError unless available.include?(grant_type.to_s)
+        raise Errors::InvalidTokenStrategy unless grant_flow
 
-        build_strategy_class(grant_type)
+        grant_flow.grant_type_strategy
       end
 
       private
 
-      def token_grant_types
-        Doorkeeper.config.token_grant_types
+      def authorization_flows
+        Doorkeeper.configuration.authorization_response_flows
       end
 
-      def build_strategy_class(grant_or_request_type)
+      def token_flows
+        Doorkeeper.configuration.token_grant_flows
+      end
+
+      def build_fallback_strategy_class(grant_or_request_type)
         strategy_class_name = grant_or_request_type.to_s.tr(" ", "_").camelize
         "Doorkeeper::Request::#{strategy_class_name}".constantize
       end

--- a/spec/doorkeeper/server_spec.rb
+++ b/spec/doorkeeper/server_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe Doorkeeper::Server do
     end
 
     it "builds the request with composite strategy name" do
-      allow(Doorkeeper.configuration)
-        .to receive(:authorization_response_types)
-        .and_return(["id_token token"])
+      Doorkeeper.configure do
+        grant_flows ["id_token token"]
+      end
 
       stub_const "Doorkeeper::Request::IdTokenToken", fake_class
       expect(fake_class).to receive(:new).with(server)

--- a/spec/doorkeeper/server_spec.rb
+++ b/spec/doorkeeper/server_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Doorkeeper::Server do
     it "builds the request with selected strategy" do
       stub_const "Doorkeeper::Request::Code", fake_class
       expect(fake_class).to receive(:new).with(server)
+      expect(::Kernel).to receive(:warn)
       server.authorization_request :code
     end
 
@@ -44,6 +45,7 @@ RSpec.describe Doorkeeper::Server do
 
       stub_const "Doorkeeper::Request::IdTokenToken", fake_class
       expect(fake_class).to receive(:new).with(server)
+      expect(::Kernel).to receive(:warn)
       server.authorization_request "id_token token"
     end
   end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -191,8 +191,8 @@ RSpec.describe Doorkeeper::Config do
       expect(config.refresh_token_enabled?).to be_a(Proc)
     end
 
-    it "does not includes 'refresh_token' in authorization_response_types" do
-      expect(config.token_grant_types).not_to include "refresh_token"
+    it "does not includes 'refresh_token' in token_grant_flows" do
+      expect(config.token_grant_flows).not_to include Doorkeeper::GrantFlow.get("refresh_token")
     end
 
     context "when enabled" do
@@ -203,8 +203,8 @@ RSpec.describe Doorkeeper::Config do
         end
       end
 
-      it "includes 'refresh_token' in authorization_response_types" do
-        expect(config.token_grant_types).to include "refresh_token"
+      it "includes 'refresh_token' in token_grant_flows" do
+        expect(config.token_grant_flows).to include Doorkeeper::GrantFlow.get("refresh_token")
       end
     end
   end
@@ -406,12 +406,12 @@ RSpec.describe Doorkeeper::Config do
         end
       end
 
-      it "includes 'code' in authorization_response_types" do
-        expect(config.authorization_response_types).to include "code"
+      it "includes 'authorization_code' in authorization_response_flows" do
+        expect(config.authorization_response_flows).to include Doorkeeper::GrantFlow.get("authorization_code")
       end
 
-      it "includes 'authorization_code' in token_grant_types" do
-        expect(config.token_grant_types).to include "authorization_code"
+      it "includes 'authorization_code' in token_grant_flows" do
+        expect(config.token_grant_flows).to include Doorkeeper::GrantFlow.get("authorization_code")
       end
     end
 
@@ -423,8 +423,8 @@ RSpec.describe Doorkeeper::Config do
         end
       end
 
-      it "includes 'token' in authorization_response_types" do
-        expect(config.authorization_response_types).to include "token"
+      it "includes 'implicit' in authorization_response_flows" do
+        expect(config.authorization_response_flows).to include Doorkeeper::GrantFlow.get("implicit")
       end
     end
 
@@ -436,8 +436,8 @@ RSpec.describe Doorkeeper::Config do
         end
       end
 
-      it "includes 'password' in token_grant_types" do
-        expect(config.token_grant_types).to include "password"
+      it "includes 'password' in token_grant_flows" do
+        expect(config.token_grant_flows).to include Doorkeeper::GrantFlow.get("password")
       end
     end
 
@@ -449,8 +449,8 @@ RSpec.describe Doorkeeper::Config do
         end
       end
 
-      it "includes 'client_credentials' in token_grant_types" do
-        expect(config.token_grant_types).to include "client_credentials"
+      it "includes 'client_credentials' in token_grant_flows" do
+        expect(config.token_grant_flows).to include Doorkeeper::GrantFlow.get("client_credentials")
       end
     end
   end

--- a/spec/lib/grant_flow/flow_spec.rb
+++ b/spec/lib/grant_flow/flow_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::GrantFlow::Flow do
+  subject(:flow) { described_class.new(name, **options) }
+
+  let(:name) { "secret_handshake" }
+  let(:options) { {} }
+
+  it "reflects the given name" do
+    expect(flow.name).to eq name
+  end
+
+  context "with neither grant_type nor response_type" do
+    it "does not handle grant_type" do
+      expect(flow.handles_grant_type?).to be false
+    end
+
+    it "does not handle response_type" do
+      expect(flow.handles_response_type?).to be false
+    end
+  end
+
+  context "when given a grant_type to match" do
+    let(:grant_type_matches) { "secret_handshake" }
+    let(:options) { { grant_type_matches: grant_type_matches } }
+
+    it "handles grant_type" do
+      expect(flow.handles_grant_type?).to be true
+    end
+
+    context "when grant_type_matches is a string" do
+      it "matches grant_type values" do
+        expect(flow.matches_grant_type?(grant_type_matches)).to be true
+      end
+    end
+
+    context "when grant_type_matches is a regular expression" do
+      let(:grant_type_matches) { /^secret_(.*)$/ }
+
+      it "matches grant_type values" do
+        expect(flow.matches_grant_type?("secret_boogie")).to be true
+      end
+    end
+  end
+
+  context "when given a response_type to match" do
+    let(:response_type_matches) { "secret_handshake" }
+    let(:options) { { response_type_matches: response_type_matches } }
+
+    it "handles response_type" do
+      expect(flow.handles_response_type?).to be true
+    end
+
+    context "when response_type_matches is a string" do
+      it "matches response_type values" do
+        expect(flow.matches_response_type?(response_type_matches)).to be true
+      end
+    end
+
+    context "when response_type_matches is a regular expression" do
+      let(:response_type_matches) { /^secret_(.*)$/ }
+
+      it "matches response_type values" do
+        expect(flow.matches_response_type?("secret_boogie")).to be true
+      end
+    end
+  end
+end

--- a/spec/lib/grant_flow_spec.rb
+++ b/spec/lib/grant_flow_spec.rb
@@ -45,4 +45,18 @@ RSpec.describe Doorkeeper::GrantFlow do
       end
     end
   end
+
+  describe "#register_alias" do
+    it "allows to alias multiple grant flows" do
+      described_class.register_alias("implicit_oidc", as: ["token", "id_token", "id_token token"])
+
+      expect(described_class.aliases).to include(implicit_oidc: ["token", "id_token", "id_token token"])
+    end
+
+    it "allows to alias a single grant flow" do
+      described_class.register_alias("implicit_oidc", as: :id_token)
+
+      expect(described_class.aliases).to include(implicit_oidc: [:id_token])
+    end
+  end
 end

--- a/spec/lib/grant_flow_spec.rb
+++ b/spec/lib/grant_flow_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::GrantFlow do
+  describe "#register" do
+    context "with a name and options" do
+      subject(:the_registered_flow) { described_class.get(name) }
+
+      let(:name) { "puzzle_box" }
+      let(:grant_type_matches) { "tile_position" }
+      let(:grant_type_strategy) { double }
+
+      before do
+        described_class.register(
+          name,
+          grant_type_matches: grant_type_matches,
+          grant_type_strategy: grant_type_strategy,
+        )
+      end
+
+      it "creates a new Flow" do
+        expect(the_registered_flow).to be_a(Doorkeeper::GrantFlow::Flow)
+      end
+
+      it "passes on the given name" do
+        expect(the_registered_flow.name).to eq name
+      end
+
+      it "sets the options" do
+        expect(the_registered_flow.grant_type_matches).to eq grant_type_matches
+        expect(the_registered_flow.grant_type_strategy).to eq grant_type_strategy
+      end
+    end
+
+    context "with an existing flow" do
+      let(:existing_flow) { Doorkeeper::GrantFlow::Flow.new("light") }
+
+      before do
+        described_class.register(existing_flow)
+      end
+
+      it "records the existing Flow using its name" do
+        expect(described_class.get(existing_flow.name)).to eq existing_flow
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow flexible extending of Doorkeeper with a new OAuth Grant Flows without adding them to the gem itself.

A new flow is registered like so:

```ruby
Doorkeeper::GrantFlow.register :authorization_code,
  response_type_matches: 'code',
  response_type_strategy: Doorkeeper::Request::Code,
  grant_type_matches: 'authorization_code',
  grant_type_strategy: Doorkeeper::Request::AuthorizationCode
```

Based on #733 with additions & retro-compatibility for next extensions:
* doorkeeper_openid-connect
* doorkeeper-grant_assertions

This changes allows to fix / implement:

* #764 (SAML)
* https://github.com/doorkeeper-gem/doorkeeper-grants_assertion/issues/9 (Assertions)

## TODO:

- [x] Implement custom grant flows registration
- [x] Allow multiple flows aliased with a one name in `grant_flows` (like in openid_connect)
- [x] Add specs