### PR TITLE
Add resource indicators

### DIFF
--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -48,6 +48,7 @@ module Doorkeeper
         pre_auth.client,
         current_resource_owner,
         pre_auth.scopes,
+        pre_auth.resource_indicators,
       )
     end
 
@@ -84,7 +85,10 @@ module Doorkeeper
     end
 
     def pre_auth_params
-      params.slice(*pre_auth_param_fields).permit(*pre_auth_param_fields)
+      Doorkeeper::Helpers::ResourceIndicators.resource_identifier_from_request(
+        request,
+        params.slice(*pre_auth_param_fields).permit(*pre_auth_param_fields),
+      )
     end
 
     def pre_auth_param_fields

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -19,6 +19,19 @@
     </div>
   <% end %>
 
+  <% if @pre_auth.resource.count > 0 %>
+    <div id="oauth-permissions">
+      <h3>Resources</h3>
+
+      <p> This application will be able to access:</p>
+      <ul class="text-info">
+        <% Array(@pre_auth.resource).each do |resource| %>
+          <li><%= resource %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div class="actions">
     <%= form_tag oauth_authorization_path, method: :post do %>
       <%= hidden_field_tag :client_id, @pre_auth.client.uid, id: nil %>
@@ -29,6 +42,9 @@
       <%= hidden_field_tag :scope, @pre_auth.scope, id: nil %>
       <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge, id: nil %>
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
+      <% @pre_auth.resource.each do |resource| %>
+        <%= hidden_field_tag "resource[]", resource, id: nil %>
+      <% end %>
       <%= submit_tag t('doorkeeper.authorizations.buttons.authorize'), class: "btn btn-success btn-lg btn-block" %>
     <% end %>
     <%= form_tag oauth_authorization_path, method: :delete do %>
@@ -40,6 +56,9 @@
       <%= hidden_field_tag :scope, @pre_auth.scope, id: nil %>
       <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge, id: nil %>
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
+      <% @pre_auth.resource.each do |resource| %>
+        <%= hidden_field_tag "resource[]", resource %>
+      <% end %>
       <%= submit_tag t('doorkeeper.authorizations.buttons.deny'), class: "btn btn-danger btn-lg btn-block" %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,7 +117,8 @@ en:
         invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
         invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
         unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
-
+        invalid_target: 'The requested resource is invalid, missing, unknown, or malformed.'
+        
         invalid_token:
           revoked: "The access token was revoked"
           expired: "The access token expired"

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -22,6 +22,7 @@ module Doorkeeper
 
   module Helpers
     autoload :Controller, "doorkeeper/helpers/controller"
+    autoload :ResourceIndicators, "doorkeeper/helpers/resource_indicators"
   end
 
   module Request
@@ -56,6 +57,8 @@ module Doorkeeper
     autoload :TokenIntrospection, "doorkeeper/oauth/token_introspection"
     autoload :TokenRequest, "doorkeeper/oauth/token_request"
     autoload :TokenResponse, "doorkeeper/oauth/token_response"
+    autoload :ListLike, "doorkeeper/oauth/concerns/list_like"
+    autoload :ResourceIndicators, "doorkeeper/oauth/resource_indicators"
 
     module Authorization
       autoload :Code, "doorkeeper/oauth/authorization/code"
@@ -78,6 +81,7 @@ module Doorkeeper
       autoload :ScopeChecker, "doorkeeper/oauth/helpers/scope_checker"
       autoload :URIChecker, "doorkeeper/oauth/helpers/uri_checker"
       autoload :UniqueToken, "doorkeeper/oauth/helpers/unique_token"
+      autoload :ResourceIndicatorsChecker, "doorkeeper/oauth/helpers/resource_indicators_checker"
     end
 
     module Hooks
@@ -92,6 +96,7 @@ module Doorkeeper
     autoload :Orderable, "doorkeeper/models/concerns/orderable"
     autoload :Scopes, "doorkeeper/models/concerns/scopes"
     autoload :Reusable, "doorkeeper/models/concerns/reusable"
+    autoload :ResourceIndicators, "doorkeeper/models/concerns/resource_indicators"
     autoload :ResourceOwnerable, "doorkeeper/models/concerns/resource_ownerable"
     autoload :Revocable, "doorkeeper/models/concerns/revocable"
     autoload :SecretStorable, "doorkeeper/models/concerns/secret_storable"

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -179,6 +179,12 @@ module Doorkeeper
         @config.instance_variable_set(:@polymorphic_resource_owner, true)
       end
 
