### PR TITLE
Make oauth_applications' owner_id column a bigint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Add your PR description here.
+- [#1457] Make owner_id a bigint for newly-generated owner migrations
 - [#1452] Empty previous_refresh_token only if present
 - [#1440] Validate empty host in redirect_uri
 - [#1438] Add form post response mode.

--- a/lib/generators/doorkeeper/templates/add_owner_to_application_migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/add_owner_to_application_migration.rb.erb
@@ -2,7 +2,7 @@
 
 class AddOwnerToApplication < ActiveRecord::Migration<%= migration_version %>
   def change
-    add_column :oauth_applications, :owner_id, :integer, null: true
+    add_column :oauth_applications, :owner_id, :bigint, null: true
     add_column :oauth_applications, :owner_type, :string, null: true
     add_index :oauth_applications, [:owner_id, :owner_type]
   end


### PR DESCRIPTION
### Summary

For newly-generated owner migrations, this will make owner_id a bigint just in case anyone ever hits the limit for int4 values on their users table.

Fixes #1456.

### Other Information

I've tested this change in a Rails app I maintain and it works fine, and I don't think it should require any changes besides the migration itself since Rails treats int4 and int8 values the same on its side of things.
