### PR TITLE
Add form post response mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Add your PR description here.
+- [#1438] Add form post response mode.
 
 ## 5.5.0.rc1
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -52,10 +52,19 @@ module Doorkeeper
     def redirect_or_render(auth)
       if auth.redirectable?
         if Doorkeeper.configuration.api_only
-          render(
-            json: { status: :redirect, redirect_uri: auth.redirect_uri },
-            status: auth.status,
-          )
+          if pre_auth.form_post_response?
+            render(
+              json: { status: :post, redirect_uri: pre_auth.redirect_uri, body: auth.body },
+              status: auth.status,
+            )
+          else
+            render(
+              json: { status: :redirect, redirect_uri: auth.redirect_uri },
+              status: auth.status,
+            )
+          end
+        elsif pre_auth.form_post_response?
+          render :form_post
         else
           redirect_to auth.redirect_uri
         end
@@ -82,6 +91,7 @@ module Doorkeeper
         code_challenge
         code_challenge_method
         response_type
+        response_mode
         redirect_uri
         scope
         state

--- a/app/views/doorkeeper/authorizations/form_post.html.erb
+++ b/app/views/doorkeeper/authorizations/form_post.html.erb
@@ -1,0 +1,11 @@
+<header class="page-header">
+  <h1><%= t('.title') %></h1>
+</header>
+
+<main role="main" onload="document.forms[0].submit()">
+  <%= form_tag @pre_auth.redirect_uri, method: :post do %>
+    <% @authorize_response.body.each do |key, value| %>
+      <%= hidden_field_tag key, value %>
+    <% end %>
+  <% end %>
+</main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,6 +109,7 @@ en:
 
         # Access grant errors
         unsupported_response_type: 'The authorization server does not support this response type.'
+        unsupported_response_mode: 'The authorization server does not support this response mode.'
 
         # Access token errors
         invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,8 @@ en:
         able_to: 'This application will be able to'
       show:
         title: 'Authorization code'
+      form_post:
+        title: 'Submit this form'
 
     authorized_applications:
       confirmations:

--- a/lib/doorkeeper/grant_flow.rb
+++ b/lib/doorkeeper/grant_flow.rb
@@ -11,12 +11,14 @@ module Doorkeeper
     register(
       :implicit,
       response_type_matches: "token",
+      response_mode_matches: %w[fragment form_post],
       response_type_strategy: Doorkeeper::Request::Token,
     )
 
     register(
       :authorization_code,
       response_type_matches: "code",
+      response_mode_matches: %w[query fragment form_post],
       response_type_strategy: Doorkeeper::Request::Code,
       grant_type_matches: "authorization_code",
       grant_type_strategy: Doorkeeper::Request::AuthorizationCode,

--- a/lib/doorkeeper/grant_flow/flow.rb
+++ b/lib/doorkeeper/grant_flow/flow.rb
@@ -4,7 +4,8 @@ module Doorkeeper
   module GrantFlow
     class Flow
       attr_reader :name, :grant_type_matches, :grant_type_strategy,
-                  :response_type_matches, :response_type_strategy
+                  :response_type_matches, :response_type_strategy,
+                  :response_mode_matches
 
       def initialize(name, **options)
         @name = name
@@ -12,6 +13,7 @@ module Doorkeeper
         @grant_type_strategy = options[:grant_type_strategy]
         @response_type_matches = options[:response_type_matches]
         @response_type_strategy = options[:response_type_strategy]
+        @response_mode_matches = options[:response_mode_matches]
       end
 
       def handles_grant_type?
@@ -28,6 +30,14 @@ module Doorkeeper
 
       def matches_response_type?(value)
         response_type_matches === value
+      end
+
+      def default_response_mode
+        response_mode_matches[0]
+      end
+
+      def matches_response_mode?(value)
+        response_mode_matches.include?(value)
       end
     end
   end

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -21,6 +21,10 @@ module Doorkeeper
           { action: :show, code: token.plaintext_token }
         end
 
+        def access_grant?
+          true
+        end
+
         private
 
         def authorization_code_expires_in

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -76,6 +76,10 @@ module Doorkeeper
           }
         end
 
+        def access_token?
+          true
+        end
+
         private
 
         def controller

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -60,6 +60,10 @@ module Doorkeeper
         pre_auth_hash
       end
 
+      def form_post_response?
+        response_mode == "form_post"
+      end
+
       private
 
       attr_reader :client_id, :server
@@ -146,7 +150,9 @@ module Doorkeeper
       end
 
       def response_on_fragment?
-        response_type == "token"
+        return response_type == "token" if response_mode.nil?
+
+        response_mode == "fragment"
       end
 
       def grant_type

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -12,16 +12,19 @@ module Doorkeeper
       validate :redirect_uri, error: :invalid_redirect_uri
       validate :params, error: :invalid_request
       validate :response_type, error: :unsupported_response_type
+      validate :response_mode, error: :unsupported_response_mode
       validate :scopes, error: :invalid_scope
       validate :code_challenge_method, error: :invalid_code_challenge_method
 
       attr_reader :client, :code_challenge, :code_challenge_method, :missing_param,
-                  :redirect_uri, :resource_owner, :response_type, :state
+                  :redirect_uri, :resource_owner, :response_type, :state,
+                  :authorization_response_flow, :response_mode
 
       def initialize(server, parameters = {}, resource_owner = nil)
         @server                = server
         @client_id             = parameters[:client_id]
         @response_type         = parameters[:response_type]
+        @response_mode         = parameters[:response_mode]
         @redirect_uri          = parameters[:redirect_uri]
         @scope                 = parameters[:scope]
         @state                 = parameters[:state]
@@ -110,8 +113,20 @@ module Doorkeeper
 
       def validate_response_type
         server.authorization_response_flows.any? do |flow|
-          flow.matches_response_type?(response_type)
+          if flow.matches_response_type?(response_type)
+            @authorization_response_flow = flow
+            true
+          end
         end
+      end
+
+      def validate_response_mode
+        if response_mode.blank?
+          @response_mode = authorization_response_flow.default_response_mode
+          return true
+        end
+
+        authorization_response_flow.matches_response_mode?(response_mode)
       end
 
       def validate_scopes

--- a/spec/lib/grant_flow/flow_spec.rb
+++ b/spec/lib/grant_flow/flow_spec.rb
@@ -67,4 +67,17 @@ RSpec.describe Doorkeeper::GrantFlow::Flow do
       end
     end
   end
+
+  context "when given a response_mode to match" do
+    let(:response_mode_matches) { %w[secret_handshake_1 secret_handshake_2] }
+    let(:options) { { response_mode_matches: response_mode_matches } }
+
+    it "default response_mode value" do
+      expect(flow.default_response_mode).to eq "secret_handshake_1"
+    end
+
+    it "matches response_mode values" do
+      expect(flow.matches_response_mode?("secret_handshake_2")).to be true
+    end
+  end
 end

--- a/spec/lib/oauth/code_response_spec.rb
+++ b/spec/lib/oauth/code_response_spec.rb
@@ -3,26 +3,36 @@
 require "spec_helper"
 
 RSpec.describe Doorkeeper::OAuth::CodeResponse do
-  describe "#redirect_uri" do
-    context "when generating the redirect URI for an implicit grant" do
-      subject(:redirect_uri) do
-        described_class.new(pre_auth, auth, response_on_fragment: true).redirect_uri
+  let(:pre_auth) do
+    double(
+      :pre_auth,
+      client: double(:application, id: 1),
+      redirect_uri: "http://tst.com/cb",
+      state: "state",
+      scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+    )
+  end
+  let(:owner) { FactoryBot.build_stubbed(:resource_owner) }
+
+  describe "#body" do
+    subject(:body) { described_class.new(pre_auth, auth).body }
+
+    context "when auth object is for authorization code flow" do
+      let(:auth) do
+        Doorkeeper::OAuth::Authorization::Code.new(pre_auth, owner).tap(&:issue_token!)
       end
 
-      let(:pre_auth) do
-        double(
-          :pre_auth,
-          client: double(:application, id: 1),
-          redirect_uri: "http://tst.com/cb",
-          state: nil,
-          scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
-        )
+      before do
+        allow(pre_auth).to receive(:code_challenge).and_return("code_challenge")
+        allow(pre_auth).to receive(:code_challenge_method).and_return("plain")
       end
 
-      let(:owner) do
-        FactoryBot.build_stubbed(:resource_owner)
+      it "return body response for authorization code" do
+        expect(body).to eq({ code: auth.token.plaintext_token, state: pre_auth.state })
       end
+    end
 
+    context "when auth object is for implicit grant flow" do
       let(:auth) do
         Doorkeeper::OAuth::Authorization::Token.new(pre_auth, owner).tap do |c|
           c.issue_token!
@@ -30,8 +40,52 @@ RSpec.describe Doorkeeper::OAuth::CodeResponse do
         end
       end
 
-      it "includes the remaining TTL of the token relative to the time the token was generated" do
-        expect(redirect_uri).to include("expires_in=3600")
+      it "return body response for access token" do
+        expect(body).to eq(
+          {
+            access_token: auth.token.plaintext_token,
+            token_type: auth.token.token_type,
+            expires_in: auth.token.expires_in_seconds,
+            state: pre_auth.state,
+          },
+        )
+      end
+    end
+  end
+
+  describe "#redirect_uri" do
+    subject(:redirect_uri) do
+      described_class.new(pre_auth, auth, response_on_fragment: response_on_fragment).redirect_uri
+    end
+
+    context "when generating the redirect URI for an authorization code grant" do
+      let(:response_on_fragment) { false }
+      let(:auth) do
+        Doorkeeper::OAuth::Authorization::Code.new(pre_auth, owner).tap(&:issue_token!)
+      end
+
+      before do
+        allow(pre_auth).to receive(:code_challenge).and_return("code_challenge")
+        allow(pre_auth).to receive(:code_challenge_method).and_return("plain")
+      end
+
+      it "includes the authorization code was generated and state" do
+        expect(redirect_uri).to eq("#{pre_auth.redirect_uri}?code=#{auth.token.plaintext_token}&state=#{pre_auth.state}")
+      end
+    end
+
+    context "when generating the redirect URI for an implicit grant" do
+      let(:response_on_fragment) { true }
+      let(:auth) do
+        Doorkeeper::OAuth::Authorization::Token.new(pre_auth, owner).tap do |c|
+          c.issue_token!
+          allow(c.token).to receive(:expires_in_seconds).and_return(3600)
+        end
+      end
+
+      it "includes info of the token was generated and state" do
+        expect(redirect_uri).to include("#{pre_auth.redirect_uri}#access_token=#{auth.token.plaintext_token}&" \
+          "token_type=#{auth.token.token_type}&expires_in=3600&state=#{pre_auth.state}")
       end
     end
   end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
       redirect_uri
       params
       response_type
+      response_mode
       scopes
       code_challenge_method
     ])
