### PR TITLE
Fix rails 7 deprecation warning

### DIFF
--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -82,7 +82,7 @@ module Doorkeeper
       end
 
       def x_www_form_urlencoded?
-        request.content_type == "application/x-www-form-urlencoded"
+        request.media_type == "application/x-www-form-urlencoded"
       end
     end
   end


### PR DESCRIPTION
### Summary

Rails 7.1 is going to change `content_type` to return the full header rather than just the media type and 7.0 is issuing deprecation warnings:

```
DEPRECATION WARNING: Rails 7.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead.
```

### Other Information

The `media_type` method is already available in 6.0 which appears to be the earliest version supported by doorkeeper so I don't think there's any need for a more complicated solution than this.