+      # Enabled Resource Indicator support. Requires additional database
+      # columns to be setup.
+      def use_resource_indicators
+        @config.instance_variable_set(:@use_resource_indicators, true)
+      end
+
       # Forbids creating/updating applications with arbitrary scopes that are
       # not in configuration, i.e. `default_scopes` or `optional_scopes`.
       # (disabled by default)
@@ -323,6 +329,9 @@ module Doorkeeper
     # Hook to allow arbitrary user-client authorization
     option :authorize_resource_owner_for_client,
            default: ->(_client, _resource_owner) { true }
+
+    option :resource_indicator_authorizer,
+           default: ->(_application, _resource_owner, _resource_indicators) { true }
 
     # Allows to customize OAuth grant flows that +each+ application support.
     # You can configure a custom block (or use a class respond to `#call`) that must
@@ -539,6 +548,10 @@ module Doorkeeper
 
     def polymorphic_resource_owner?
       option_set? :polymorphic_resource_owner
+    end
+
+    def using_resource_indicators?
+      option_set? :use_resource_indicators
     end
 
     def confirm_application_owner?

--- a/lib/doorkeeper/helpers/resource_indicators.rb
+++ b/lib/doorkeeper/helpers/resource_indicators.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Helpers
+    # The RFC for resource indicators allows for multiple to be specified using this syntax:
+    #  GET /as/authorization.oauth2?response_type=code
+    #  ...
+    #  &scope=calendar%20contacts
+    #  &resource=https%3A%2F%2Fcal.example.com%2F
+    #  &resource=https%3A%2F%2Fcontacts.example.com%2F
+    #
+    # The default ActionController query paramater parsing will not accept that as an array
+    # so we've got to do it ourselves. Post body request parsing also sees the same issue.
+    module ResourceIndicators
+      def self.resource_identifier_from_request(request, existing_params)
+        resource_params = params_from_query(request)
+        resource_params = resource_params.merge(params_from_post(request)) unless resource_params.key?("resource")
+        resource_params = ActionController::Parameters.new(resource_params).slice(:resource).permit(resource: [])
+        existing_params.merge(resource_params)
+      end
+
+      def self.params_from_post(request)
+        return {} unless request.raw_post
+
+        parsed_body = CGI.parse(request.raw_post)
+        resources = parsed_body["resource"].presence || parsed_body["resource[]"].presence
+        if resources
+          { "resource" => resources }
+        else
+          {}
+        end
+      end
+
+      def self.params_from_query(request)
+        URI.parse(request.original_url).query.then do |query|
+          return {} unless query
+
+          { "resource" => CGI.parse(query)["resource"] }
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -12,6 +12,7 @@ module Doorkeeper
     include Models::SecretStorable
     include Models::Scopes
     include Models::ResourceOwnerable
+    include Models::ResourceIndicators
 
     # Never uses PKCE if PKCE migrations were not generated
     def uses_pkce?

--- a/lib/doorkeeper/models/concerns/resource_indicators.rb
+++ b/lib/doorkeeper/models/concerns/resource_indicators.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Models
+    # Provides getters and setters for resource indicators. Since we can't rely on
+    # database specifics like array types resource indicators are stored as a string
+    # in the database - similar to scopes.
+    module ResourceIndicators
+      def resource_indicators
+        OAuth::ResourceIndicators.from_string(resource_indicators_string)
+      end
+
+      def resource_indicators=(value)
+        if value.is_a?(Array)
+          super(Doorkeeper::OAuth::ResourceIndicators.from_array(value).to_s)
+        else
+          super(Doorkeeper::OAuth::ResourceIndicators.from_string(value.to_s).to_s)
+        end
+      end
+
+      def resource_indicators_string
+        self[:resource_indicators]
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -39,6 +39,10 @@ module Doorkeeper
             scopes: pre_auth.scopes.to_s,
           }
 
+          if Doorkeeper.config.using_resource_indicators?
+            attributes[:resource_indicators] = pre_auth.resource_indicators
+          end
+
           if Doorkeeper.config.polymorphic_resource_owner?
             attributes[:resource_owner] = resource_owner
           else

--- a/lib/doorkeeper/oauth/authorization/context.rb
+++ b/lib/doorkeeper/oauth/authorization/context.rb
@@ -4,7 +4,7 @@ module Doorkeeper
   module OAuth
     module Authorization
       class Context
