### PR TITLE
Add support for configuring a custom application secret generator

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -387,11 +387,20 @@ module Doorkeeper
     option :access_token_generator,
            default: "Doorkeeper::OAuth::Helpers::UniqueToken"
 
+    # Use a custom class for generating the application secret.
+    # https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-application-secret-generator
+    #
+    # @param application_secret_generator [String]
+    #   the name of the application secret generator class
+    #
+    option :application_secret_generator,
+           default: "Doorkeeper::OAuth::Helpers::UniqueToken"
+
     # Default access token generator is a SecureRandom class from Ruby stdlib.
     # This option defines which method will be used to generate a unique token value.
     #
-    # @param access_token_generator [String]
-    #   the name of the access token generator class
+    # @param default_generator_method [Symbol]
+    #   the method name of the default access token generator
     #
     option :default_generator_method, default: :urlsafe_base64
 

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -517,6 +517,22 @@ RSpec.describe Doorkeeper::Config do
     end
   end
 
+  describe "application_secret_generator" do
+    it "is 'Doorkeeper::OAuth::Helpers::UniqueToken' by default" do
+      expect(Doorkeeper.configuration.application_secret_generator).to(
+        eq("Doorkeeper::OAuth::Helpers::UniqueToken"),
+      )
+    end
+
+    it "can change the value" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        application_secret_generator "Example"
+      end
+      expect(config.application_secret_generator).to eq("Example")
+    end
+  end
+
   describe "default_generator_method" do
     it "is :urlsafe_base64 by default" do
       expect(Doorkeeper.configuration.default_generator_method)

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -86,6 +86,23 @@ RSpec.describe Doorkeeper::Application do
     expect(new_application).not_to be_valid
   end
 
+  it "generates a secret using a custom object" do
+    module CustomGeneratorArgs
+      def self.generate
+        "custom_application_secret"
+      end
+    end
+
+    Doorkeeper.configure do
+      orm DOORKEEPER_ORM
+      application_secret_generator "CustomGeneratorArgs"
+    end
+
+    expect(new_application.secret).to be_nil
+    new_application.save
+    expect(new_application.secret).to eq("custom_application_secret")
+  end
+
   context "when application_owner is enabled" do
     let(:new_application) { FactoryBot.build(:application_with_owner) }
 


### PR DESCRIPTION
### Summary

Right now the application secret generator can't be configured and the only way to ensure that application secrets have an identifiable prefix is by overwriting `renew_secret`.

Generating identifiable tokens and secrets is important and relevant for things like the GitHub Secret Scanning program and we use this already for other things like regular OAuth tokens where we overwrite them with a prefix so they are clearly identifiable for secret scanning.

The changes here also allow such an override for the application secret.

### Other Information

This adds a new reference to the documentation, but that documentation would also need to be created. If this change is considered a good idea, I'm happy to also send a pull request for the documentation then to add it there as well. 