### PR TITLE
Fix ROPC client authentication validation when it's optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ User-visible changes worth mentioning.
 ## main
 
 - [#PR ID] Add your PR description here.
+- [#1488] Verify client authentication for Resource Owner Password Grant when
+  `config.skip_client_authentication_for_password_grant` is set and the client credentials
+  are sent in a HTTP Basic auth header.
 
 ## 5.5.0
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -278,6 +278,10 @@ module Doorkeeper
     # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1189
     option :token_reuse_limit,              default: 100
 
+    # Don't require client authentication for password grants. If client credentials
+    # are present they will still be validated, and the grant rejected if the credentials
+    # are invalid.
+    #
     # This is discouraged. Spec says that password grants always require a client.
     #
     # See https://github.com/doorkeeper-gem/doorkeeper/issues/1412#issuecomment-632750422

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -10,12 +10,13 @@ module Doorkeeper
       validate :resource_owner, error: :invalid_grant
       validate :scopes, error: :invalid_scope
 
-      attr_reader :client, :resource_owner, :parameters, :access_token
+      attr_reader :client, :credentials, :resource_owner, :parameters, :access_token
 
-      def initialize(server, client, resource_owner, parameters = {})
+      def initialize(server, client, credentials, resource_owner, parameters = {})
         @server          = server
         @resource_owner  = resource_owner
         @client          = client
+        @credentials     = credentials
         @parameters      = parameters
         @original_scopes = parameters[:scope]
         @grant_type      = Doorkeeper::OAuth::PASSWORD
@@ -60,7 +61,7 @@ module Doorkeeper
       #
       def validate_client
         if Doorkeeper.config.skip_client_authentication_for_password_grant
-          !parameters[:client_id] || client.present?
+          client.present? || (!parameters[:client_id] && credentials.blank?)
         else
           client.present?
         end

--- a/lib/doorkeeper/request/password.rb
+++ b/lib/doorkeeper/request/password.rb
@@ -9,6 +9,7 @@ module Doorkeeper
         @request ||= OAuth::PasswordAccessTokenRequest.new(
           Doorkeeper.config,
           client,
+          credentials,
           resource_owner,
           parameters,
         )


### PR DESCRIPTION
### Summary

When `skip_client_authentication_for_password_grant` is enabled and invalid client credentials are present in a Basic auth header, an access token is still granted.

We do validate if `client_id` is present as a query-string parameter, and should do the same if an authorization header is present.

### Other Information

See previous PRs https://github.com/doorkeeper-gem/doorkeeper/pull/1420 and https://github.com/doorkeeper-gem/doorkeeper/pull/1458.

I guess this option should really be called `require_client_authentication_for_password_grant` to make the intent clearer, but I guess it's too late for that now :wink: 

Still, this change should be useful for correctness and troubleshooting purposes. I don't think there's really a security aspect to this since clients can also just not send any credentials at all.