-        attr_reader :client, :grant_type, :resource_owner, :scopes
+        attr_reader :client, :grant_type, :resource_owner, :scopes, :resource_indicators
 
         def initialize(**attributes)
           attributes.each do |name, value|

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -65,6 +65,7 @@ module Doorkeeper
             scopes: pre_auth.scopes,
             expires_in: self.class.access_token_expires_in(Doorkeeper.config, context),
             use_refresh_token: false,
+            resource_indicators: pre_auth.resource_indicators,
           )
         end
 

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -9,6 +9,7 @@ module Doorkeeper
       # @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
       validate :redirect_uri, error: :invalid_grant
       validate :code_verifier, error: :invalid_grant
+      validate :resource_indicators, error: :invalid_target
 
       attr_reader :grant, :client, :redirect_uri, :access_token, :code_verifier,
                   :invalid_request_reason, :missing_param
@@ -20,9 +21,18 @@ module Doorkeeper
         @grant_type = Doorkeeper::OAuth::AUTHORIZATION_CODE
         @redirect_uri = parameters[:redirect_uri]
         @code_verifier = parameters[:code_verifier]
+        @resource = parameters[:resource]
       end
 
       private
+
+      def validate_resource_indicators
+        Helpers::ResourceIndicatorsChecker.valid?(grant, resource_indicators)
+      end
+
+      def resource_indicators
+        @resource_indicators ||= ResourceIndicators.from_array(@resource)
+      end
 
       def before_successful_response
         grant.transaction do
@@ -36,6 +46,7 @@ module Doorkeeper
             resource_owner,
             grant.scopes,
             server,
+            @resource_indicators,
           )
         end
 

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -26,7 +26,7 @@ module Doorkeeper
         @scopes ||= build_scopes
       end
 
-      def find_or_create_access_token(client, resource_owner, scopes, server)
+      def find_or_create_access_token(client, resource_owner, scopes, server, resource_indicators)
         context = Authorization::Token.build_context(client, grant_type, scopes, resource_owner)
         @access_token = server_config.access_token_model.find_or_create_for(
           application: client,
@@ -34,6 +34,7 @@ module Doorkeeper
           scopes: scopes,
           expires_in: Authorization::Token.access_token_expires_in(server, context),
           use_refresh_token: Authorization::Token.refresh_token_enabled?(server, context),
+          resource_indicators: resource_indicators,
         )
       end
 

--- a/lib/doorkeeper/oauth/client_credentials/issuer.rb
+++ b/lib/doorkeeper/oauth/client_credentials/issuer.rb
@@ -37,6 +37,7 @@ module Doorkeeper
           creator.call(
             client,
             scopes,
+            resource_indicators: validator.resource_indicators,
             use_refresh_token: false,
             expires_in: ttl,
           )

--- a/lib/doorkeeper/oauth/client_credentials/validator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/validator.rb
@@ -10,6 +10,7 @@ module Doorkeeper
         validate :client, error: :invalid_client
         validate :client_supports_grant_flow, error: :unauthorized_client
         validate :scopes, error: :invalid_scope
+        validate :resource_indicators, error: :invalid_target
 
         def initialize(server, request)
           @server = server
@@ -19,7 +20,21 @@ module Doorkeeper
           validate
         end
 
+        def resource_indicators
+          @request.resource
+        end
+
         private
+
+        def validate_resource_indicators
+          return true unless Doorkeeper.config.using_resource_indicators?
+
+          Doorkeeper.configuration.resource_indicator_authorizer.call(
+            @client.application,
+            nil,
+            @request.resource,
+          )
+        end
 
         def validate_client
           @client.present?

--- a/lib/doorkeeper/oauth/client_credentials_request.rb
+++ b/lib/doorkeeper/oauth/client_credentials_request.rb
@@ -3,7 +3,7 @@
 module Doorkeeper
   module OAuth
     class ClientCredentialsRequest < BaseRequest
-      attr_reader :client, :original_scopes, :response
+      attr_reader :client, :original_scopes, :response, :resource
 
       alias error_response response
 
@@ -14,6 +14,7 @@ module Doorkeeper
         @server = server
         @response = nil
         @original_scopes = parameters[:scope]
+        @resource = OAuth::ResourceIndicators.from_array parameters[:resource]
       end
 
       def access_token

