### PR TITLE
Refactor `skip_client_authentication_for_password_grant` option to make it available for the long term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ User-visible changes worth mentioning.
 - [#1452] Empty previous_refresh_token only if present
 - [#1440] Validate empty host in redirect_uri
 - [#1438] Add form post response mode.
+- [#1458] Make `config.skip_client_authentication_for_password_grant` a long term configuration option
 
 ## 5.5.0.rc1
 
@@ -23,12 +24,12 @@ User-visible changes worth mentioning.
 - [#1415] Ignore PKCE params for non-PKCE grants.
 - [#1418] Add ability to register custom OAuth Grant Flows.
 - [#1420] Require client authentication for Resource Owner Password Grant as stated in OAuth RFC.
-  
+
   **[IMPORTANT]** you need to create a new OAuth client (`Doorkeeper::Application`) if you didn't
     have it before and use client credentials in HTTP Basic auth if you previously used this grant
-    flow without client authentication. For migration purposes you could enable
-    `skip_client_authentication_for_password_grant` configuration option to `true`, but such behavior
-    (as well as configuration option) would be completely removed in a future version of Doorkeeper.
+    flow without client authentication. To opt out of this you could set the
+    `skip_client_authentication_for_password_grant` configuration option to `true`, but note that
+    this is in violation of the OAuth spec and represents a security risk.
     All the users of your provider application now need to include client credentials when they use
     this grant flow.
 
@@ -43,7 +44,7 @@ User-visible changes worth mentioning.
 
 - [#1371] Add `#as_json` method and attributes serialization restriction for Application model.
   Fixes information disclosure vulnerability (CVE-2020-10187).
-  
+
   **[IMPORTANT]** you need to re-implement `#as_json` method for Doorkeeper Application model
   if you previously used `#to_json` serialization with custom options or attributes or rely on
   JSON response from /oauth/applications.json or /oauth/authorized_applications.json. This change
@@ -57,17 +58,17 @@ User-visible changes worth mentioning.
 - [#1402] Handle trying authorization with client credentials.
 
 ## 5.4.0.rc1
-- [#1366] Sets expiry of token generated using `refresh_token` to that of original token. (Fixes #1364) 
+- [#1366] Sets expiry of token generated using `refresh_token` to that of original token. (Fixes #1364)
 - [#1354] Add `authorize_resource_owner_for_client` option to authorize the calling user to access an application.
 - [#1355] Allow to enable polymorphic Resource Owner association for Access Token & Grant
   models (`use_polymorphic_resource_owner` configuration option).
-  
+
   **[IMPORTANT]** Review your custom patches or extensions for Doorkeeper internals if you
   have such - since now Doorkeeper passes Resource Owner instance to every objects and not
   just it's ID. See PR description for details.
-  
+
 - [#1356] Remove duplicated scopes from Access Tokens and Grants on attribute assignment.
-- [#1357] Fix `Doorkeeper::OAuth::PreAuthorization#as_json` method causing 
+- [#1357] Fix `Doorkeeper::OAuth::PreAuthorization#as_json` method causing
   `Stack level too deep` error with AMS (fix #1312).
 - [#1358] Deprecate `active_record_options` configuration option.
 - [#1359] Refactor Doorkeeper configuration options DSL to make it easy to reuse it
@@ -79,7 +80,7 @@ User-visible changes worth mentioning.
   **[IMPORTANT]** now fully according to RFC 7009 nobody can do a revocation request without `client_id`
   (for public clients) and `client_secret` (for private clients). Please update your apps to include that
   info in the revocation request payload.
-  
+
 - [#1373] Make Doorkeeper routes mapper reusable in extensions.
 - [#1374] Revoke and issue client credentials token in a transaction with a row lock.
 - [#1384] Add context object with auth/pre_auth and issued_token for authorization hooks.
@@ -124,9 +125,9 @@ User-visible changes worth mentioning.
 
 - [#1371] Backport: add `#as_json` method and attributes serialization restriction for Application model.
   Fixes information disclosure vulnerability (CVE-2020-10187).
-  
+
 ## 5.2.4
-  
+
 - [#1360] Backport: Increase `matching_token_for` batch lookup size to 10 000 and make it configurable.
 
 ## 5.2.3

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -276,10 +276,16 @@ module Doorkeeper
     # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1189
     option :token_reuse_limit,              default: 100
 
-    # [NOTE]: will be removed in a future version of Doorkeeper
+    # This is discouraged. Spec says that password grants always require a client.
+    #
+    # See https://github.com/doorkeeper-gem/doorkeeper/issues/1412#issuecomment-632750422
+    # and https://github.com/doorkeeper-gem/doorkeeper/pull/1420
+    #
+    # Since many applications use this unsafe behavior in the wild, this is kept as a
+    # not-recommended option. You should be aware that you are not following the OAuth
+    # spec, and understand the security implications of doing so.
     option :skip_client_authentication_for_password_grant,
-           default: false,
-           deprecated: { message: "OAuth RFC requires client authentication so you need at least to create one" }
+           default: false
 
     option :active_record_options,
            default: {},

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -43,6 +43,24 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
     expect(request.error).to eq(:invalid_client)
   end
 
+  context "when skip_client_authentication_for_password_grant is true" do
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        skip_client_authentication_for_password_grant true
+      end
+    end
+
+    it "issues a new token for the client without client authentication" do
+      request = described_class.new(server, nil, owner)
+      expect do
+        request.authorize
+      end.to change { Doorkeeper::AccessToken.count }.by(1)
+
+      expect(Doorkeeper::AccessToken.all.max_by(&:created_at).expires_in).to eq(1234)
+    end
+  end
+
   it "doesn't issue a new token with an invalid client" do
     request = described_class.new(server, nil, owner, { client_id: "bad_id" })
     expect do


### PR DESCRIPTION
I appreciate the work done in https://github.com/doorkeeper-gem/doorkeeper/pull/1370 and https://github.com/doorkeeper-gem/doorkeeper/pull/1420 to make Doorkeeper more secure by default. I think strictly enforcing the RFC by default is exactly right.

The changes are causing us a bit of concern on existing apps that have been running with this authentication strategy for many years.

Our example use case is here: https://my.tanda.co/api/v2/documentation#header-authentication-(password) - we have hundreds of consumers relying on this approach in the wild (many of them whom we have never directly talked to about it), in addition we have built native apps that depend on this behavior for user login, and we believe other third parties have too.

An unaffiliated example of a similar workflow can be found here https://developer.twitter.com/en/docs/authentication/basic-auth

For this reason, I would like to propose keeping `config.skip_client_authentication_for_password_grant` as an option for the long term, but heavily discouraging it.

In this PR I've:

- Added a big warning around the `config.skip_client_authentication_for_password_grant` config, but removed the deprecation notice.
- Lightly refactored `Doorkeeper::TokensController`, and made the behavior in https://github.com/doorkeeper-gem/doorkeeper/pull/1370 conditional on `config.skip_client_authentication_for_password_grant`.
- Added tests for https://github.com/doorkeeper-gem/doorkeeper/pull/1370 and https://github.com/doorkeeper-gem/doorkeeper/pull/1420 when `config.skip_client_authentication_for_password_grant` is `true`.
- Updated the `CHANGELOG` - noting this change, but also tweaking the warning for https://github.com/doorkeeper-gem/doorkeeper/pull/1420 slightly. (If this PR is approved I'd also update the [wiki](https://github.com/doorkeeper-gem/doorkeeper/wiki/Migration-from-old-versions#from-5x-to-54x))

Thank you for considering!