### PR TITLE
Ensure AccessToken#expired? always returns a boolean

### DIFF
--- a/lib/doorkeeper/models/concerns/expirable.rb
+++ b/lib/doorkeeper/models/concerns/expirable.rb
@@ -8,7 +8,7 @@ module Doorkeeper
       #
       # @return [Boolean] true if object expired and false in other case
       def expired?
-        expires_in && Time.now.utc > expires_at
+        !!(expires_in && Time.now.utc > expires_at)
       end
 
       # Calculates expiration time in seconds.


### PR DESCRIPTION
I noticed compared to `revoked?` `expired?` may return `nil` :)