--- a/lib/doorkeeper/oauth/concerns/list_like.rb
+++ b/lib/doorkeeper/oauth/concerns/list_like.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    # ListLike is a mixin for the common functionality in both the
+    # ResourceIndicator and Scope sets.
+    module ListLike
+      extend ActiveSupport::Concern
+      include Enumerable
+      include Comparable
+
+      class_methods do
+        def from_string(string)
+          string ||= ""
+          new.tap do |collection|
+            collection.add(*string.split)
+          end
+        end
+
+        def from_array(array)
+          new.tap do |collection|
+            collection.add(*array)
+          end
+        end
+      end
+
+      delegate :each, :empty?, to: :@collection
+
+      def initialize
+        @collection = []
+      end
+
+      def exists?(collection_item)
+        @collection.include? collection_item.to_s
+      end
+
+      def add(*collection)
+        @collection.push(*collection.map(&:to_s))
+        @collection.uniq!
+      end
+
+      def all
+        @collection
+      end
+
+      def to_s
+        @collection.join(" ")
+      end
+
+      def contains_all?(collection)
+        collection.all? { |collection_item| exists?(collection_item) }
+      end
+
+      def +(other)
+        self.class.from_array(all + to_array(other))
+      end
+
+      def <=>(other)
+        if other.respond_to?(:map)
+          map(&:to_s).sort <=> other.map(&:to_s).sort
+        else
+          super
+        end
+      end
+
+      def &(other)
+        self.class.from_array(all & to_array(other))
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -5,7 +5,7 @@ module Doorkeeper
     class ErrorResponse < BaseResponse
       include OAuth::Helpers
 
