### PR TITLE
Add Resource Owner instance to authorization hook context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ User-visible changes worth mentioning.
     All the users of your provider application now need to include client credentials when they use
     this grant flow.
 
+- [#1421] Add Resource Owner instance to authorization hook context for `custom_access_token_expires_in`
+  configuration option to allow resource owner based Access Tokens TTL.
+
 ## 5.4.0
 
 - [#1404] Make `Doorkeeper::Application#read_attribute_for_serialization` public.

--- a/lib/doorkeeper/oauth/authorization/context.rb
+++ b/lib/doorkeeper/oauth/authorization/context.rb
@@ -4,12 +4,12 @@ module Doorkeeper
   module OAuth
     module Authorization
       class Context
-        attr_reader :client, :grant_type, :scopes
+        attr_reader :client, :grant_type, :resource_owner, :scopes
 
-        def initialize(client, grant_type, scopes)
-          @client = client
-          @grant_type = grant_type
-          @scopes = scopes
+        def initialize(**attributes)
+          attributes.each do |name, value|
+            instance_variable_set(:"@#{name}", value) if respond_to?(name)
+          end
         end
       end
     end

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -7,7 +7,7 @@ module Doorkeeper
         attr_reader :pre_auth, :resource_owner, :token
 
         class << self
-          def build_context(pre_auth_or_oauth_client, grant_type, scopes)
+          def build_context(pre_auth_or_oauth_client, grant_type, scopes, resource_owner)
             oauth_client = if pre_auth_or_oauth_client.respond_to?(:application)
                              pre_auth_or_oauth_client.application
                            elsif pre_auth_or_oauth_client.respond_to?(:client)
@@ -17,9 +17,10 @@ module Doorkeeper
                            end
 
             Doorkeeper::OAuth::Authorization::Context.new(
-              oauth_client,
-              grant_type,
-              scopes,
+              client: oauth_client,
+              grant_type: grant_type,
+              scopes: scopes,
+              resource_owner: resource_owner,
             )
           end
 
@@ -55,6 +56,7 @@ module Doorkeeper
             pre_auth.client,
             Doorkeeper::OAuth::IMPLICIT,
             pre_auth.scopes,
+            resource_owner,
           )
 
           @token = Doorkeeper.config.access_token_model.find_or_create_for(

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -27,7 +27,7 @@ module Doorkeeper
       end
 
       def find_or_create_access_token(client, resource_owner, scopes, server)
-        context = Authorization::Token.build_context(client, grant_type, scopes)
+        context = Authorization::Token.build_context(client, grant_type, scopes, resource_owner)
         @access_token = server_config.access_token_model.find_or_create_for(
           application: client,
           resource_owner: resource_owner,

--- a/lib/doorkeeper/oauth/client_credentials/issuer.rb
+++ b/lib/doorkeeper/oauth/client_credentials/issuer.rb
@@ -30,6 +30,7 @@ module Doorkeeper
             client,
             Doorkeeper::OAuth::CLIENT_CREDENTIALS,
             scopes,
+            nil,
           )
           ttl = Authorization::Token.access_token_expires_in(@server, context)
 

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -62,6 +62,19 @@ module Doorkeeper
           attributes[:previous_refresh_token] = refresh_token.refresh_token
         end
 
+        # RFC6749
+        # 1.5.  Refresh Token
+        #
+        # Refresh tokens are issued to the client by the authorization server and are
+        # used to obtain a new access token when the current access token
+        # becomes invalid or expires, or to obtain additional access tokens
+        # with identical or narrower scope (access tokens may have a shorter
+        # lifetime and fewer permissions than authorized by the resource
+        # owner).
+        #
+        # Here we assume that TTL of the token received after refreshing should be
+        # the same as that of the original token.
+        #
         @access_token = server_config.access_token_model.create_for(
           application: refresh_token.application,
           resource_owner: resource_owner,

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -103,12 +103,13 @@ Doorkeeper.configure do
   #
   # `context` has the following properties available:
   #
-  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
-  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
-  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #   * `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  #   * `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  #   * `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #   * `resource_owner` - authorized resource owner instance (if present)
   #
   # custom_access_token_expires_in do |context|
-  #   context.client.application.additional_settings.implicit_oauth_expiration
+  #   context.client.additional_settings.implicit_oauth_expiration
   # end
 
   # Use a custom class for generating the access token.


### PR DESCRIPTION
Add Resource Owner instance to authorization hook context for `custom_access_token_expires_in` configuration option to allow resource owner based Access Tokens TTL

Fixes #1386