### PR TITLE
Enable AuthorizedApplications and Applications controller in API mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Add your PR description here.
+- [#1473] Enable `Applications` and `AuthorizedApplications` controllers in API mode.
+  
+  **[IMPORTANT]** you can still skip these controllers using `skip_controllers` in 
+    `use_doorkeeper` inside `routes.rb`. Please do it in case you don't need them.
+  
 - [#1472] Fix `establish_connection` configuration for custom defined models.
 - [#1471] Add support for Ruby 3.0.
 - [#1469] Check if `redirect_uri` exists.

--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -29,8 +29,6 @@ module Doorkeeper
 
       def initialize(routes, mapper = Mapper.new, &block)
         super
-
-        @mapping.skips.push(:applications, :authorized_applications) if Doorkeeper.config.api_only
       end
 
       def generate_routes!(options)


### PR DESCRIPTION
We manually skip these controllers so developers who want to use them have to patch internals. We had to skip controllers before JSON API support was added to controllers, so now we can safely enable them back and allow developers to choose either they want to disable them or not. Also these endpoints are protected by default (admin / resource owner) so it's safe enough to enable them by default.

You can still skip these controllers using `skip_controllers` in `use_doorkeeper` inside `routes.rb`. Please do it in case you don't need them. See https://github.com/doorkeeper-gem/doorkeeper/wiki/Customizing-routes

Fixes #1448 