-      NON_REDIRECTABLE_STATES = %i[invalid_redirect_uri invalid_client unauthorized_client].freeze
+      NON_REDIRECTABLE_STATES = %i[invalid_redirect_uri invalid_client unauthorized_client invalid_target].freeze
 
       def self.from_request(request, attributes = {})
         new(
@@ -34,7 +34,7 @@ module Doorkeeper
       end
 
       def status
-        if name == :invalid_client || name == :unauthorized_client
+        if %i[invalid_client invalid_target unauthorized_client].include?(name)
           :unauthorized
         else
           :bad_request

--- a/lib/doorkeeper/oauth/helpers/resource_indicators_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/resource_indicators_checker.rb
@@ -3,14 +3,13 @@
 module Doorkeeper
   module OAuth
     module Helpers
-      # ResourceIndicatorsChecker validates that a proded set of indicators is valid
+      # ResourceIndicatorsChecker validates that a provided set of indicators is valid
       # for a given grant. A grant should contain the same or more grants for any provided set.
       module ResourceIndicatorsChecker
         def self.valid?(grant, requested_indicators)
           return true unless Doorkeeper.config.using_resource_indicators?
-          return true if grant.resource_indicators.empty?
 
-          requested_indicators.any? && grant.resource_indicators.contains_all?(requested_indicators)
+          grant.resource_indicators.contains_all?(requested_indicators)
         end
       end
     end

--- a/lib/doorkeeper/oauth/helpers/resource_indicators_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/resource_indicators_checker.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    module Helpers
+      # ResourceIndicatorsChecker validates that a proded set of indicators is valid
+      # for a given grant. A grant should contain the same or more grants for any provided set.
+      module ResourceIndicatorsChecker
+        def self.valid?(grant, requested_indicators)
+          return true unless Doorkeeper.config.using_resource_indicators?
+          return true if grant.resource_indicators.empty?
+
+          requested_indicators.any? && grant.resource_indicators.contains_all?(requested_indicators)
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/invalid_target_response.rb
+++ b/lib/doorkeeper/oauth/invalid_target_response.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    class InvalidTargetResponse < ErrorResponse
+      attr_reader :reason
+
+      def self.from_request(request, attributes = {})
+        new(
+          attributes.merge(
+            state: request.try(:state),
+            redirect_uri: request.try(:redirect_uri),
+            missing_param: request.try(:missing_param),
+            reason: request.try(:invalid_request_reason),
+          ),
+        )
+      end
+
+      def initialize(attributes = {})
+        super(attributes.merge(name: :invalid_request))
+        @missing_param = attributes[:missing_param]
+        @reason = @missing_param.nil? ? attributes[:reason] : :missing_param
+      end
+
+      def status
+        :bad_request
+      end
+
+      def description
+        I18n.translate(
+          reason,
+          scope: %i[doorkeeper errors messages invalid_request],
+          default: :unknown,
+          value: @missing_param,
+        )
+      endv
+      def redirectable?
+        super && @missing_param != :client_id
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -5,14 +5,14 @@ module Doorkeeper
     class RefreshTokenRequest < BaseRequest
       include OAuth::Helpers
 
-      validate :token_presence, error: :invalid_request
-      validate :token,        error: :invalid_grant
-      validate :client,       error: :invalid_client
-      validate :client_match, error: :invalid_grant
-      validate :scope,        error: :invalid_scope
+      validate :token_presence,      error: :invalid_request
+      validate :token,               error: :invalid_grant
+      validate :client,              error: :invalid_client
+      validate :client_match,        error: :invalid_grant
+      validate :scope,               error: :invalid_scope
+      validate :resource_indicators, error: :invalid_target
 
-      attr_reader :access_token, :client, :credentials, :refresh_token
-      attr_reader :missing_param
+      attr_reader :access_token, :client, :credentials, :refresh_token, :missing_param
 
       def initialize(server, refresh_token, credentials, parameters = {})
         @server = server
@@ -21,9 +21,18 @@ module Doorkeeper
         @original_scopes = parameters[:scope] || parameters[:scopes]
         @refresh_token_parameter = parameters[:refresh_token]
         @client = load_client(credentials) if credentials
+        @resource = parameters[:resource]
       end
 
       private
+
+      def validate_resource_indicators
+        Helpers::ResourceIndicatorsChecker.valid?(@refresh_token, resource_indicators)
+      end
+
+      def resource_indicators
+        @resource_indicators ||= ResourceIndicators.from_array(@resource)
+      end
 
       def load_client(credentials)
         server_config.application_model.by_uid_and_secret(credentials.uid, credentials.secret)
@@ -58,9 +67,9 @@ module Doorkeeper
             refresh_token.resource_owner_id
           end
 
-        if refresh_token_revoked_on_use?
-          attributes[:previous_refresh_token] = refresh_token.refresh_token
-        end
+        attributes[:previous_refresh_token] = refresh_token.refresh_token if refresh_token_revoked_on_use?
+
+        attributes[:resource_indicators] = resource_indicators if Doorkeeper.config.using_resource_indicators?
 
         # RFC6749
         # 1.5.  Refresh Token

--- a/lib/doorkeeper/oauth/resource_indicators.rb
+++ b/lib/doorkeeper/oauth/resource_indicators.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    # Represents a set of resource indicators, much like the matching Scope class.
+    class ResourceIndicators
+      include OAuth::ListLike
+
+      alias has_resource_indicators? contains_all?
+      alias resource_indicators? contains_all?
+
+      def common_or_lesser(other)
+        intersection(other)
+      end
+
+      private
+
+      def to_array(other)
+        case other
+        when ResourceIndicators
+          other.all
+        else
+          other.to_a
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/scopes.rb
+++ b/lib/doorkeeper/oauth/scopes.rb
@@ -3,66 +3,10 @@
 module Doorkeeper
   module OAuth
     class Scopes
-      include Enumerable
-      include Comparable
+      include OAuth::ListLike
 
-      def self.from_string(string)
-        string ||= ""
-        new.tap do |scope|
-          scope.add(*string.split)
-        end
-      end
-
-      def self.from_array(array)
-        new.tap do |scope|
-          scope.add(*array)
-        end
-      end
-
-      delegate :each, :empty?, to: :@scopes
-
-      def initialize
-        @scopes = []
-      end
-
-      def exists?(scope)
-        @scopes.include? scope.to_s
-      end
-
-      def add(*scopes)
-        @scopes.push(*scopes.map(&:to_s))
-        @scopes.uniq!
-      end
-
-      def all
-        @scopes
-      end
-
-      def to_s
-        @scopes.join(" ")
-      end
-
-      def scopes?(scopes)
-        scopes.all? { |scope| exists?(scope) }
-      end
-
-      alias has_scopes? scopes?
-
-      def +(other)
-        self.class.from_array(all + to_array(other))
-      end
-
-      def <=>(other)
-        if other.respond_to?(:map)
-          map(&:to_s).sort <=> other.map(&:to_s).sort
-        else
-          super
-        end
-      end
-
-      def &(other)
-        self.class.from_array(all & to_array(other))
-      end
+      alias has_scopes? contains_all?
+      alias scopes? contains_all?
 
       private
 

--- a/lib/doorkeeper/server.rb
+++ b/lib/doorkeeper/server.rb
@@ -20,7 +20,10 @@ module Doorkeeper
 
     # TODO: context should be the request
     def parameters
-      context.request.parameters
+      Doorkeeper::Helpers::ResourceIndicators.resource_identifier_from_request(
+        context.request,
+        context.request.parameters,
+      )
     end
 
     def client

--- a/lib/generators/doorkeeper/enable_resource_indicators_generator.rb
+++ b/lib/generators/doorkeeper/enable_resource_indicators_generator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Doorkeeper
+  # Generates migration to add resource indicator support to the
+  # doorkeeper tables.
+  #
+  class EnableResourceIndicatorsGenerator < ::Rails::Generators::Base
+    include ::Rails::Generators::Migration
+    source_root File.expand_path("templates", __dir__)
+    desc "Support Resource Indicators for OAuth 2 (rfc8707)"
+
+    def self.next_migration_number(path)
+      ActiveRecord::Generators::Base.next_migration_number(path)
+    end
+
+    def previous_refresh_token
+      migration_template(
+        "add_resource_indicators_to_access_grants_and_access_tokens.rb.erb",
+        "db/migrate/add_resource_indicators_to_access_grants_and_access_tokens.rb",
+      )
+      gsub_file(
+        "config/initializers/doorkeeper.rb",
+        "# use_resource_indicators",
+        "use_resource_indicators",
+      )
+    end
+
+    private
+
+    def migration_version
+      "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+    end
+  end
+end

--- a/lib/generators/doorkeeper/templates/add_resource_indicators_to_access_grants_and_access_tokens.rb.erb
+++ b/lib/generators/doorkeeper/templates/add_resource_indicators_to_access_grants_and_access_tokens.rb.erb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddResourceIndicatorsToAccessGrantsAndAccessTokens < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_column(
+      :oauth_access_grants,
+      :resource_indicators,
+      :string,
+      null: true,
+    )
+
+    add_column(
+      :oauth_access_tokens,
+      :resource_indicators,
+      :string,
+      null: true,
+    )
+  end
+end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -489,4 +489,20 @@ Doorkeeper.configure do
   # WWW-Authenticate Realm (default: "Doorkeeper").
   #
   # realm "Doorkeeper"
+
+  # Enables resource indicator (https://datatracker.ietf.org/doc/html/rfc8707) support.
+  # When enabled access request will delegate to the below callback to verify that the resource
+  # paramater provided by calling apps is appropriate for your application.
+  #
+  # Although the RFC suggests to use urls for indicators there's no restriction on their form
+  # and it's entirely up to your code to make a judgement as to if the resource owner, indicator
+  # pair is valid.
+  #
+  # Authorized resources are saved to the AccessToken for inspection on your protected endpoints.
+  #
+  # use_resource_indicators
+  #
+  resource_indicator_authorizer do |_application, _resource_owner, _resource_indicators|
+    raise "Please configure doorkeeper resource_indicator_authorizer block located in #{__FILE__}"
+  end
 end

--- a/spec/dummy/db/migrate/20220224160655_add_resource_indicators_to_access_grants_and_access_tokens.rb
+++ b/spec/dummy/db/migrate/20220224160655_add_resource_indicators_to_access_grants_and_access_tokens.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddResourceIndicatorsToAccessGrantsAndAccessTokens < ActiveRecord::Migration[7.0]
+  def change
+    add_column(
+      :oauth_access_grants,
+      :resource_indicators,
+      :string,
+      null: true,
+    )
+
+    add_column(
+      :oauth_access_tokens,
+      :resource_indicators,
+      :string,
+      null: true,
+    )
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20180210183654) do
     t.datetime "created_at", null: false
     t.datetime "revoked_at"
     t.string "scopes"
