### PR TITLE
Add grant types to access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1430] Add grant types to access tokens. run `rails generate doorkeeper:grant_type_access_tokens` to generate necessary migration. If you create your own `Doorkeeper::AccessToken`s, be sure to add the relevant `grant_type` string param.
 - [#1426] Ensure ActiveRecord callbacks are executed on token revocation.
 - [#1407] Remove redundant and complex to support helpers froms tests (`should_have_json`, etc).
 - [#1416] Don't add introspection route if token introspection completely disabled.

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -65,6 +65,7 @@ module Doorkeeper
             scopes: pre_auth.scopes,
             expires_in: self.class.access_token_expires_in(Doorkeeper.config, context),
             use_refresh_token: false,
+            grant_type: Doorkeeper::OAuth::IMPLICIT,
           )
         end
 

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -32,6 +32,7 @@ module Doorkeeper
           application: client,
           resource_owner: resource_owner,
           scopes: scopes,
+          grant_type: grant_type,
           expires_in: Authorization::Token.access_token_expires_in(server, context),
           use_refresh_token: Authorization::Token.refresh_token_enabled?(server, context),
         )

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -17,6 +17,7 @@ module Doorkeeper
               application: client,
               resource_owner: nil,
               scopes: scopes,
+              grant_type: Doorkeeper::OAuth::CLIENT_CREDENTIALS,
               **attributes,
             )
           end

--- a/lib/doorkeeper/oauth/client_credentials/issuer.rb
+++ b/lib/doorkeeper/oauth/client_credentials/issuer.rb
@@ -39,6 +39,7 @@ module Doorkeeper
             scopes,
             use_refresh_token: false,
             expires_in: ttl,
+            grant_type: Doorkeeper::OAuth::CLIENT_CREDENTIALS,
           )
         end
       end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -81,6 +81,7 @@ module Doorkeeper
           scopes: scopes,
           expires_in: refresh_token.expires_in,
           use_refresh_token: true,
+          grant_type: refresh_token.grant_type || Doorkeeper::OAuth::REFRESH_TOKEN,
           **attributes,
         )
       end

--- a/lib/doorkeeper/orm/active_record/mixins/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/access_token.rb
@@ -19,6 +19,7 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
 
       validates :token, presence: true, uniqueness: { case_sensitive: true }
       validates :refresh_token, uniqueness: { case_sensitive: true }, if: :use_refresh_token?
+      validates :grant_type, presence: true, on: :create
 
       # @attr_writer [Boolean, nil] use_refresh_token
       #   indicates the possibility of using refresh token

--- a/lib/generators/doorkeeper/grant_type_access_tokens_generator.rb
+++ b/lib/generators/doorkeeper/grant_type_access_tokens_generator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Doorkeeper
+  # Generates migration to add grant_type column to Doorkeeper
+  # oauth_access_tokens table.
+  #
+  class GrantTypeAccessTokensGenerator < ::Rails::Generators::Base
+    include ::Rails::Generators::Migration
+    source_root File.expand_path("templates", __dir__)
+    desc "Add grant_type column to Doorkeeper Access Tokens"
+
+    def grant_type_access_tokens
+      migration_template(
+        "add_grant_type_to_access_tokens.rb.erb",
+        "db/migrate/add_grant_type_to_access_tokens.rb",
+        migration_version: migration_version,
+      )
+    end
+
+    def self.next_migration_number(dirname)
+      ActiveRecord::Generators::Base.next_migration_number(dirname)
+    end
+
+    private
+
+    def migration_version
+      "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+    end
+  end
+end

--- a/lib/generators/doorkeeper/templates/add_grant_type_to_access_tokens.rb.erb
+++ b/lib/generators/doorkeeper/templates/add_grant_type_to_access_tokens.rb.erb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddGrantTypeToAccessTokens < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_column(
+      :oauth_access_tokens,
+      :grant_type,
+      :string,
+      null: true,
+    )
+  end
+end

--- a/lib/generators/doorkeeper/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/migration.rb.erb
@@ -56,6 +56,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
       t.datetime :revoked_at
       t.datetime :created_at, null: false
       t.string   :scopes
+      t.string   :grant_type
 
       # The authorization server MAY issue a new refresh token, in which case
       # *the client MUST discard the old refresh token* and replace it with the

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe Doorkeeper::AuthorizationsController do
     it "issues the token for the current resource owner" do
       expect(Doorkeeper::AccessToken.first.resource_owner_id).to eq(user.id)
     end
+
+    it "sets the implicit grant_type on the token" do
+      expect(Doorkeeper::AccessToken.last.grant_type).to eq(Doorkeeper::OAuth::IMPLICIT)
+    end
   end
 
   describe "POST #create in API mode" do