@@ -79,6 +80,70 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
     it 'does not accept "token" as response type' do
       attributes[:response_type] = "token"
       expect(pre_auth).not_to be_authorizable
+    end
+  end
+
+  context "with response_mode parameter is provided" do
+    context "when response_type is 'code'" do
+      before { attributes[:response_type] = "code" }
+
+      it "sets response_mode as 'query' when it is not provided" do
+        attributes[:response_mode] = ""
+
+        expect(pre_auth).to be_authorizable
+        expect(pre_auth.response_mode).to eq("query")
+      end
+
+      it 'accepts "query" as response_mode' do
+        attributes[:response_mode] = "query"
+        expect(pre_auth).to be_authorizable
+      end
+
+      it 'accepts "fragment" as response_mode' do
+        attributes[:response_mode] = "fragment"
+        expect(pre_auth).to be_authorizable
+      end
+
+      it 'accepts "form_post" as response_mode' do
+        attributes[:response_mode] = "form_post"
+        expect(pre_auth).to be_authorizable
+      end
+
+      it "does not accept response_mode other than query, fragment, form_post" do
+        attributes[:response_mode] = "other response_mode"
+
+        expect(pre_auth).not_to be_authorizable
+      end
+    end
+
+    context "when response_type is 'token'" do
+      before do
+        allow(server).to receive(:grant_flows).and_return(["implicit"])
+        attributes[:response_type] = "token"
+      end
+
+      it "sets response_mode as 'fragment' when it is not provided" do
+        attributes[:response_mode] = ""
+
+        expect(pre_auth).to be_authorizable
+        expect(pre_auth.response_mode).to eq("fragment")
+      end
+
+      it 'accepts "fragment" as response_mode' do
+        attributes[:response_mode] = "fragment"
+        expect(pre_auth).to be_authorizable
+      end
+
+      it 'accepts "form_post" as response_mode' do
+        attributes[:response_mode] = "form_post"
+        expect(pre_auth).to be_authorizable
+      end
+
+      it 'does not accept "query" response_mode when response_type is "token"' do
+        attributes[:response_mode] = "query"
+
+        expect(pre_auth).not_to be_authorizable
+      end
     end
   end
 

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -286,6 +286,20 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
     end
   end
 
