### PR TITLE
Add support for Trilogy MySQL adapter

### DIFF
--- a/lib/doorkeeper/models/concerns/expiration_time_sql_math.rb
+++ b/lib/doorkeeper/models/concerns/expiration_time_sql_math.rb
@@ -56,6 +56,7 @@ module Doorkeeper
         "postgresql" => PostgresExpirationTimeSqlGenerator,
         "mysql" => MySqlExpirationTimeSqlGenerator,
         "mysql2" => MySqlExpirationTimeSqlGenerator,
+        "trilogy" => MySqlExpirationTimeSqlGenerator,
         "sqlserver" => SqlServerExpirationTimeSqlGenerator,
         "oracleenhanced" => OracleExpirationTimeSqlGenerator,
       }.freeze


### PR DESCRIPTION
This adds support for GitHub's [Trilogy](https://github.blog/2022-08-25-introducing-trilogy-a-new-database-adapter-for-ruby-on-rails/)  MySQL adapter to `ExpirationTimeSqlMath`. It uses the same class as `mysql` and `mysql2`.
