### PR TITLE
Validate empty host in redirect_uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Add your PR description here.
+- [#1440] Validate empty host in redirect_uri
 - [#1438] Add form post response mode.
 
 ## 5.5.0.rc1

--- a/lib/doorkeeper/orm/active_record/redirect_uri_validator.rb
+++ b/lib/doorkeeper/orm/active_record/redirect_uri_validator.rb
@@ -21,6 +21,7 @@ module Doorkeeper
           record.errors.add(attribute, :unspecified_scheme) if unspecified_scheme?(uri)
           record.errors.add(attribute, :relative_uri) if relative_uri?(uri)
           record.errors.add(attribute, :secured_uri) if invalid_ssl_uri?(uri)
+          record.errors.add(attribute, :invalid_uri) if unspecified_host?(uri)
         end
       end
     rescue URI::InvalidURIError
@@ -41,6 +42,10 @@ module Doorkeeper
       return true if uri.opaque.present?
 
       %w[localhost].include?(uri.try(:scheme))
+    end
+
+    def unspecified_host?(uri)
+      uri.is_a?(URI::HTTP) && uri.host.nil?
     end
 
     def relative_uri?(uri)

--- a/spec/doorkeeper/redirect_uri_validator_spec.rb
+++ b/spec/doorkeeper/redirect_uri_validator_spec.rb
@@ -71,6 +71,12 @@ RSpec.describe Doorkeeper::RedirectUriValidator do
     expect(client).to be_valid
   end
 
+  it "is invalid when host is not specified" do
+    client.redirect_uri = "https://"
+    expect(client).to be_invalid
+    expect(client.errors[:redirect_uri].first).to eq(I18n.t("activerecord.errors.models.doorkeeper/application.attributes.redirect_uri.invalid_uri"))
+  end
+
   context "when force secured uri configured" do
     it "accepts a valid uri" do
       client.redirect_uri = "https://example.com/callback"


### PR DESCRIPTION
### Summary

When `http://` or `https://` is specified as `redirect_uri`, we should expect it to be invalid

We had this behavior until these changes have been specified: https://github.com/doorkeeper-gem/doorkeeper/commit/ebedb3c8fde06ad377f33ba11958e32dc7ff614e#diff-1de26e1e806e732aaaf8b2010ee70af7L25