### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 cache: bundler
-
+arch:
+  - amd64
+  - ppc64le
+  
 rvm:
   - 2.5
   - 2.6
@@ -21,6 +24,14 @@ matrix:
     - rvm: 2.5
       gemfile: gemfiles/rails_5_2.gemfile
       script: bundle exec danger
+    - rvm: 2.5
+      arch: ppc64le
+      gemfile: gemfiles/rails_5_2.gemfile
+      script: bundle exec danger
   allow_failures:
     - gemfile: gemfiles/rails_master.gemfile
     - rvm: ruby-head
+    - gemfile: gemfiles/rails_master.gemfile
+      arch: ppc64le
+    - rvm: ruby-head
+      arch: ppc64le


### PR DESCRIPTION
Added support for architecture ppc64le.  This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. 
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/doorkeeper