### PR TITLE
Make respond_to available for API-Only applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#PR ID] Add your PR description here.
+- [#1495] Fix `respond_to` undefined in API-only mode 
 - [#1488] Verify client authentication for Resource Owner Password Grant when
   `config.skip_client_authentication_for_password_grant` is set and the client credentials
   are sent in a HTTP Basic auth header.

--- a/app/controllers/doorkeeper/application_controller.rb
+++ b/app/controllers/doorkeeper/application_controller.rb
@@ -4,6 +4,7 @@ module Doorkeeper
   class ApplicationController <
     Doorkeeper.config.resolve_controller(:base)
     include Helpers::Controller
+    include ActionController::MimeResponds if Doorkeeper.config.api_only
 
     unless Doorkeeper.config.api_only
       protect_from_forgery with: :exception

--- a/app/controllers/doorkeeper/authorized_applications_controller.rb
+++ b/app/controllers/doorkeeper/authorized_applications_controller.rb
@@ -26,7 +26,7 @@ module Doorkeeper
           )
         end
 
-        format.json { render :no_content }
+        format.json { head :no_content }
       end
     end
   end


### PR DESCRIPTION
### Summary
This PR fixes that the `respond_to` was not found in the API only mode. I also found a little bug that when removing an authorized application in API only mode the response code was 200 with an empty payload instead of a 204. 

Resolved #1494