### PR TITLE
Use token_type_hint when searching for access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#1581] Consider `token_type_hint` when searching for access token in TokensController to avoid extra database calls.
 - [#ID] Add your PR description here.
 
 ## 5.6.0.rc1

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -30,6 +30,7 @@ module Doorkeeper
       end
     end
 
+    # OAuth 2.0 Token Introspection - https://datatracker.ietf.org/doc/html/rfc7662
     def introspect
       introspection = OAuth::TokenIntrospection.new(server, token)
 
@@ -115,12 +116,14 @@ module Doorkeeper
       token.revoke if token&.accessible?
     end
 
-    # Doorkeeper does not use the token_type_hint logic described in the
-    # RFC 7009 due to the refresh token implementation that is a field in
-    # the access token model.
     def token
-      @token ||= Doorkeeper.config.access_token_model.by_token(params["token"]) ||
-                 Doorkeeper.config.access_token_model.by_refresh_token(params["token"])
+      @token ||=
+        if params[:token_type_hint] == "refresh_token"
+          Doorkeeper.config.access_token_model.by_refresh_token(params["token"])
+        else
+          Doorkeeper.config.access_token_model.by_token(params["token"]) ||
+            Doorkeeper.config.access_token_model.by_refresh_token(params["token"])
+        end
     end
 
     def strategy

--- a/spec/requests/flows/revoke_token_spec.rb
+++ b/spec/requests/flows/revoke_token_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Revoke Token Flow" do
     end
 
     it "revokes the refresh token provided" do
-      post revocation_token_endpoint_url, params: { token: access_token.refresh_token }, headers: headers
+      post revocation_token_endpoint_url, params: { token: access_token.refresh_token, token_type_hint: "refresh_token" }, headers: headers
 
       expect(response).to be_successful
       expect(access_token.reload).to be_revoked


### PR DESCRIPTION
Allows to avoid 1 database call when the clients want's to request something and knows the exact type of the token