### PR TITLE
Use built-in option to remove padding

### DIFF
--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -89,8 +89,7 @@ module Doorkeeper
       # suitable for PKCE validation
       #
       def generate_code_challenge(code_verifier)
-        padded_result = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier))
-        padded_result.split("=")[0] # Remove any trailing '='
+        Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false)
       end
 
       def pkce_supported?


### PR DESCRIPTION
### Summary

I was reading the code and came across how the padding is stripped from the `code_challenge`. There's a builtin option in `Base64.urlsafe_encode64(..., padding: false)` to do that. Tiny tiny change but we're saving a split. :)