### PR TITLE
Move Doorkeeper.gem_version from lib/doorkeeper/version.rb to lib/doorkeeper.rb

### DIFF
--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -6,7 +6,7 @@ require "doorkeeper/version"
 
 Gem::Specification.new do |gem|
   gem.name        = "doorkeeper"
-  gem.version     = Doorkeeper.gem_version
+  gem.version     = Doorkeeper::VERSION::STRING
   gem.authors     = ["Felipe Elias Philipp", "Tute Costa", "Jon Moss", "Nikita Bulai"]
   gem.email       = %w[bulaj.nikita@gmail.com]
   gem.homepage    = "https://github.com/doorkeeper-gem/doorkeeper"

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -115,4 +115,8 @@ module Doorkeeper
   def self.authenticate(request, methods = Doorkeeper.config.access_token_methods)
     OAuth::Token.authenticate(request, *methods)
   end
+
+  def self.gem_version
+    ::Gem::Version.new(::Doorkeeper::VERSION::STRING)
+  end
 end

--- a/lib/doorkeeper/version.rb
+++ b/lib/doorkeeper/version.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module Doorkeeper
-  def self.gem_version
-    Gem::Version.new VERSION::STRING
-  end
-
   module VERSION
     # Semantic versioning
     MAJOR = 5


### PR DESCRIPTION
### Summary

This is a bug fix.

When I upgraded the version of doorkeeper gem (from 5.0.1 to 5.4.0) in my Rails application, I encountered a problem with `NoMethodError` where `Doorkeeper.gem_version` was called.

After a litte research, I found out that https://github.com/doorkeeper-gem/doorkeeper/pull/1394, added from doorkeeper 5.4.0.rc1, is apparently related to this problem.

To make `Doorkeeper.gem_version` callable without (auto)loading lib/doorkeeper/version.rb, I changed the method location from lib/doorkeeper/version.rb to lib/doorkeeper.rb. In addition, I tweaked doorkeeper.gemspec a bit because no longer `Doorkeeper.gem_version` can be called there.

### Other Information

I wrote a script to reproduce the problem I encountered.

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'rails'

  gem 'doorkeeper', '5.4.0'
end

require 'doorkeeper'
require 'minitest/autorun'

class DoorkeeperTest < Minitest::Test
  def test_gem_version
    assert ::Doorkeeper.gem_version
  end
end
```

```
$ ruby test.rb
Run options: --seed 37178

# Running:

E

Error:
DoorkeeperTest#test_gem_version:
NoMethodError: undefined method `gem_version' for Doorkeeper:Module
    test.rb:16:in `test_gem_version'


rails test test.rb:15



Finished in 0.002405s, 415.8696 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

Or:

```console
$ ruby -r rails -r doorkeeper -e "Doorkeeper.gem_version"
Traceback (most recent call last):
-e:1:in `<main>': undefined method `gem_version' for Doorkeeper:Module (NoMethodError)
```