### PR TITLE
Make error response not redirectable when client is unauthorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## master
 
+- [#1435] Make error response not redirectable when client is unauthorized
 - [#1426] Ensure ActiveRecord callbacks are executed on token revocation.
 - [#1407] Remove redundant and complex to support helpers froms tests (`should_have_json`, etc).
 - [#1416] Don't add introspection route if token introspection completely disabled.

--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -5,6 +5,8 @@ module Doorkeeper
     class ErrorResponse < BaseResponse
       include OAuth::Helpers
 
+      NON_REDIRECTABLE_STATES = %i[invalid_redirect_uri invalid_client unauthorized_client].freeze
+
       def self.from_request(request, attributes = {})
         new(
           attributes.merge(
@@ -32,7 +34,7 @@ module Doorkeeper
       end
 
       def status
-        if name == :invalid_client
+        if name == :invalid_client || name == :unauthorized_client
           :unauthorized
         else
           :bad_request
@@ -40,8 +42,7 @@ module Doorkeeper
       end
 
       def redirectable?
-        name != :invalid_redirect_uri && name != :invalid_client &&
-          !URIChecker.oob_uri?(@redirect_uri)
+        !NON_REDIRECTABLE_STATES.include?(name) && !URIChecker.oob_uri?(@redirect_uri)
       end
 
       def redirect_uri

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -84,6 +84,11 @@ module Doorkeeper
         Doorkeeper.config.allow_grant_flow_for_client?(grant_type, client.application)
       end
 
+      def validate_resource_owner_authorize_for_client
+        # The `authorize_resource_owner_for_client` config option is used for this validation
+        client.application.authorized_for_resource_owner?(@resource_owner)
+      end
+
       def validate_redirect_uri
         return false if redirect_uri.blank?
 
@@ -123,11 +128,6 @@ module Doorkeeper
 
         code_challenge.blank? ||
           (code_challenge_method.present? && code_challenge_method =~ /^plain$|^S256$/)
-      end
-
-      def validate_resource_owner_authorize_for_client
-        # The `authorize_resource_owner_for_client` config option is used for this validation
-        client.application.authorized_for_resource_owner?(@resource_owner)
       end
 
       def response_on_fragment?

--- a/spec/lib/oauth/invalid_request_response_spec.rb
+++ b/spec/lib/oauth/invalid_request_response_spec.rb
@@ -58,4 +58,18 @@ RSpec.describe Doorkeeper::OAuth::InvalidRequestResponse do
       end
     end
   end
+
+  describe ".redirectable?" do
+    it "not redirectable when missing_param is client_id" do
+      subject = described_class.new(missing_param: :client_id)
+
+      expect(subject.redirectable?).to be false
+    end
+
+    it "is redirectable when missing_param is other than client_id" do
+      subject = described_class.new(missing_param: :code_verifier)
+
+      expect(subject.redirectable?).to be true
+    end
+  end
 end


### PR DESCRIPTION
### Summary

1. Fix bug: [unauthorized_client error on pre_authorization](https://github.com/doorkeeper-gem/doorkeeper/blob/master/lib/doorkeeper/oauth/pre_authorization.rb#L10) may be return by redirection to client.

As rfc6749 has mentioned, when client is invalid, it MUST_NOT redirect the user-agent: https://tools.ietf.org/html/rfc6749#section-4.1.2.1
> If the request fails due to a missing, invalid, or mismatching
   redirection URI, or **if the client identifier is missing or invalid**,
   the authorization server SHOULD inform the resource owner of the
   error and MUST NOT automatically redirect the user-agent to the
   invalid redirection URI.

- return status code as 401 when error is unauthorized_client [lib/doorkeeper/oauth/error_response.rb](https://github.com/doorkeeper-gem/doorkeeper/pull/1435/files#diff-8b0ec02fd78d980d0036c02439acf8a6)
- add `name != :unauthorized_client &&` to `redirectable?` method of error_response [lib/doorkeeper/oauth/error_response.rb](https://github.com/doorkeeper-gem/doorkeeper/pull/1435/files#diff-8b0ec02fd78d980d0036c02439acf8a6)

- add unit test on `redirectable?` for error_response_spec and invalid_request_response_spec [spec/lib/oauth/error_response_spec.rb](https://github.com/doorkeeper-gem/doorkeeper/pull/1435/files#diff-c43c8ad55277805d55aacd88f686f101), [spec/lib/oauth/invalid_request_response_spec.rb](https://github.com/doorkeeper-gem/doorkeeper/pull/1435/files#diff-a9d709531ebc7f63561c24c886977c1c)
- add test `must call the validations on client and redirect_uri before other validations because they are not redirectable` to pre_authorization_spec. [spec/lib/oauth/pre_authorization_spec.rb](https://github.com/doorkeeper-gem/doorkeeper/pull/1435/files#diff-b2085d14cb8374956712da8c8d55e8ef)
  - Explain: [pre_authorization validations return first error it encounters](https://github.com/doorkeeper-gem/doorkeeper/blob/614ec7d4b9db3bda309e118536e6f0533977ab69/lib/doorkeeper/validations.rb#L14). With the authorization_request that has two errors: `missing parameter response_type` and `invalid_redirect_uri`, if the `missing parameter response_type` validation is run before `invalid_redirect_uri` validation, authorization server will return error by redirect the user-agent to the invalid redirect_uri, which is not followed quote from rfc6749 above (which lead to vulnerability on redirection)
  - So I add this test to make sure un-redirectable validations must be run before others.

### Other Information

- reordering the `validate_resource_owner_authorize_for_client` in pre_authorization as order of validate declaration. [lib/doorkeeper/oauth/pre_authorization.rb](https://github.com/doorkeeper-gem/doorkeeper/pull/1435/files#diff-5c19299fbbf253b0b137bb78daa96299)
- delete duplicated rspecs, and unnecessary rspecs on pre_authorization_spec. 