### PR TITLE
Revert disallowing query params in redirect_uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
-- [#PR ID] Add your PR description here.
+- [#1535] Revert changes introduced in #1528 to allow query params in `redirect_uri` as per the spec.
 
 ## 5.5.3
 

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -19,13 +19,12 @@ module Doorkeeper
           url = as_uri(url)
           client_url = as_uri(client_url)
 
-          unless client_url.query.nil? && url.query.nil?
+          unless client_url.query.nil?
             return false unless query_matches?(url.query, client_url.query)
 
             # Clear out queries so rest of URI can be tested. This allows query
             # params to be in the request but order not mattering.
             client_url.query = nil
-            url.query = nil
           end
 
           # RFC8252, Paragraph 7.3
@@ -35,6 +34,7 @@ module Doorkeeper
             client_url.port = nil
           end
 
+          url.query = nil
           url == client_url
         end
 

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -139,9 +139,9 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
   context "when redirect_uri contains some query params" do
     let(:redirect_uri) { "#{client.redirect_uri}?query=q" }
 
-    it "responds with invalid_grant" do
+    it "allows query params" do
       request.validate
-      expect(request.error).to eq(:invalid_grant)
+      expect(request.error).to eq(nil)
     end
   end
 

--- a/spec/lib/oauth/helpers/uri_checker_spec.rb
+++ b/spec/lib/oauth/helpers/uri_checker_spec.rb
@@ -72,10 +72,10 @@ module Doorkeeper::OAuth::Helpers
         expect(described_class).to be_matches(uri, client_uri)
       end
 
-      it "doesn't allow additional query parameters" do
+      it "allows additional query parameters" do
         uri = "http://app.co/?query=hello"
         client_uri = "http://app.co"
-        expect(described_class).not_to be_matches(uri, client_uri)
+        expect(described_class).to be_matches(uri, client_uri)
       end
 
       it "doesn't allow non-matching domains through" do


### PR DESCRIPTION
### Summary

This PR reverts the change introduced in #1528 for disallowing query params in `redirect_uri`. As per the specs, it SHOULD (even though discouraged) be allowed for the client to set query params in the redirect URI if it needs to. In that case, the authorization server should only match the scheme, authority, and path.

Ref: https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2.2

> The authorization server SHOULD require the client to provide the
complete redirection URI (the client MAY use the "state" request
parameter to achieve per-request customization). **If requiring the
registration of the complete redirection URI is not possible, the
authorization server SHOULD require the registration of the URI
scheme, authority, and path (allowing the client to dynamically vary
only the query component of the redirection URI when requesting
authorization).**
