### PR TITLE
remove redirect uri from auth request

### DIFF
--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -7,7 +7,7 @@ module Doorkeeper
       validate :client,       error: :invalid_client
       validate :grant,        error: :invalid_grant
       # @see https://tools.ietf.org/html/rfc6749#section-5.2
-      validate :redirect_uri, error: :invalid_grant
+      validate :redirect_uri, error: :invalid_grant, if: -> { !Doorkeeper.config.allow_blank_redirect_uri }
       validate :code_verifier, error: :invalid_grant
 
       attr_reader :grant, :client, :redirect_uri, :access_token, :code_verifier,
@@ -57,7 +57,7 @@ module Doorkeeper
       def validate_params
         @missing_param = if grant&.uses_pkce? && code_verifier.blank?
                            :code_verifier
-                         elsif redirect_uri.blank?
+                         elsif !Doorkeeper.config.allow_blank_redirect_uri && redirect_uri.blank?
                            :redirect_uri
                          end
 

--- a/lib/doorkeeper/validations.rb
+++ b/lib/doorkeeper/validations.rb
@@ -10,6 +10,8 @@ module Doorkeeper
       @error = nil
 
       self.class.validations.each do |validation|
+        next unless validation[:options][:if]&.call
+
         @error = validation[:options][:error] unless send("validate_#{validation[:attribute]}")
         break if @error
       end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -220,4 +220,19 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
       end
     end
   end
+
+  context "without a redirect uri" do
+    let(:params) { {} }
+
+    it "does not throw an error without a redirect_uri" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        allow_blank_redirect_uri true
+      end
+
+      request.validate
+
+      expect(request.error).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Hello everyone!

I'm currently stumped on this one. According to the company I'm trying to integrate with, `redirect_uri` shouldn't be required for requesting an access token. Which makes sense to me but I'm not 100% in what is supposed to happen. I tried making request_uri optional from my DB but it looks like `request_uri` is required from the `AuthorizationCodeRequest`.

```bash
# account linking
account_linking=$(
    curl -X GET ${BASE_URL}/oauth/authorize \
    -F response_type=code \
    -F scopes=${SCOPES} \
    -F redirect_uri=${REDIRECT_URI} \
    -F client_id=${CLIENT_ID} \
    -F client_secret=${CLIENT_SECRET}
)

# request access token
# redirect_uri shoulnd't be required here
code="tOgZlTLHWtfFpqxsHSDRCOID-ky0VU2Yvpc9Mw1Dh0g"
access_token=$(
    curl -vvv -X POST ${BASE_URL}/oauth/token \
    -F grant_type=authorization_code \
    -F code=${code} \
    -F client_id=${CLIENT_ID} \
    -F client_secret=${CLIENT_SECRET}
)

# echo $account_linking
echo $access_token
```

This PR removes this `request_uri` requirement.