### PR TITLE
Allow state param query in redirect_uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
-- [#PR ID] Add your PR description here.
+- [#1534] Allow the use of `state` query param in the `redirect_uri` conforming with the specs.
 
 ## 5.5.3
 

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -20,7 +20,7 @@ module Doorkeeper
           client_url = as_uri(client_url)
 
           unless client_url.query.nil? && url.query.nil?
-            return false unless query_matches?(url.query, client_url.query)
+            return false unless query_matches?(url.query, client_url.query) || safe_query?(url.query)
 
             # Clear out queries so rest of URI can be tested. This allows query
             # params to be in the request but order not mattering.
@@ -76,6 +76,10 @@ module Doorkeeper
 
         def self.oob_uri?(uri)
           NonStandard::IETF_WG_OAUTH2_OOB_METHODS.include?(uri)
+        end
+
+        def self.safe_query?(query)
+          CGI.parse(query.to_s).keys == ["state"]
         end
       end
     end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -145,6 +145,15 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
     end
   end
 
+  context "when redirect_uri contains `state` query param" do
+    let(:redirect_uri) { "#{client.redirect_uri}?state=q" }
+
+    it "validates the request" do
+      request.validate
+      expect(request.error).to eq(nil)
+    end
+  end
+
   context "when redirect_uri is not an URI" do
     let(:redirect_uri) { "123d#!s" }
 

--- a/spec/lib/oauth/helpers/uri_checker_spec.rb
+++ b/spec/lib/oauth/helpers/uri_checker_spec.rb
@@ -78,6 +78,12 @@ module Doorkeeper::OAuth::Helpers
         expect(described_class).not_to be_matches(uri, client_uri)
       end
 
+      it "allows state query parameter" do
+        uri = "http://app.co/?state=hello"
+        client_uri = "http://app.co"
+        expect(described_class).to be_matches(uri, client_uri)
+      end
+
       it "doesn't allow non-matching domains through" do
         uri = "http://app.abc/?query=hello"
         client_uri = "http://app.co"


### PR DESCRIPTION
### Summary

This PR allows the use of `state` query param in the `redirect_uri`.
According to the specs here:
https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2.2
here
https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
and according to the guide [here](https://www.oauth.com/oauth2-servers/redirect-uris/redirect-uri-registration/#per-request) as well, it is recommended that the client can use the `state` query param to customize the redirect URI according to its needs.

### Other Information

PS: The spec also mention an optional query param `scope`. It's not being covered by this PR though. If you think it should be, please let me know and I will modify the implementation.

