### PR TITLE
Fix redirect_uri validation with query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#1519] Allow to skip redirect_uri parameter for authorization request as stated in RFC 6749 section 4.1.1.
+- [#1528] Don't allow extra query params in redirect_uri
 - [#PR ID] Add your PR description here.
 
 ## 5.5.2

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -19,12 +19,13 @@ module Doorkeeper
           url = as_uri(url)
           client_url = as_uri(client_url)
 
-          unless client_url.query.nil?
+          unless client_url.query.nil? && url.query.nil?
             return false unless query_matches?(url.query, client_url.query)
 
             # Clear out queries so rest of URI can be tested. This allows query
             # params to be in the request but order not mattering.
             client_url.query = nil
+            url.query = nil
           end
 
           # RFC8252, Paragraph 7.3
@@ -34,7 +35,6 @@ module Doorkeeper
             client_url.port = nil
           end
 
-          url.query = nil
           url == client_url
         end
 

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -130,11 +130,11 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
   end
 
   context "when redirect_uri contains some query params" do
-    let(:redirect_uri) { client.redirect_uri + "?query=q" }
+    let(:redirect_uri) { "#{client.redirect_uri}?query=q" }
 
-    it "compares only host part with grant's redirect_uri" do
+    it "responds with invalid_grant" do
       request.validate
-      expect(request.error).to eq(nil)
+      expect(request.error).to eq(:invalid_grant)
     end
   end
 

--- a/spec/lib/oauth/helpers/uri_checker_spec.rb
+++ b/spec/lib/oauth/helpers/uri_checker_spec.rb
@@ -72,10 +72,10 @@ module Doorkeeper::OAuth::Helpers
         expect(described_class).to be_matches(uri, client_uri)
       end
 
-      it "ignores query parameter on comparison" do
+      it "doesn't allow additional query parameters" do
         uri = "http://app.co/?query=hello"
         client_uri = "http://app.co"
-        expect(described_class).to be_matches(uri, client_uri)
+        expect(described_class).not_to be_matches(uri, client_uri)
       end
 
       it "doesn't allow non-matching domains through" do
@@ -133,7 +133,7 @@ module Doorkeeper::OAuth::Helpers
           expect(described_class).not_to be_matches(uri, client_uri)
         end
 
-        it "is true if queries are present and matche" do
+        it "is true if queries are present and match" do
           uri = "http://app.co/?vendorId=AJ4L7XXW9&foo=bar"
           client_uri = "http://app.co/?vendorId=AJ4L7XXW9&foo=bar"
           expect(described_class).to be_matches(uri, client_uri)


### PR DESCRIPTION
### Summary

According to OAuth 2.0 protocol redirect_uri
shouldn't contain any extra query params.
We should consider exact query params list match
when comparing redirect_uris

More on topic: https://tools.ietf.org/id/draft-ietf-oauth-security-topics-18.html#name-protecting-redirect-based-f

Fixes https://github.com/doorkeeper-gem/doorkeeper/issues/1527