+    t.string "resource_indicators"
     unless ENV["WITHOUT_PKCE"]
       t.string   "code_challenge"
       t.string   "code_challenge_method"
@@ -40,6 +41,7 @@ ActiveRecord::Schema.define(version: 20180210183654) do
     t.datetime "created_at", null: false
     t.string "scopes"
     t.string "previous_refresh_token", default: "", null: false
+    t.string "resource_indicators"
     t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
     t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true

--- a/spec/generators/enable_resource_indicators_generator_spec.rb
+++ b/spec/generators/enable_resource_indicators_generator_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "generators/doorkeeper/enable_resource_indicators_generator"
+
+RSpec.describe Doorkeeper::EnableResourceIndicatorsGenerator do
+  include GeneratorSpec::TestCase
+
+  tests described_class
+  destination ::File.expand_path("tmp/dummy", __dir__)
+
+  describe "after running the generator" do
+    before do
+      prepare_destination
+      FileUtils.mkdir_p(::File.expand_path("config/initializers", Pathname(destination_root)))
+      FileUtils.copy_file(
+        ::File.expand_path("../../lib/generators/doorkeeper/templates/initializer.rb", __dir__),
+        ::File.expand_path("config/initializers/doorkeeper.rb", Pathname.new(destination_root)),
+      )
+    end
+
+    it "creates a migration with a version specifier" do
+      stub_const("ActiveRecord::VERSION::MAJOR", 5)
+      stub_const("ActiveRecord::VERSION::MINOR", 0)
+
+      run_generator
+
+      assert_migration "db/migrate/add_resource_indicators_to_access_grants_and_access_tokens.rb" do |migration|
+        assert migration.include?("ActiveRecord::Migration[5.0]\n")
+      end
+
+      expect(destination_root).to(have_structure do
+        directory "config" do
+          directory "initializers" do
+            file "doorkeeper.rb" do
+              contains "  use_resource_indicators"
+            end
+          end
+        end
+      end)
+    end
+  end
+end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -174,11 +174,11 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
     end
 
     context "when resource indicators are omitted" do
