### PR TITLE
Change translation source for forbidden token error message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ User-visible changes worth mentioning.
 ## main
 
 - [#1528] Don't allow extra query params in redirect_uri
+- [#1519] Allow to skip redirect_uri parameter for authorization request as stated in RFC 6749 section 4.1.1.
+- [#1525] I18n source for forbidden token error is now `doorkeeper.errors.messages.forbidden_token.missing_scope`.
 - [#PR ID] Add your PR description here.
 
 ## 5.5.2

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,9 @@ en:
         revoke:
           unauthorized: "You are not authorized to revoke this token"
 
+        forbidden_token:
+          missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
+
     flash:
       applications:
         create:

--- a/lib/doorkeeper/oauth/forbidden_token_response.rb
+++ b/lib/doorkeeper/oauth/forbidden_token_response.rb
@@ -23,7 +23,8 @@ module Doorkeeper
       end
 
       def description
-        @description ||= @scopes.map { |s| I18n.t(s, scope: %i[doorkeeper scopes]) }.join("\n")
+        @description ||= I18n.t("doorkeeper.errors.messages.forbidden_token.missing_scope",
+                                oauth_scopes: @scopes.map(&:to_s).join(" "),)
       end
 
       protected

--- a/spec/lib/oauth/forbidden_token_response_spec.rb
+++ b/spec/lib/oauth/forbidden_token_response_spec.rb
@@ -14,9 +14,18 @@ RSpec.describe Doorkeeper::OAuth::ForbiddenTokenResponse do
   end
 
   describe ".from_scopes" do
-    it "have a list of acceptable scopes" do
-      response = described_class.from_scopes(["public"])
+    subject(:response) { described_class.from_scopes(["public"]) }
+
+    it "includes a list of acceptable scopes" do
       expect(response.description).to include("public")
+    end
+
+    it "explains that the problem is due to a missing scope" do
+      expect(response.description).to match(/requires scope/i)
+    end
+
+    it "does not use the scope description from authorize page" do
+      expect(response.description).not_to eql("Access your public data")
     end
   end
 end


### PR DESCRIPTION
### Summary

Changes error message source text for forbidden tokens due to incorrect scope when accessing a resource. 

The previous re-use of the scope descriptions leads to odd error messages, e.g. `{"error": "Access your public data"}`, because the text is intended for a different purpose.

The fix is to use a new dedicated source for the text of fobidden token errors.

The new locale key is `doorkeeper.errors.messages.forbidden_token.missing_scope`. The new default English error response this produces is `{"error": 'Access to this resource requires scope "public".'}` 

