### PR TITLE
Add support for rails ~> 7.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-gem "rails", "~> 6.0"
+gem "rails", ">= 6.0", "< 7.1"
+
+gem "sprockets-rails"
 
 gem "rspec-core"
 gem "rspec-expectations"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.0.0alpha1"
+gem "rails", "~> 7.0.0"
 gem "rspec-core"
 gem "rspec-expectations"
 gem "rspec-mocks"


### PR DESCRIPTION
### Summary

Expands dependency range to include Rails ~> 7.0.0

### Other Information

Just expands the Rails dependency range to include the first versions of Rails 7. I needed to add `sprockets-rails` to the Gemfile for the tests to succeed, but after adding that to the Gemfile all the tests still pass.
