### PR TITLE
Use update_attribute to ensure callbacks are executed on revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1426] Ensure ActiveRecord callbacks are executed on token revocation.
 - [#1407] Remove redundant and complex to support helpers froms tests (`should_have_json`, etc).
 - [#1416] Don't add introspection route if token introspection completely disabled.
 - [#1410] Properly memoize `current_resource_owner` value (consider `nil` and `false` values).

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -377,7 +377,7 @@ module Doorkeeper
       return unless self.class.refresh_token_revoked_on_use?
 
       old_refresh_token&.revoke
-      update_column(:previous_refresh_token, "")
+      update_attribute(:previous_refresh_token, "")
     end
 
     private

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -9,7 +9,7 @@ module Doorkeeper
       # @param clock [Time] time object
       #
       def revoke(clock = Time)
-        update_column(:revoked_at, clock.now.utc)
+        update_attribute(:revoked_at, clock.now.utc)
       end
 
       # Indicates whether the object has been revoked.

--- a/spec/lib/models/revocable_spec.rb
+++ b/spec/lib/models/revocable_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Doorkeeper::Models::Revocable do
     it "updates :revoked_at attribute with current time" do
       utc = double utc: double
       clock = double now: utc
-      expect(fake_object).to receive(:update_column).with(:revoked_at, clock.now.utc)
+      expect(fake_object).to receive(:update_attribute).with(:revoked_at, clock.now.utc)
       fake_object.revoke(clock)
     end
   end


### PR DESCRIPTION
### Summary

Reverts revoke method implementations to use `#update_attribute` instead of `#update_column`. This ensures that models mixing this functionality in will have callbacks invoked whenever the token is revoked.

Some users relied on callback behavior during revocation to e.g. invalidate a cache entry when tokens are revoked. The earlier change to `#update_column` affected this behavior and broke some use cases.

### Other Information

* Issue: https://github.com/doorkeeper-gem/doorkeeper/issues/1424
* Previous PR that introduced the change: https://github.com/doorkeeper-gem/doorkeeper/pull/1384
