### PR TITLE
Empty previous_refresh_token if present?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Add your PR description here.
+- [#1452] Empty previous_refresh_token only if present
 - [#1440] Validate empty host in redirect_uri
 - [#1438] Add form post response mode.
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -377,7 +377,7 @@ module Doorkeeper
       return unless self.class.refresh_token_revoked_on_use?
 
       old_refresh_token&.revoke
-      update_attribute(:previous_refresh_token, "")
+      update_attribute(:previous_refresh_token, "") if previous_refresh_token.present?
     end
 
     private


### PR DESCRIPTION
### Summary

The call to `update_attribute` in `revoke_previous_refresh_token!` is always performed, regardless of the current state. This means a DB transaction is opened, even if there are no changes to apply (i.e. the `previous_refresh_token` was already emptied).

This PR simply empty the `previous_refresh_token` if it is `present?` to avoid an unnecessary database transaction, which can happen at each `authenticate` call if `Doorkeeper.config.refresh_token_enabled?` ([source](https://github.com/doorkeeper-gem/doorkeeper/blob/034d87eff801ef6576fa1af31ba995eefa435924/lib/doorkeeper/oauth/token.rb#L19))
