### PR TITLE
Simplify TokenInfoController to be overridable (extract response rendering)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## master
 
 - [#PR ID] Add your PR description here.
+- [#1482] Simplify `TokenInfoController` to be overridable (extract response rendering).
 - [#1478] Fix ownership association and Rake tasks when custom models configured.
 - [#1477] Respect `ActiveRecord::Base.pluralize_table_names` for Doorkeeper table names.
 

--- a/app/controllers/doorkeeper/token_info_controller.rb
+++ b/app/controllers/doorkeeper/token_info_controller.rb
@@ -4,12 +4,22 @@ module Doorkeeper
   class TokenInfoController < Doorkeeper::ApplicationMetalController
     def show
       if doorkeeper_token&.accessible?
-        render json: doorkeeper_token, status: :ok
+        render json: doorkeeper_token_to_json, status: :ok
       else
         error = OAuth::InvalidTokenResponse.new
         response.headers.merge!(error.headers)
-        render json: error.body, status: error.status
+        render json: error_to_json(error), status: error.status
       end
+    end
+
+    protected
+
+    def doorkeeper_token_to_json
+      doorkeeper_token
+    end
+
+    def error_to_json(error)
+      error.body
     end
   end
 end


### PR DESCRIPTION
Now you can override response(s) for `Doorkeeper::TokenInfoController` with more elegant way:

```ruby
class TokenInfoController < Doorkeeper::TokenInfoController
  protected

  def doorkeeper_token_to_json
    {}
  end

  def error_to_json(error)
    {}
  end
end

# config/routes.rb
Rails.application.routes.draw do
  use_doorkeeper do
    controllers token_info: 'token_info_controller'
  end
end
```

Relates to #1466
