### PR TITLE
Make ROPG flow to require client auth as stated in the RFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ User-visible changes worth mentioning.
 - [#1410] Properly memoize `current_resource_owner` value (consider `nil` and `false` values).
 - [#1415] Ignore PKCE params for non-PKCE grants.
 - [#1418] Add ability to register custom OAuth Grant Flows.
+- [#1419] Require client authentication for Resource Owner Password Grant as stated in OAuth RFC.
+  
+  **[IMPORTANT]** you need to create a new OAuth client (`Doorkeeper::Application`) if yoo didn't
+    have it before and use client credentials in HTTP Basic auth if you previously used this grant
+    flow without client authentication. For migration purposes you could enable
+    `skip_client_authentication_for_password_grant` configuration option to `true`, but such behavior
+    (as well as configuration option) would be completely removed in a future version of Doorkeeper.
+    All the users of your provider application now need to include client credentials when they use
+    this grant flow.
 
 ## 5.4.0
 

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -69,6 +69,9 @@ module Doorkeeper
     private
 
     # OAuth 2.0 Section 2.1 defines two client types, "public" & "confidential".
+    #
+    # RFC7009
+    # Section 5. Security Considerations
     # A malicious client may attempt to guess valid tokens on this endpoint
     # by making revocation requests against potential token strings.
     # According to this specification, a client's request must contain a

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -270,6 +270,11 @@ module Doorkeeper
     option :handle_auth_errors,             default: :render
     option :token_lookup_batch_size,        default: 10_000
 
+    # [NOTE]: will be removed in a future version of Doorkeeper
+    option :skip_client_authentication_for_password_grant,
+           default: false,
+           deprecated: { message: "OAuth RFC requires client authentication so you need at least to create one" }
+
     # Sets the token_reuse_limit
     # It will be used only when reuse_access_token option in enabled
     # By default it will be 100

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -43,8 +43,27 @@ module Doorkeeper
         resource_owner.present?
       end
 
+      # Section 4.3.2. Access Token Request for Resource Owner Password Credentials Grant:
+      #
+      #   If the client type is confidential or the client was issued client credentials (or assigned
+      #   other authentication requirements), the client MUST authenticate with the authorization
+      #   server as described in Section 3.2.1.
+      #
+      #   The authorization server MUST:
+      #
+      #    o  require client authentication for confidential clients or for any  client that was
+      #       issued client credentials (or with other authentication requirements)
+      #
+      #    o  authenticate the client if client authentication is included,
+      #
+      #   @see https://tools.ietf.org/html/rfc6749#section-4.3
+      #
       def validate_client
-        !parameters[:client_id] || client.present?
+        if Doorkeeper.config.skip_client_authentication_for_password_grant
+          !parameters[:client_id] || client.present?
+        else
+          client.present?
+        end
       end
 
       def validate_client_supports_grant_flow

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -813,7 +813,7 @@ RSpec.describe Doorkeeper::Config do
   describe "options deprecation" do
     it "prints a warning message when an option is deprecated" do
       expect(Kernel).to receive(:warn).with(
-        "[DOORKEEPER] native_redirect_uri has been deprecated and will soon be removed",
+        /\[DOORKEEPER\] native_redirect_uri has been deprecated and will soon be removed/,
       )
       Doorkeeper.configure do
         orm DOORKEEPER_ORM

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -34,16 +34,16 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
     expect(application.reload.access_tokens.max_by(&:created_at).expires_in).to eq(1234)
   end
 
-  it "issues a new token without a client" do
+  it "doesn't issue a new token without client authentication" do
     request = described_class.new(server, nil, owner)
-    expect(request).to be_valid
-
     expect do
       request.authorize
-    end.to change { Doorkeeper::AccessToken.count }.by(1)
+    end.not_to(change { Doorkeeper::AccessToken.count })
+
+    expect(request.error).to eq(:invalid_client)
   end
 
-  it "does not issue a new token with an invalid client" do
+  it "doesn't issue a new token with an invalid client" do
     request = described_class.new(server, nil, owner, { client_id: "bad_id" })
     expect do
       request.authorize


### PR DESCRIPTION
Require client authentication for Resource Owner Password Grant as stated in OAuth RFC

  **[IMPORTANT]** you need to create a new OAuth client (`Doorkeeper::Application`) if yoo didn't
    have it before and use client credentials in HTTP Basic auth if you previously used this grant
    flow without client authentication. For migration purposes you could enable
    `skip_client_authentication_for_password_grant` configuration option to `true`, but such behavior
    (as well as configuration option) would be completely removed in a future version of Doorkeeper.
    All the users of your provider application now need to include client credentials when they use
    this grant flow.

Fixes https://github.com/doorkeeper-gem/doorkeeper/issues/1412#issuecomment-632750422