### PR TITLE
Fix that authorization code is returned by fragment if response_mode is fragament

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-visible changes worth mentioning.
 - [#1502] Drop support for Ruby 2.4 because of EOL.
 - [#1504] Updated the url fragment in the comment.
 - [#1512] Fix form behavior when response mode is form_post.
+- [#1511] Fix that authorization code is returned by fragment if response_mode is fragament.
 
 ## 5.5.1
 

--- a/lib/doorkeeper/oauth/code_request.rb
+++ b/lib/doorkeeper/oauth/code_request.rb
@@ -13,7 +13,7 @@ module Doorkeeper
       def authorize
         auth = Authorization::Code.new(pre_auth, resource_owner)
         auth.issue_token!
-        CodeResponse.new(pre_auth, auth)
+        CodeResponse.new(pre_auth, auth, response_on_fragment: pre_auth.response_mode == "fragment")
       end
 
       def deny

--- a/spec/lib/oauth/code_request_spec.rb
+++ b/spec/lib/oauth/code_request_spec.rb
@@ -20,19 +20,30 @@ RSpec.describe Doorkeeper::OAuth::CodeRequest do
       client_id: client.uid,
       response_type: "code",
       redirect_uri: "https://app.com/callback",
-    }
+      response_mode: response_mode,
+    }.compact
 
     pre_auth = Doorkeeper::OAuth::PreAuthorization.new(Doorkeeper.config, attributes)
     pre_auth.authorizable?
     pre_auth
   end
 
+  let(:response_mode) { nil }
   let(:owner) { FactoryBot.create(:resource_owner) }
 
   context "when pre_auth is authorized" do
     it "creates an access grant and returns a code response" do
       expect { request.authorize }.to change { Doorkeeper::AccessGrant.count }.by(1)
       expect(request.authorize).to be_a(Doorkeeper::OAuth::CodeResponse)
+      expect(request.authorize.response_on_fragment).to be false
+    end
+
+    context "with 'fragment' as response_mode" do
+      let(:response_mode) { "fragment" }
+
+      it "returns a code response with response_on_fragment set to true" do
+        expect(request.authorize.response_on_fragment).to be true
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

There is a problem that the authorization code is returned in the query even if "fragment" is specified for response_mode in the authorization request.

### Other Information

Whether the authorization code is returned as a query or as a fragment is determined by the following in `CodeResponse`.
https://github.com/doorkeeper-gem/doorkeeper/blob/a56b1a5379e97fed5cf838f834702724e070db38/lib/doorkeeper/oauth/code_response.rb#L43-L47

In order for this to be determined correctly, `response_on_fragment` must be passed when initializing `CodeResponse`.
However, since `response_on_fragment` is not specified when `CodeReponse` is initialized in `CodeRequest`.
Therefore, the authorization code is always returned in query.
