### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: >-

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -2,6 +2,9 @@ name: Danger
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   danger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
