### PR TITLE
Only filter code parameter if authorization_code grant flow is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#1558] Fixed bug: able to obtain a token with default scopes even if they are not present in the 
   application scopes when using client credentials.
+- [#1567] Only filter `code` parameter if authorization_code grant flow is enabled
 - [#ID] Add your PR description here.
 
 ## 5.6.0.rc1

--- a/lib/doorkeeper/engine.rb
+++ b/lib/doorkeeper/engine.rb
@@ -3,7 +3,8 @@
 module Doorkeeper
   class Engine < Rails::Engine
     initializer "doorkeeper.params.filter" do |app|
-      parameters = %w[client_secret code authentication_token access_token refresh_token]
+      parameters = %w[client_secret authentication_token access_token refresh_token]
+      parameters << "code" if Doorkeeper.config.grant_flows.include?("authorization_code")
       app.config.filter_parameters << /^(#{Regexp.union(parameters)})$/
     end
 


### PR DESCRIPTION
### Summary

Changes the Rails engine `filter_parameters` configuration to only include the `code` parameter if the "authorization_code" grant flow is enabled.

### Other Information

Similar to #1335, I realized a Rails app I was working on was filtering the `code` parameter in unexpected requests.
This was surprising to me, since the application only uses the "client_credentials" flow, and I couldn't find any requests in the logs where we would want `code` filtered out.

Hopefully this change is agreeable, but let me know if not. I did a bit of searching to see if other flows used this parameter but "authorization_code" was the only one that jumped out.