### PR TITLE
Revoke old_refresh_token if previous_refresh_token is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#PR ID] Add your PR description here.
+- [#1496] Revoke `old_refresh_token` if `previous_refresh_token` is present.
 - [#1495] Fix `respond_to` undefined in API-only mode 
 - [#1488] Verify client authentication for Resource Owner Password Grant when
   `config.skip_client_authentication_for_password_grant` is set and the client credentials

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -374,10 +374,10 @@ module Doorkeeper
     # and clears `:previous_refresh_token` attribute.
     #
     def revoke_previous_refresh_token!
-      return unless self.class.refresh_token_revoked_on_use?
+      return if !self.class.refresh_token_revoked_on_use? || previous_refresh_token.blank?
 
       old_refresh_token&.revoke
-      update_attribute(:previous_refresh_token, "") if previous_refresh_token.present?
+      update_attribute(:previous_refresh_token, "")
     end
 
     private


### PR DESCRIPTION
### Summary

When `doorkeeper_authorize!` was called, 2 queries were executed like below:

```
Doorkeeper::AccessToken Load (0.9ms)  SELECT "oauth_access_tokens".* FROM "oauth_access_tokens" WHERE "oauth_access_tokens"."token" = $1 LIMIT $2  [["token", "e88af143a8a378f5a46c6a955c2aff7566373ad686b4185aab7272ce186a696e"], ["LIMIT", 1]]
Doorkeeper::AccessToken Load (0.7ms)  SELECT "oauth_access_tokens".* FROM "oauth_access_tokens" WHERE "oauth_access_tokens"."refresh_token" = $1 LIMIT $2  [["refresh_token", ""], ["LIMIT", 1]]
```

I think last query is meaningless in this case, so I fixed `old_refresh_token` will be called when `previous_refresh_token` is present. 

https://github.com/doorkeeper-gem/doorkeeper/blob/e048bedb7813bb273e05554a66cc1c0411638d44/lib/doorkeeper/models/access_token_mixin.rb#L391-L393

https://github.com/doorkeeper-gem/doorkeeper/blob/e048bedb7813bb273e05554a66cc1c0411638d44/lib/doorkeeper/models/access_token_mixin.rb#L55-L57

Related issue: https://github.com/doorkeeper-gem/doorkeeper/pull/1452.