+  describe "#form_post_response?" do
+    it { is_expected.to respond_to(:form_post_response?) }
+
+    it "return true when response_mode is form_post" do
+      attributes[:response_mode] = "form_post"
+      expect(pre_auth.form_post_response?).to be true
+    end
+
+    it "when response_mode is other than form_post" do
+      attributes[:response_mode] = "fragment"
+      expect(pre_auth.form_post_response?).to be false
+    end
+  end
+
   context "when using PKCE params" do
     context "when PKCE is supported" do
       before do

--- a/spec/requests/endpoints/authorization_spec.rb
+++ b/spec/requests/endpoints/authorization_spec.rb
@@ -68,6 +68,12 @@ feature "Authorization endpoint" do
       i_should_not_see "Authorize"
       i_should_see_translated_error_message :unsupported_response_type
     end
+
+    scenario "displays unsupported_response_mode error when using an invalid response mode" do
+      visit authorization_endpoint_url(client: @client, response_mode: "invalid_response_mode")
+      i_should_not_see "Authorize"
+      i_should_see_translated_error_message :unsupported_response_mode
+    end
   end
 
   context "when forgery protection enabled" do

--- a/spec/requests/flows/implicit_grant_errors_spec.rb
+++ b/spec/requests/flows/implicit_grant_errors_spec.rb
@@ -43,4 +43,12 @@ feature "Implicit Grant Flow Errors" do
       i_should_see_translated_error_message :invalid_redirect_uri
     end
   end
