### PR TITLE
Memoize nil doorkeeper_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Add your PR description here.
+- [#1465] Memoize nil doorkeeper_token
 - [#1457] Make owner_id a bigint for newly-generated owner migrations
 - [#1452] Empty previous_refresh_token only if present
 - [#1440] Validate empty host in redirect_uri

--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -38,6 +38,8 @@ module Doorkeeper
 
       # :doc:
       def doorkeeper_token
+        return @doorkeeper_token if defined?(@doorkeeper_token)
+
         @doorkeeper_token ||= OAuth::Token.authenticate(request, *config_methods)
       end
 


### PR DESCRIPTION
### Summary

In some applications extending `AccessToken` class with custom
functionality, it's some times required to call `doorkeeper_token`
method directly. If this method is called multiple times, it can cause
repeated DB calls when there's an invalid token that returns `nil` from
the `OAuth::Token.authenticate` call.

This could be improved by doing similar as in `current_resource_owner`,
where it memoizes `nil` return values for
`instance_eval(&Doorkeeper.config.authenticate_resource_owner)`

With this proposed change, it will memoize `nil` doorkeeper_token
values too.

