### PR TITLE
Disable strict-loading for models by default (fixes #1509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ User-visible changes worth mentioning.
 
 ## main
 
-- [#1528] Don't allow extra query params in redirect_uri
+- [#1528] Don't allow extra query params in redirect_uri.
 - [#1525] I18n source for forbidden token error is now `doorkeeper.errors.messages.forbidden_token.missing_scope`.
+- [#1531] Disable `strict-loading` for models by default.
 - [#PR ID] Add your PR description here.
 
 ## 5.5.2

--- a/lib/doorkeeper/orm/active_record/mixins/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/access_grant.rb
@@ -6,6 +6,7 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
 
     included do
       self.table_name = compute_doorkeeper_table_name
+      self.strict_loading_by_default = false if respond_to?(:strict_loading_by_default)
 
       include ::Doorkeeper::AccessGrantMixin
 

--- a/lib/doorkeeper/orm/active_record/mixins/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/access_token.rb
@@ -6,6 +6,7 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
 
     included do
       self.table_name = compute_doorkeeper_table_name
+      self.strict_loading_by_default = false if respond_to?(:strict_loading_by_default)
 
       include ::Doorkeeper::AccessTokenMixin
 

--- a/lib/doorkeeper/orm/active_record/mixins/application.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/application.rb
@@ -6,6 +6,7 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
 
     included do
       self.table_name = compute_doorkeeper_table_name
+      self.strict_loading_by_default = false if respond_to?(:strict_loading_by_default)
 
       include ::Doorkeeper::ApplicationMixin
 


### PR DESCRIPTION
We trust our self (ha-ha :see_no_evil: ). So no strict-loading by default.
If you wanna to enable it - override the models and enable it (or hack the config somewhere in initializers).