+
+  context "when validate response_mode param" do
+    scenario "displays unsupported_response_mode error when using 'query' response mode" do
+      visit authorization_endpoint_url(client: @client, response_type: "token", response_mode: "query")
+      i_should_not_see "Authorize"
+      i_should_see_translated_error_message :unsupported_response_mode
+    end
+  end
 end

--- a/spec/support/helpers/url_helper.rb
+++ b/spec/support/helpers/url_helper.rb
@@ -32,6 +32,7 @@ module UrlHelper
       client_id: options[:client_id] || options[:client].try(:uid),
       redirect_uri: options[:redirect_uri] || options[:client].try(:redirect_uri),
       response_type: options[:response_type] || "code",
+      response_mode: options[:response_mode] || "",
       scope: options[:scope],
       state: options[:state],
       code_challenge: options[:code_challenge],


### PR DESCRIPTION
### Summary
Resolves #1423 

#### What did I do?

- [x]  add response_mode_matches to Flow and register at GrantFlow https://github.com/doorkeeper-gem/doorkeeper/pull/1438/commits/031a9d6721fb799cea82fffee2aa587a833ab150
  - Authorization Code Flow:
    - query, fragment, form_post.
    - "query" as default response_mode.
  - Implicit Flow:
    - fragment, form_post.
    - "fragment" as default response_mode.
    - "query" is not allow because with this response_mode, sensitive data (access token, id token (oidc)) can be seen by user/browser history/server log)

- [x] handle response_mode and validate response_mode at PreAuthorization https://github.com/doorkeeper-gem/doorkeeper/pull/1438/commits/96ec599334c2117f35235784c3c0ca589c54d946
  - get default response_mode from `authorization_response_flow` if parameter[:response_mode] does not exist

- [x] define body method to get result of code_response https://github.com/doorkeeper-gem/doorkeeper/pull/1438/commits/a14d79081b577b0b07cce4c9e89703668b476bdd
  - write `body` method for CodeResponse as [ErrorResponse](https://github.com/doorkeeper-gem/doorkeeper/blob/bf9d348f75360309a1deb30e44f5358df5c46e47/lib/doorkeeper/oauth/error_response.rb#L28-L34) to use in authorization controller

- [x] handle response by form_post on authorization controller https://github.com/doorkeeper-gem/doorkeeper/pull/1438/commits/b044b3333755fb87423091d0a5faff7d770764d1
  - create form_post.html.erb with javascript code follow [Appendix A.  "form_post" Response Mode Example](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html)

#### References:
- [OAuth 2.0 Multiple Response Type Encoding Practices](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html)
- [OAuth 2.0 Form Post Response Mode](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html)
- https://ldapwiki.com/wiki/Response_mode

### Other Information

- Do we need a config `response_mode_by_grant_type ` like current config [scopes_by_grant_type](https://github.com/doorkeeper-gem/doorkeeper/blob/a94b280c145f3c6cacccb064f3945bd868019306/lib/doorkeeper/config.rb#L96-L101) to allow config which response_mode can be used?

[UPD]
- I will prepare the change for this response_mode on [doorkeeper_openid_connect](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/92) after this PR is merged.