### PR TITLE
Fix form behavior when response mode is form_post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ User-visible changes worth mentioning.
 - [#PR ID] Add your PR description here.
 - [#1502] Drop support for Ruby 2.4 because of EOL.
 - [#1504] Updated the url fragment in the comment.
+- [#1512] Fix form behavior when response mode is form_post.
 
 ## 5.5.1
 

--- a/app/views/doorkeeper/authorizations/form_post.html.erb
+++ b/app/views/doorkeeper/authorizations/form_post.html.erb
@@ -2,10 +2,14 @@
   <h1><%= t('.title') %></h1>
 </header>
 
-<main role="main" onload="document.forms[0].submit()">
-  <%= form_tag @pre_auth.redirect_uri, method: :post do %>
-    <% @authorize_response.body.each do |key, value| %>
-      <%= hidden_field_tag key, value %>
-    <% end %>
+<%= form_tag @pre_auth.redirect_uri, method: :post, name: :redirect_form, authenticity_token: false do %>
+  <% @authorize_response.body.compact.each do |key, value| %>
+    <%= hidden_field_tag key, value %>
   <% end %>
-</main>
+<% end %>
+
+<script>
+  window.onload = function () {
+    document.forms['redirect_form'].submit();
+  };
+</script>

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -25,6 +25,7 @@
       <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
       <%= hidden_field_tag :state, @pre_auth.state %>
       <%= hidden_field_tag :response_type, @pre_auth.response_type %>
+      <%= hidden_field_tag :response_mode, @pre_auth.response_mode %>
       <%= hidden_field_tag :scope, @pre_auth.scope %>
       <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge %>
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method %>
@@ -35,6 +36,7 @@
       <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
       <%= hidden_field_tag :state, @pre_auth.state %>
       <%= hidden_field_tag :response_type, @pre_auth.response_type %>
+      <%= hidden_field_tag :response_mode, @pre_auth.response_mode %>
       <%= hidden_field_tag :scope, @pre_auth.scope %>
       <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge %>
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method %>


### PR DESCRIPTION
### Summary

There are three problems with the behavior when `response_mode=form_post` is specified

- Form is not automatically posted.
- When no state is specified, an empty state is posted.
- Unnecessary authenticity_token is posted.
- response_mode is not posted when approving or denying.

### Other Information

N/A