### PR TITLE
Allow blank redirect URI in authorization request

### DIFF
--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -55,11 +55,9 @@ module Doorkeeper
       end
 
       def validate_params
-        @missing_param = if grant&.uses_pkce? && code_verifier.blank?
-                           :code_verifier
-                         elsif redirect_uri.blank?
-                           :redirect_uri
-                         end
+        if grant&.uses_pkce? && code_verifier.blank?
+          @missing_param = :code_verifier
+        end
 
         @missing_param.nil?
       end
@@ -75,6 +73,13 @@ module Doorkeeper
       end
 
       def validate_redirect_uri
+        # 4.1.1.  Authorization Request
+        #   redirect_uri
+        #      OPTIONAL.  As described in Section 3.1.2.
+        #
+        # @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
+        return true if redirect_uri.nil?
+
         Helpers::URIChecker.valid_for_authorization?(
           redirect_uri,
           grant.redirect_uri,

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -97,7 +97,12 @@ module Doorkeeper
       end
 
       def validate_redirect_uri
-        return false if redirect_uri.blank?
+        # Authorization request `redirect_uri` parameter is optional.
+        # Should validate in case it's provided, otherwise use one from the client
+        if redirect_uri.nil?
+          @redirect_uri = client.redirect_uri
+          return true
+        end
 
         Helpers::URIChecker.valid_for_authorization?(
           redirect_uri,

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -65,13 +65,6 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
     expect(request.error).to eq(:invalid_client)
   end
 
-  it "requires the redirect_uri" do
-    request = described_class.new(server, grant, nil, params.except(:redirect_uri))
-    request.validate
-    expect(request.error).to eq(:invalid_request)
-    expect(request.missing_param).to eq(:redirect_uri)
-  end
-
   it "matches the redirect_uri with grant's one" do
     request = described_class.new(server, grant, client, params.merge(redirect_uri: "http://other.com"))
     request.validate

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -243,11 +243,6 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
     expect(pre_auth).not_to be_authorizable
   end
 
-  it "requires a redirect uri" do
-    attributes[:redirect_uri] = nil
-    expect(pre_auth).not_to be_authorizable
-  end
-
   context "when resource_owner cannot access client application" do
     before { allow(Doorkeeper.configuration).to receive(:authorize_resource_owner_for_client).and_return(->(*_) { false }) }
 
@@ -256,7 +251,15 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
     end
   end
 
-  describe "as_json" do
+  describe "#redirect_uri" do
+    it "uses a redirect uri from the grant if not provided in the params" do
+      attributes[:redirect_uri] = nil
+      expect(pre_auth).to be_authorizable
+      expect(pre_auth.redirect_uri).to eq(client.redirect_uri)
+    end
+  end
+
+  describe "#as_json" do
     before { pre_auth.authorizable? }
 
     it { is_expected.to respond_to :as_json }

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -24,6 +24,19 @@ feature "Authorization Code Flow" do
     url_should_not_have_param("error")
   end
 
+  scenario "resource owner authorizes the client without redirect URI provided" do
+    visit "/oauth/authorize?client_id=#{@client.uid}&response_type=code"
+    click_on "Authorize"
+
+    access_grant_should_exist_for(@client, @resource_owner)
+
+    i_should_be_on_client_callback(@client)
+
+    url_should_have_param("code", Doorkeeper::AccessGrant.first.token)
+    url_should_not_have_param("state")
+    url_should_not_have_param("error")
+  end
+
   context "when configured to check application supported grant flow" do
     before do
       config_is_set(:allow_grant_flow_for_client, ->(_grant_flow, client) { client.name == "admin" })

--- a/spec/requests/flows/implicit_grant_errors_spec.rb
+++ b/spec/requests/flows/implicit_grant_errors_spec.rb
@@ -36,12 +36,6 @@ feature "Implicit Grant Flow Errors" do
       i_should_not_see "Authorize"
       i_should_see_translated_error_message :invalid_redirect_uri
     end
-
-    scenario "displays invalid_redirect_uri error when redirect_uri is missing" do
-      visit authorization_endpoint_url(client: @client, redirect_uri: "", response_type: "token")
-      i_should_not_see "Authorize"
-      i_should_see_translated_error_message :invalid_redirect_uri
-    end
   end
 
   context "when validate response_mode param" do


### PR DESCRIPTION
Allow to skip redirect_uri parameter for authorization request [as stated in RFC 6749 section 4.1.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1 ).

Fixes #1518