-      it "issues a new token for the client" do
+      it "returns a downgraded token" do
         expect do
           request.authorize
-        end.to change { client.reload.access_tokens.count }.by(0)
-        expect(request.error).to eq(:invalid_target)
+        end.to change { client.reload.access_tokens.count }.by(1)
+        expect(client.access_tokens.last.resource_indicators).to be_empty
       end
     end
 

--- a/spec/lib/oauth/base_request_spec.rb
+++ b/spec/lib/oauth/base_request_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         resource_owner,
         "public",
         server,
+        [],
       )
 
       expect(result).to be_an_instance_of(Doorkeeper::AccessToken)
@@ -145,6 +146,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         resource_owner,
         "public",
         server,
+        [],
       )
       expect(result.expires_in).to be(500)
     end
@@ -166,6 +168,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         resource_owner,
         "public",
         server,
+        [],
       )
       expect(result.refresh_token).not_to be_nil
 
@@ -174,6 +177,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         resource_owner,
         "private",
         server,
+        [],
       )
       expect(result.refresh_token).to be_nil
     end

--- a/spec/lib/oauth/client_credentials/issuer_spec.rb
+++ b/spec/lib/oauth/client_credentials/issuer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
       access_token_expires_in: 100,
     )
   end
-  let(:validator) { double :validator, valid?: true }
+  let(:validator) { double :validator, valid?: true, resource_indicators: [] }
 
   before do
     allow(server).to receive(:option_defined?).with(:custom_access_token_expires_in).and_return(false)
@@ -33,6 +33,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
       expect(creator).to receive(:call).with(
         client,
         scopes,
+        resource_indicators: [],
         expires_in: 100,
         use_refresh_token: false,
       )
@@ -90,6 +91,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
         expect(creator).to receive(:call).with(
           client,
           scopes,
+          resource_indicators: [],
           expires_in: custom_ttl_grant,
           use_refresh_token: false,
         )
@@ -100,6 +102,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
         expect(creator).to receive(:call).with(
           client,
           custom_scope,
+          resource_indicators: [],
           expires_in: custom_ttl_scope,
           use_refresh_token: false,
         )

--- a/spec/lib/oauth/code_response_spec.rb
+++ b/spec/lib/oauth/code_response_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Doorkeeper::OAuth::CodeResponse do
       redirect_uri: "http://tst.com/cb",
       state: "state",
       scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+      resource_indicators: [],
     )
   end
   let(:owner) { FactoryBot.build_stubbed(:resource_owner) }

--- a/spec/lib/oauth/helpers/resource_indicators_checker_spec.rb
+++ b/spec/lib/oauth/helpers/resource_indicators_checker_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::OAuth::Helpers::ResourceIndicatorsChecker do
+  describe ".valid?" do
+    before do
+      allow(Doorkeeper.config).to receive(:using_resource_indicators?).and_return(true)
+    end
+
+    let(:subject) do
+      described_class.valid?(
+        double(resource_indicators: Doorkeeper::OAuth::ResourceIndicators.from_array(preapproved_indicators)),
+        Doorkeeper::OAuth::ResourceIndicators.from_array(requested_indicators),
+      )
+    end
+
+    context "when preapproved is a superset" do
+      let(:preapproved_indicators) do
+        ["http://example.com/1", "http://example.com/2"]
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1"]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when preapproved is a subset" do
+      let(:preapproved_indicators) do
+        ["http://example.com/1"]
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1", "http://example.com/2"]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when preapproved is a empty" do
+      let(:preapproved_indicators) do
+        []
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1", "http://example.com/2"]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when both are empty " do
+      let(:preapproved_indicators) do
+        []
+      end
+
+      let(:requested_indicators) do
+        []
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when both are set and equal" do
+      let(:preapproved_indicators) do
+        ["http://example.com/1"]
+      end
+
+      let(:requested_indicators) do
+        ["http://example.com/1"]
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -453,6 +453,26 @@ feature "Authorization Code Flow" do
     end
   end
 
