### PR TITLE
Form errors using Bootstrap's invalid-class

### DIFF
--- a/app/helpers/doorkeeper/dashboard_helper.rb
+++ b/app/helpers/doorkeeper/dashboard_helper.rb
@@ -6,7 +6,7 @@ module Doorkeeper
       return if object.errors[method].blank?
 
       output = object.errors[method].map do |msg|
-        content_tag(:span, class: "form-text") do
+        content_tag(:span, class: "invalid-feedback") do
           msg.capitalize
         end
       end


### PR DESCRIPTION
### Summary

Changed `doorkeeper_errors_for` to use Bootstrap's `invalid-feedback` class, which produces red highlighted text next to the corresponding field. Below is a screenshot of how it looks like:

![image](https://user-images.githubusercontent.com/2123767/123890580-1d80cc00-d960-11eb-9824-143d7838a5b8.png)