### PR TITLE
Bug: able to obtain a token with default scopes even if they are not present in the application scopes when using client credentials

### DIFF
--- a/lib/doorkeeper/oauth/client_credentials/validator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/validator.rb
@@ -35,13 +35,12 @@ module Doorkeeper
         end
 
         def validate_scopes
-          return true if @request.scopes.blank?
-
           application_scopes = if @client.present?
-                                 @client.application.scopes
-                               else
-                                 ""
-                               end
+            @client.application.scopes
+          else
+            ""
+          end
+          return true if @request.scopes.blank? && application_scopes.blank?
 
           ScopeChecker.valid?(
             scope_str: @request.scopes.to_s,

--- a/lib/doorkeeper/oauth/client_credentials/validator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/validator.rb
@@ -36,10 +36,10 @@ module Doorkeeper
 
         def validate_scopes
           application_scopes = if @client.present?
-            @client.application.scopes
-          else
-            ""
-          end
+                                 @client.application.scopes
+                               else
+                                 ""
+                               end
           return true if @request.scopes.blank? && application_scopes.blank?
 
           ScopeChecker.valid?(

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -152,6 +152,26 @@ RSpec.describe "Client Credentials Request" do
     end
   end
 
+  context "when application scopes contain none of the default scopes and no scope is passed" do
+    before do
+      client.update(scopes: "read write")
+    end
+
+    it "issues new token with one default scope that are present in application scopes" do
+      default_scopes_exist :public
+
+      headers = authorization client.uid, client.secret
+      params  = { grant_type: "client_credentials" }
+
+      post "/oauth/token", params: params, headers: headers
+
+      expect(json_response).to match(
+                                 "error" => "invalid_scope",
+                                 "error_description" => translated_error_message(:invalid_scope),
+                                 )
+    end
+  end
+
   context "when request is invalid" do
     it "does not authorize the client and returns the error" do
       headers = {}

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -166,9 +166,9 @@ RSpec.describe "Client Credentials Request" do
       post "/oauth/token", params: params, headers: headers
 
       expect(json_response).to match(
-                                 "error" => "invalid_scope",
-                                 "error_description" => translated_error_message(:invalid_scope),
-                                 )
+        "error" => "invalid_scope",
+        "error_description" => translated_error_message(:invalid_scope),
+      )
     end
   end
 

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -150,15 +150,9 @@ RSpec.describe "Client Credentials Request" do
         "scope" => "public read",
       )
     end
-  end
 
-  context "when application scopes contain none of the default scopes and no scope is passed" do
-    before do
-      client.update(scopes: "read write")
-    end
-
-    it "issues new token with one default scope that are present in application scopes" do
-      default_scopes_exist :public
+    it "forbids the request if the public scope is not present in the application scopes" do
+      default_scopes_exist :default
 
       headers = authorization client.uid, client.secret
       params  = { grant_type: "client_credentials" }


### PR DESCRIPTION
see description of issue #1557