### PR TITLE
all link that was redirected is now changed to the true url

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ functionality to your Ruby on Rails or Grape application.
 
 Supported features:
 
-- [The OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749)
-  - [Authorization Code Flow](http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-4.1)
-  - [Access Token Scopes](http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-3.3)
-  - [Refresh token](http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-1.5)
-  - [Implicit grant](http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-4.2)
-  - [Resource Owner Password Credentials](http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-4.3)
-  - [Client Credentials](http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-4.4)
-- [OAuth 2.0 Token Revocation](http://tools.ietf.org/html/rfc7009)
-- [OAuth 2.0 Token Introspection](https://tools.ietf.org/html/rfc7662)
-- [OAuth 2.0 Threat Model and Security Considerations](http://tools.ietf.org/html/rfc6819)
-- [OAuth 2.0 for Native Apps](https://tools.ietf.org/html/draft-ietf-oauth-native-apps-10)
-- [Proof Key for Code Exchange by OAuth Public Clients](https://tools.ietf.org/html/rfc7636)
+- [The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
+  - [Authorization Code Flow](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1)
+  - [Access Token Scopes](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3)
+  - [Refresh token](https://datatracker.ietf.org/doc/html/rfc6749#section-1.5)
+  - [Implicit grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.2)
+  - [Resource Owner Password Credentials](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3)
+  - [Client Credentials](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4)
+- [OAuth 2.0 Token Revocation](https://datatracker.ietf.org/doc/html/rfc7009)
+- [OAuth 2.0 Token Introspection](https://datatracker.ietf.org/doc/html/rfc7662)
+- [OAuth 2.0 Threat Model and Security Considerations](https://datatracker.ietf.org/doc/html/rfc6819)
+- [OAuth 2.0 for Native Apps](https://datatracker.ietf.org/doc/html/rfc8252)
+- [Proof Key for Code Exchange by OAuth Public Clients](https://datatracker.ietf.org/doc/html/rfc7636)
 
 ## Table of Contents
 

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -12,7 +12,7 @@ module Doorkeeper
       handle_token_exception(e)
     end
 
-    # OAuth 2.0 Token Revocation - http://tools.ietf.org/html/rfc7009
+    # OAuth 2.0 Token Revocation - https://datatracker.ietf.org/doc/html/rfc7009
     def revoke
       # The authorization server responds with HTTP status code 200 if the client
       # submitted an invalid token or the token has been revoked successfully.
@@ -94,8 +94,8 @@ module Doorkeeper
     # types, they set the application_id as null (since the claim cannot be
     # verified).
     #
-    # https://tools.ietf.org/html/rfc6749#section-2.1
-    # https://tools.ietf.org/html/rfc7009
+    # https://datatracker.ietf.org/doc/html/rfc6749#section-2.1
+    # https://datatracker.ietf.org/doc/html/rfc7009
     def authorized?
       # Token belongs to specific client, so we need to check if
       # authenticated client could access it.

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -49,7 +49,7 @@ module Doorkeeper
       end
 
       # Implements PKCE code_challenge encoding without base64 padding as described in the spec.
-      # https://tools.ietf.org/html/rfc7636#appendix-A
+      # https://datatracker.ietf.org/doc/html/rfc7636#appendix-A
       #   Appendix A.  Notes on Implementing Base64url Encoding without Padding
       #
       #   This appendix describes how to implement a base64url-encoding

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -279,7 +279,7 @@ module Doorkeeper
     end
 
     # Access Token type: Bearer.
-    # @see https://tools.ietf.org/html/rfc6750
+    # @see https://datatracker.ietf.org/doc/html/rfc6750
     #   The OAuth 2.0 Authorization Framework: Bearer Token Usage
     #
     def token_type

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -6,7 +6,7 @@ module Doorkeeper
       validate :params,       error: :invalid_request
       validate :client,       error: :invalid_client
       validate :grant,        error: :invalid_grant
-      # @see https://tools.ietf.org/html/rfc6749#section-5.2
+      # @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
       validate :redirect_uri, error: :invalid_grant
       validate :code_verifier, error: :invalid_grant
 

--- a/lib/doorkeeper/oauth/helpers/unique_token.rb
+++ b/lib/doorkeeper/oauth/helpers/unique_token.rb
@@ -11,8 +11,8 @@ module Doorkeeper
           # Access Token value must be 1*VSCHAR or
           # 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
           #
-          # @see https://tools.ietf.org/html/rfc6749#appendix-A.12
-          # @see https://tools.ietf.org/html/rfc6750#section-2.1
+          # @see https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.12
+          # @see https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
           #
           generator = options.delete(:generator) || SecureRandom.method(default_generator_method)
           token_size = options.delete(:size) || 32

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -28,7 +28,7 @@ module Doorkeeper
           end
 
           # RFC8252, Paragraph 7.3
-          # @see https://tools.ietf.org/html/rfc8252#section-7.3
+          # @see https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
           if loopback_uri?(url) && loopback_uri?(client_url)
             url.port = nil
             client_url.port = nil

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -57,7 +57,7 @@ module Doorkeeper
       #
       #    o  authenticate the client if client authentication is included,
       #
-      #   @see https://tools.ietf.org/html/rfc6749#section-4.3
+      #   @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.3
       #
       def validate_client
         if Doorkeeper.config.skip_client_authentication_for_password_grant

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -101,7 +101,7 @@ module Doorkeeper
         client.present?
       end
 
-      # @see https://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-1.5
+      # @see https://datatracker.ietf.org/doc/html/rfc6749#section-1.5
       #
       def validate_client_match
         return true if refresh_token.application_id.blank?

--- a/lib/doorkeeper/oauth/token_introspection.rb
+++ b/lib/doorkeeper/oauth/token_introspection.rb
@@ -4,7 +4,7 @@ module Doorkeeper
   module OAuth
     # RFC7662 OAuth 2.0 Token Introspection
     #
-    # @see https://tools.ietf.org/html/rfc7662
+    # @see https://datatracker.ietf.org/doc/html/rfc7662
     class TokenIntrospection
       def initialize(server, token)
         @server = server
@@ -107,7 +107,7 @@ module Doorkeeper
       # authorization server SHOULD NOT include any additional information
       # about an inactive token, including why the token is inactive.
       #
-      # @see https://tools.ietf.org/html/rfc7662 2.2. Introspection Response
+      # @see https://datatracker.ietf.org/doc/html/rfc7662 2.2. Introspection Response
       #
       def failure_response
         {
@@ -186,7 +186,7 @@ module Doorkeeper
       # Provides context (controller) and token for generating developer-specific
       # response.
       #
-      # @see https://tools.ietf.org/html/rfc7662#section-2.2
+      # @see https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
       #
       def customize_response(response)
         customized_response = Doorkeeper.config.custom_introspection_response.call(

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -343,8 +343,8 @@ Doorkeeper.configure do
   #
   # implicit and password grant flows have risks that you should understand
   # before enabling:
-  #   http://tools.ietf.org/html/rfc6819#section-4.4.2
-  #   http://tools.ietf.org/html/rfc6819#section-4.4.3
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.3
   #
   # grant_flows %w[authorization_code client_credentials]
 

--- a/lib/generators/doorkeeper/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/migration.rb.erb
@@ -61,7 +61,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
       # *the client MUST discard the old refresh token* and replace it with the
       # new refresh token. The authorization server MAY revoke the old
       # refresh token after issuing a new refresh token to the client.
-      # @see https://tools.ietf.org/html/rfc6749#section-6
+      # @see https://datatracker.ietf.org/doc/html/rfc6749#section-6
       #
       # Doorkeeper implementation: if there is a `previous_refresh_token` column,
       # refresh tokens will be revoked after a related access token is used.

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Doorkeeper::TokensController do
     end
   end
 
-  # http://tools.ietf.org/html/rfc7009#section-2.2
+  # https://datatracker.ietf.org/doc/html/rfc7009#section-2.2
   describe "POST #revoke" do
     let(:client) { FactoryBot.create(:application) }
     let(:access_token) { FactoryBot.create(:access_token, application: client) }

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -84,8 +84,8 @@ Doorkeeper.configure do
   #
   # implicit and password grant flows have risks that you should understand
   # before enabling:
-  #   http://tools.ietf.org/html/rfc6819#section-4.4.2
-  #   http://tools.ietf.org/html/rfc6819#section-4.4.3
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.3
   #
   # grant_flows %w[authorization_code client_credentials]
 


### PR DESCRIPTION
### Summary

Whenever I was going through the doorkeeper's documentation and clicking the links with `http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-4.1` it was sometimes failing to redirect. Also as all the link was from drafts some working links didn't have the proper information. That's why I tried to fix all the URLs in the documentation so that no one faces this anymore.

### Other Information

Also if you search the website for topics like `Oauth Authorization` you will see they are also notifying that their links have changed for example `RFC 6749 (was draft-ietf-oauth-v2)`

![Screen Shot 2021-08-29 at 5 59 04 PM](https://user-images.githubusercontent.com/33386534/131249612-0d6a0575-f8af-4904-a384-cff3d1686186.png)

So I thought maybe it's best if the doorkeeper has all the new links.