+  context "with resource indicators" do
+    background do
+      config_is_set(:use_resource_indicators, true)
+    end
+
+    scenario "resource owner authorizes the client with default scopes" do
+      visit authorization_endpoint_url(client: @client, resource: "http://example.com/resource1")
+      click_on "Authorize"
+      access_grant_should_exist_for(@client, @resource_owner)
+      access_grant_should_have_resource_indicators "http://example.com/resource1"
+    end
+
+    scenario "with two resource indicators" do
+      visit "#{authorization_endpoint_url(client: @client, resource: "http://example.com/resource1")}&#{{ resource: "http://example.com/resource2" }.to_param}"
+      click_on "Authorize"
+      access_grant_should_exist_for(@client, @resource_owner)
+      access_grant_should_have_resource_indicators "http://example.com/resource1", "http://example.com/resource2"
+    end
+  end
+
   context "with scopes" do
     background do
       default_scopes_exist :public

--- a/spec/support/helpers/model_helper.rb
+++ b/spec/support/helpers/model_helper.rb
@@ -48,6 +48,11 @@ module ModelHelper
     expect(grant.scopes).to eq(Doorkeeper::OAuth::Scopes.from_array(args))
   end
 
+  def access_grant_should_have_resource_indicators(*args)
+    grant = Doorkeeper::AccessGrant.first
+    expect(grant.resource_indicators).to eq(Doorkeeper::OAuth::ResourceIndicators.from_array(args))
+  end
+
   def access_token_should_have_scopes(*args)
     grant = Doorkeeper::AccessToken.last
     expect(grant.scopes).to eq(Doorkeeper::OAuth::Scopes.from_array(args))

--- a/spec/support/helpers/url_helper.rb
+++ b/spec/support/helpers/url_helper.rb
@@ -10,6 +10,7 @@ module UrlHelper
       grant_type: options[:grant_type] || "authorization_code",
       code_verifier: options[:code_verifier],
       code_challenge_method: options[:code_challenge_method],
+      resource: options[:resource],
     }.reject { |_, v| v.blank? }
     "/oauth/token?#{build_query(parameters)}"
   end
@@ -48,6 +49,7 @@ module UrlHelper
       client_id: options[:client_id] || options[:client].try(:uid),
       client_secret: options[:client_secret] || options[:client].try(:secret),
       grant_type: options[:grant_type] || "refresh_token",
+      resource: options[:resource],
     }.reject { |_, v| v.blank? }
     "/oauth/token?#{build_query(parameters)}"
   end

--- a/spec/support/helpers/url_helper.rb
+++ b/spec/support/helpers/url_helper.rb
@@ -37,6 +37,7 @@ module UrlHelper
       state: options[:state],
       code_challenge: options[:code_challenge],
       code_challenge_method: options[:code_challenge_method],
+      resource: options[:resource],
     }.reject { |_, v| v.blank? }
     "/oauth/authorize?#{build_query(parameters)}"
   end


### PR DESCRIPTION
### Summary

Adds [resource indicator](https://www.rfc-editor.org/rfc/rfc8707.html) support (#1413) as an optional extension. 

### Other Information

I've got a few implementation questions:

1) Should this be an optional extension (with a migration to generate) or just added into the default setup in a disabled state? I'm not clear how best to test the apps when the new migration hasn't been run/generated?

2) The way `resource` is specified in the RFC is quite inconvenient:
```
  GET /as/authorization.oauth2?response_type=code
     &client_id=s6BhdRkqt3
     &state=tNwzQ87pC6llebpmac_IDeeq-mCR2wLDYljHUZUAWuI
     &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
     &scope=calendar%20contacts
     &resource=https%3A%2F%2Fcal.example.com%2F
     &resource=https%3A%2F%2Fcontacts.example.com%2F HTTP/1.1
  Host: authorization-server.example.com
  ```
 
Out of the box rails params won't work in this case. You can see I've hacked together a quick fix, do you have any thoughts on a better way of doing this? Maybe it'd be better to only support one `resource`.


