### PR TITLE
pass application into AccessToken#create method

### DIFF
--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -212,7 +212,7 @@ module Doorkeeper
       # @return [Doorkeeper::AccessToken] new access token
       #
       def create_for(application:, resource_owner:, scopes:, **token_attributes)
-        token_attributes[:application_id] = application&.id
+        token_attributes[:application] = application
         token_attributes[:scopes] = scopes.to_s
 
         if Doorkeeper.config.polymorphic_resource_owner?

--- a/spec/lib/oauth/base_request_spec.rb
+++ b/spec/lib/oauth/base_request_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
            created_at: 0
   end
 
-  let(:client) { double :client, id: "1" }
+  let(:client) { Doorkeeper::Application.new(id: "1") }
 
   let(:scopes_array) { %w[public write] }
 


### PR DESCRIPTION
This avoids refetching the application object from the database when it's referenced inside of `attributes_for_token_generator`. Closes #1574 