--- a/spec/dummy/db/migrate/20200717132037_add_grant_type_to_access_tokens.rb
+++ b/spec/dummy/db/migrate/20200717132037_add_grant_type_to_access_tokens.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddGrantTypeToAccessTokens < ActiveRecord::Migration[6.0]
+  def change
+    add_column(
+      :oauth_access_tokens,
+      :grant_type,
+      :string,
+      null: true,
+    )
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -2,19 +2,19 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180210183654) do
+ActiveRecord::Schema.define(version: 2020_07_17_132037) do
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
-    t.string "resource_owner_type" # [NOTE] null: false skipped to allow test pass
+    t.string "resource_owner_type"
     t.integer "application_id", null: false
     t.string "token", null: false
     t.integer "expires_in", null: false
@@ -22,10 +22,8 @@ ActiveRecord::Schema.define(version: 20180210183654) do
     t.datetime "created_at", null: false
     t.datetime "revoked_at"
     t.string "scopes"
-    unless ENV["WITHOUT_PKCE"]
-      t.string   "code_challenge"
-      t.string   "code_challenge_method"
-    end
+    t.string "code_challenge"
+    t.string "code_challenge_method"
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
@@ -40,6 +38,7 @@ ActiveRecord::Schema.define(version: 20180210183654) do
     t.datetime "created_at", null: false
     t.string "scopes"
     t.string "previous_refresh_token", default: "", null: false
+    t.string "grant_type"
     t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
     t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     sequence(:resource_owner_id) { |n| n }
     application
     expires_in { 2.hours }
+    grant_type { resource_owner_id.nil? ? "client_credentials" : "authorization_code" }
 
     factory :clientless_access_token do
       application { nil }

--- a/spec/generators/grant_type_access_tokens_generator_spec.rb
+++ b/spec/generators/grant_type_access_tokens_generator_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "generators/doorkeeper/grant_type_access_tokens_generator"
+
+RSpec.describe Doorkeeper::GrantTypeAccessTokensGenerator do
+  include GeneratorSpec::TestCase
+
+  tests described_class
+  destination ::File.expand_path("../tmp/dummy", __FILE__)
+
+  describe "after running the generator" do
+    before do
+      prepare_destination
+    end
+
+    it "creates a migration with a version specifier" do
+      stub_const("ActiveRecord::VERSION::MAJOR", 5)
+      stub_const("ActiveRecord::VERSION::MINOR", 0)
+
+      run_generator
+
+      assert_migration "db/migrate/add_grant_type_to_access_tokens.rb" do |migration|
+        assert migration.include?("ActiveRecord::Migration[5.0]\n")
+        assert migration.include?(":grant_type")
+      end
+    end
+  end
+end

--- a/spec/lib/oauth/base_request_spec.rb
+++ b/spec/lib/oauth/base_request_spec.rb
@@ -118,6 +118,11 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
 
   describe "#find_or_create_access_token" do
     let(:resource_owner) { FactoryBot.build_stubbed(:resource_owner) }
+    let(:grant_type) { "authorization_code" }
+
+    before do
+      allow(request).to receive(:grant_type).and_return(grant_type)
+    end
 
     it "returns an instance of AccessToken" do
       result = request.find_or_create_access_token(
@@ -176,6 +181,16 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         server,
       )
       expect(result.refresh_token).to be_nil
+    end
+
+    it "stores the grant type on the token" do
+      result = request.find_or_create_access_token(
+        client,
+        resource_owner,
+        "private",
+        server,
+      )
+      expect(result.grant_type).to eq(grant_type)
     end
   end
 

--- a/spec/lib/oauth/client_credentials/creator_spec.rb
+++ b/spec/lib/oauth/client_credentials/creator_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Creator do
     end.to change { Doorkeeper::AccessToken.count }.by(1)
   end
 
+  it "assigns the client_credentials grant type to the new token" do
+    creator.call(client, scopes)
+    expect(Doorkeeper::AccessToken.last.grant_type).to eq("client_credentials")
+  end
+
   context "when reuse_access_token is true" do
     before do
       allow(Doorkeeper.config).to receive(:reuse_access_token).and_return(true)

--- a/spec/lib/oauth/client_credentials/issuer_spec.rb
+++ b/spec/lib/oauth/client_credentials/issuer_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
         scopes,
         expires_in: 100,
         use_refresh_token: false,
+        grant_type: "client_credentials",
       )
 
       issuer.create client, scopes, creator
@@ -92,6 +93,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
           scopes,
           expires_in: custom_ttl_grant,
           use_refresh_token: false,
+          grant_type: "client_credentials",
         )
         issuer.create client, scopes, creator
       end
@@ -102,6 +104,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
           custom_scope,
           expires_in: custom_ttl_scope,
           use_refresh_token: false,
+          grant_type: "client_credentials",
         )
         issuer.create client, custom_scope, creator
       end


### PR DESCRIPTION
### Summary

We've found it useful in our doorkeeper integration to record an access tokens grant type.

There are a few pretty specific instances where we factor grant_type into authorization. It's also helpful to have for auditability.

This PR adds the `grant_type` field to the `oauth_access_tokens` table, and makes it's presence a requirement on creation only.

Tokens created from refresh tokens will take on the grant_type of it's predecessor, or `refresh_token` to ensure backwards compatibility.
