### PR TITLE
Fix typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ User-visible changes worth mentioning.
 - [#1418] Add ability to register custom OAuth Grant Flows.
 - [#1420] Require client authentication for Resource Owner Password Grant as stated in OAuth RFC.
   
-  **[IMPORTANT]** you need to create a new OAuth client (`Doorkeeper::Application`) if yoo didn't
+  **[IMPORTANT]** you need to create a new OAuth client (`Doorkeeper::Application`) if you didn't
     have it before and use client credentials in HTTP Basic auth if you previously used this grant
     flow without client authentication. For migration purposes you could enable
     `skip_client_authentication_for_password_grant` configuration option to `true`, but such behavior


### PR DESCRIPTION
### Summary

Fix typo in changelog, `yoo` -> `you`.
