### PR TITLE
Updated the URL fragment in the comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#PR ID] Add your PR description here.
 - [#1502] Drop support for Ruby 2.4 because of EOL.
+- [#1504] Updated the url fragment in the comment.
 
 ## 5.5.1
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -374,7 +374,7 @@ module Doorkeeper
 
     # The controller Doorkeeper::ApplicationController inherits from.
     # Defaults to ActionController::Base.
-    # https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-base-controller
+    # https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-controllers
     #
     # @param base_controller [String] the name of the base controller
     option :base_controller,

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -120,7 +120,7 @@ Doorkeeper.configure do
   # The controller +Doorkeeper::ApplicationController+ inherits from.
   # Defaults to +ActionController::Base+ unless +api_only+ is set, which changes the default to
   # +ActionController::API+. The return value of this option must be a stringified class name.
-  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-base-controller
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-controllers
   #
   # base_controller 'ApplicationController'
 


### PR DESCRIPTION
### Summary

Updated the URL fragment in the comment, as it is still outdated.

### Other Information

The fragment of the guide page has been changed by this commit.
https://github.com/doorkeeper-gem/guides/commit/c7d44cf27c78b26c5708c757a04756863fc6269a#diff-39a543265faf95bfa5c45320f86543d270f927190008959cc10701a46bfde059L15-R16
