### PR TITLE
Improve #find_matching_token performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#1542] Improve performance of `Doorkeeper::AccessToken#matching_token_for` using database specific SQL time math.
+
+  **[IMPORTANT]**: API of the `Doorkeeper::AccessToken#matching_token_for` method has changed and now it returns
+  only **active** access tokens (previously they were just not revoked). Please remember that the idea of the
+  `reuse_access_token` option is to check for existing _active_ token (see configuration option description).
+
 - [#ID] Add your PR description here.
 
 ## 5.5.4
@@ -25,7 +31,7 @@ User-visible changes worth mentioning.
 - [#1502] Drop support for Ruby 2.4 because of EOL.
 - [#1504] Updated the url fragment in the comment for code documentation.
 - [#1512] Fix form behavior when response mode is form_post.
-- [#1511] Fix that authorization code is returned by fragment if response_mode is fragament.
+- [#1511] Fix that authorization code is returned by fragment if response_mode is fragment.
 
 ## 5.5.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,4 @@ gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 1.4", platform: %i[ruby mswin mingw x64_mingw]
 
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw]
+gem "timecop"

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -24,7 +24,7 @@ module Doorkeeper
 
     def render_success
       if skip_authorization? || matching_token?
-        redirect_or_render authorize_response
+        redirect_or_render(authorize_response)
       elsif Doorkeeper.configuration.api_only
         render json: pre_auth
       else
@@ -41,6 +41,8 @@ module Doorkeeper
       end
     end
 
+    # Active access token issued for the same client and resource owner with
+    # the same set of the scopes exists?
     def matching_token?
       Doorkeeper.config.access_token_model.matching_token_for(
         pre_auth.client,

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -55,4 +55,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "grape"
   gem.add_development_dependency "rake", ">= 11.3.0"
   gem.add_development_dependency "rspec-rails"
+  gem.add_development_dependency "timecop"
 end

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -16,5 +16,6 @@ gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 1.3", "< 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
+gem "timecop"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -16,5 +16,6 @@ gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
+gem "timecop"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -16,5 +16,6 @@ gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
+gem "timecop"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -16,5 +16,6 @@ gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
+gem "timecop"
 
 gemspec path: "../"

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -16,5 +16,6 @@ gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
+gem "timecop"
 
 gemspec path: "../"

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -88,6 +88,7 @@ module Doorkeeper
   module Models
     autoload :Accessible, "doorkeeper/models/concerns/accessible"
     autoload :Expirable, "doorkeeper/models/concerns/expirable"
+    autoload :ExpirationTimeSqlMath, "doorkeeper/models/concerns/expiration_time_sql_math"
     autoload :Orderable, "doorkeeper/models/concerns/orderable"
     autoload :Scopes, "doorkeeper/models/concerns/scopes"
     autoload :Reusable, "doorkeeper/models/concerns/reusable"

--- a/lib/doorkeeper/config/validations.rb
+++ b/lib/doorkeeper/config/validations.rb
@@ -24,8 +24,8 @@ module Doorkeeper
         return if !reuse_access_token || strategy.allows_restoring_secrets?
 
         ::Rails.logger.warn(
-          "You have configured both reuse_access_token " \
-          "AND strategy strategy '#{strategy}' that cannot restore tokens. " \
+          "[DOORKEEPER] You have configured both reuse_access_token " \
+          "AND '#{strategy}' strategy which cannot restore tokens. " \
           "This combination is unsupported. reuse_access_token will be disabled",
         )
         @reuse_access_token = false
@@ -43,7 +43,7 @@ module Doorkeeper
                   (token_reuse_limit > 0 && token_reuse_limit <= 100)
 
         ::Rails.logger.warn(
-          "You have configured an invalid value for token_reuse_limit option. " \
+          "[DOORKEEPER] You have configured an invalid value for token_reuse_limit option. " \
           "It will be set to default 100",
         )
         @token_reuse_limit = 100

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -13,6 +13,7 @@ module Doorkeeper
     include Models::SecretStorable
     include Models::Scopes
     include Models::ResourceOwnerable
+    include Models::ExpirationTimeSqlMath
 
     module ClassMethods
       # Returns an instance of the Doorkeeper::AccessToken with
@@ -87,7 +88,7 @@ module Doorkeeper
       #   nil if matching record was not found
       #
       def matching_token_for(application, resource_owner, scopes)
-        tokens = authorized_tokens_for(application&.id, resource_owner)
+        tokens = authorized_tokens_for(application&.id, resource_owner).not_expired
         find_matching_token(tokens, application, scopes)
       end
 
@@ -104,9 +105,7 @@ module Doorkeeper
       #
       # ActiveRecord 5.x - 6.x ignores custom ordering so we can't perform a
       # database sort by created_at, so we need to load all the matching records,
-      # sort them and find latest one. Probably it would be better to rewrite this
-      # query using Time math if possible, but we n eed to consider ORM and
-      # different databases support.
+      # sort them and find latest one.
       #
       # @param relation [ActiveRecord::Relation]
       #   Access tokens relation

--- a/lib/doorkeeper/models/concerns/expiration_time_sql_math.rb
+++ b/lib/doorkeeper/models/concerns/expiration_time_sql_math.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Models
+    module ExpirationTimeSqlMath
+      extend ::ActiveSupport::Concern
+
+      class ExpirationTimeSqlGenerator
+        attr_reader :model
+
+        delegate :table_name, to: :@model
+
+        def initialize(model)
+          @model = model
+        end
+
+        def generate_sql
+          raise "`generate_sql` should be overridden for a #{self.class.name}!"
+        end
+      end
+
+      class MySqlExpirationTimeSqlGenerator < ExpirationTimeSqlGenerator
+        def generate_sql
+          Arel.sql("DATE_ADD(#{table_name}.created_at, INTERVAL #{table_name}.expires_in SECOND)")
+        end
+      end
+
+      class SqlLiteExpirationTimeSqlGenerator < ExpirationTimeSqlGenerator
+        def generate_sql
+          Arel.sql("DATETIME(#{table_name}.created_at, '+' || #{table_name}.expires_in || ' SECONDS')")
+        end
+      end
+
+      class SqlServerExpirationTimeSqlGenerator < ExpirationTimeSqlGenerator
+        def generate_sql
+          Arel.sql("DATEADD(second, #{table_name}.expires_in, #{table_name}.created_at) AT TIME ZONE 'UTC'")
+        end
+      end
+
+      class OracleExpirationTimeSqlGenerator < ExpirationTimeSqlGenerator
+        def generate_sql
+          Arel.sql("#{table_name}.created_at + INTERVAL to_char(#{table_name}.expires_in) second")
+        end
+      end
+
+      class PostgresExpirationTimeSqlGenerator < ExpirationTimeSqlGenerator
+        def generate_sql
+          Arel.sql("#{table_name}.created_at + #{table_name}.expires_in * INTERVAL '1 SECOND'")
+        end
+      end
+
+      ADAPTERS_MAPPING = {
+        "sqlite" => SqlLiteExpirationTimeSqlGenerator,
+        "sqlite3" => SqlLiteExpirationTimeSqlGenerator,
+        "postgis" => PostgresExpirationTimeSqlGenerator,
+        "postgresql" => PostgresExpirationTimeSqlGenerator,
+        "mysql" => MySqlExpirationTimeSqlGenerator,
+        "mysql2" => MySqlExpirationTimeSqlGenerator,
+        "sqlserver" => SqlServerExpirationTimeSqlGenerator,
+        "oracleenhanced" => OracleExpirationTimeSqlGenerator,
+      }.freeze
+
+      module ClassMethods
+        def supports_expiration_time_math?
+          ADAPTERS_MAPPING.key?(adapter_name.downcase) ||
+            respond_to?(:custom_expiration_time_sql)
+        end
+
+        def expiration_time_sql
+          if respond_to?(:custom_expiration_time_sql)
+            custom_expiration_time_sql
+          else
+            expiration_time_sql_expression
+          end
+        end
+
+        def expiration_time_sql_expression
+          ADAPTERS_MAPPING.fetch(adapter_name.downcase).new(self).generate_sql
+        end
+
+        def adapter_name
+          ActiveRecord::Base.connection.adapter_name
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -8,12 +8,12 @@ module Doorkeeper
           existing_token = nil
 
           if lookup_existing_token?
-            existing_token = find_existing_token_for(client, scopes)
+            existing_token = find_active_existing_token_for(client, scopes)
             return existing_token if server_config.reuse_access_token && existing_token&.reusable?
           end
 
           with_revocation(existing_token: existing_token) do
-            server_config.access_token_model.find_or_create_for(
+            server_config.access_token_model.create_for(
               application: client,
               resource_owner: nil,
               scopes: scopes,
@@ -43,7 +43,7 @@ module Doorkeeper
             server_config.revoke_previous_client_credentials_token?
         end
 
-        def find_existing_token_for(client, scopes)
+        def find_active_existing_token_for(client, scopes)
           server_config.access_token_model.matching_token_for(client, nil, scopes)
         end
 

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -126,9 +126,10 @@ Doorkeeper.configure do
 
   # Reuse access token for the same resource owner within an application (disabled by default).
   #
-  # This option protects your application from creating new tokens before old valid one becomes
-  # expired so your database doesn't bloat. Keep in mind that when this option is `on` Doorkeeper
-  # doesn't updates existing token expiration time, it will create a new token instead.
+  # This option protects your application from creating new tokens before old **valid** one becomes
+  # expired so your database doesn't bloat. Keep in mind that when this option is enabled Doorkeeper
+  # doesn't update existing token expiration time, it will create a new token instead if no active matching
+  # token found for the application, resources owner and/or set of scopes.
   # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
   #
   # You can not enable this option together with +hash_token_secrets+.

--- a/spec/lib/oauth/client_credentials/creator_spec.rb
+++ b/spec/lib/oauth/client_credentials/creator_spec.rb
@@ -128,10 +128,4 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Creator do
       expect(existing_token.reload).not_to be_revoked
     end
   end
-
-  it "returns false if creation fails" do
-    expect(Doorkeeper::AccessToken).to receive(:find_or_create_for).and_return(false)
-    created = creator.call(client, scopes)
-    expect(created).to be_falsey
-  end
 end

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -186,11 +186,11 @@ feature "Authorization Code Flow" do
     )
   end
 
-  scenario "silently authorizes if matching token exists" do
+  scenario "silently authorizes if active matching token exists" do
     default_scopes_exist :public, :write
 
     access_token_exists application: @client,
-                        expires_in: -100, # even expired token
+                        expires_in: 10_000,
                         resource_owner_id: @resource_owner.id,
                         resource_owner_type: @resource_owner.class.name,
                         scopes: "public write"


### PR DESCRIPTION
Add expiration time math for `#matching_token_for`. Improves performance of the token lookup for known AR db adapters. For unknown it provides a warning and allows to add a custom SQL.

---

Some real scenario when we have ~1 600 000 expired tokens and just a few or them are still active:

```ruby
# Tests were performed for MySQL

app = Doorkeeper::Application.create!(name: "Test", redirect_uri: "https://domain.com")

Doorkeeper::AccessToken.transaction do
  500.times do 
    Doorkeeper::AccessToken.create!(application: app, expires_in: nil)
  end

  1_600_000.times do  
     Doorkeeper::AccessToken.create!(application: app, expires_in: 1)
  end
end
```

## IPS performance

```ruby
require 'benchmark/ips'

app = Doorkeeper::Application.first

Benchmark.ips do |x|
  x.report("Old lookup") do
    Doorkeeper::AccessToken.matching_token_for(app, nil, "")
  end
  
  x.report("New lookup") do
    Doorkeeper::AccessToken.matching_token_for2(app, nil, "")
  end

  x.compare!
end

# Warming up --------------------------------------
#           Old lookup     1.000  i/100ms
#           New lookup     1.000  i/100ms
# Calculating -------------------------------------
#           Old lookup      0.018  (± 0.0%) i/s -      1.000  in  55.587743s
#           New lookup      0.143  (± 0.0%) i/s -      1.000  in   7.017439s
# 
# Comparison:
#           New lookup:        0.1 i/s
#           Old lookup:        0.0 i/s - 7.92x  (± 0.00) slower
```

## Execution performance

```ruby
app = Doorkeeper::Application.first

Benchmark.bm do |x|
  x.report('Old lookup') do
    5.times { Doorkeeper::AccessToken.matching_token_for(app, nil, "") }
  end

  x.report('New lookup') do
    5.times { Doorkeeper::AccessToken.matching_token_for2(app, nil, "") }
  end
end

#              user              system      total           real
# Old lookup   258.036051   0.852471    258.888522  (289.124156)
# New lookup  0.084175      0.000020     0.084195     ( 32.517308)

```

Should fix #1485 , #1310
Relates to #1487