### PR TITLE
Capitalize token_type in specs

### DIFF
--- a/spec/lib/oauth/base_request_spec.rb
+++ b/spec/lib/oauth/base_request_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
            expires_in_seconds: "300",
            scopes_string: "two scopes",
            plaintext_refresh_token: "some-refresh-token",
-           token_type: "bearer",
+           token_type: "Bearer",
            created_at: 0
   end
 

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Doorkeeper::OAuth::TokenResponse do
              expires_in_seconds: "300",
              scopes_string: "two scopes",
              plaintext_refresh_token: "some-refresh-token",
-             token_type: "bearer",
+             token_type: "Bearer",
              created_at: 0
     end
 
@@ -34,7 +34,7 @@ RSpec.describe Doorkeeper::OAuth::TokenResponse do
     end
 
     it "includes :token_type" do
-      expect(body["token_type"]).to eq("bearer")
+      expect(body["token_type"]).to eq("Bearer")
     end
 
     # expires_in_seconds is returned as `expires_in` in order to match
@@ -65,7 +65,7 @@ RSpec.describe Doorkeeper::OAuth::TokenResponse do
              expires_in_seconds: "",
              scopes_string: "",
              plaintext_refresh_token: "",
-             token_type: "bearer",
+             token_type: "Bearer",
              created_at: 0
     end
 


### PR DESCRIPTION
https://github.com/doorkeeper-gem/doorkeeper/blob/v5.4.0/lib/doorkeeper/models/access_token_mixin.rb#L286
`Bearer` token type starts with capital B since v4.4.something. But In specs it's still `bearer` and it's a little bit confusing.