### PR TITLE
Add optional support to use the url path for the native authorization code flow. Ports forward [#1143] from 4.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#1593] Add support for Trilogy ActiveRecord adapter.
 - [#ID] Add your PR description here.
 
 ## 5.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#1593] Add support for Trilogy ActiveRecord adapter.
+- [#1597] Add optional support to use the url path for the native authorization code flow.  Ports forward [#1143] from 4.4.3
 - [#ID] Add your PR description here.
 
 ## 5.6.0

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -159,6 +159,15 @@ module Doorkeeper
         @config.instance_variable_set(:@reuse_access_token, true)
       end
 
+      # Choose to use the url path for native autorization codes 
+      # Enabling this flag sets the authorization code response route for
+      # native redirect uris to oauth/authorize/<code>. The default is
+      # oauth/authorize/native?code=<code>.
+      # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1143
+      def use_url_path_for_native_authorization
+        @config.instance_variable_set(:@use_url_path_for_native_authorization, true)
+      end
+
       # TODO: maybe make it more generic for other flows too?
       # Only allow one valid access token obtained via client credentials
       # per client. If a new access token is obtained before the old one
@@ -622,6 +631,11 @@ module Doorkeeper
     # [NOTE]: deprecated and will be removed soon
     def deprecated_token_grant_types_resolver
       @deprecated_token_grant_types ||= calculate_token_grant_types
+    end
+    
+    def native_authorization_code_route
+      @use_url_path_for_native_authorization = false unless defined?(@use_url_path_for_native_authorization)
+      @use_url_path_for_native_authorization ? '/:code' : '/native'
     end
 
     # [NOTE]: deprecated and will be removed soon

--- a/lib/doorkeeper/models/concerns/expiration_time_sql_math.rb
+++ b/lib/doorkeeper/models/concerns/expiration_time_sql_math.rb
@@ -56,6 +56,7 @@ module Doorkeeper
         "postgresql" => PostgresExpirationTimeSqlGenerator,
         "mysql" => MySqlExpirationTimeSqlGenerator,
         "mysql2" => MySqlExpirationTimeSqlGenerator,
+        "trilogy" => MySqlExpirationTimeSqlGenerator,
         "sqlserver" => SqlServerExpirationTimeSqlGenerator,
         "oracleenhanced" => OracleExpirationTimeSqlGenerator,
       }.freeze

--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -53,8 +53,8 @@ module Doorkeeper
           as: mapping[:as],
           controller: mapping[:controllers],
         ) do
-          routes.get "/native", action: :show, on: :member
-          routes.get "/", action: :new, on: :member
+          routes.get native_authorization_code_route, action: :show, on: :member
+          routes.get '/', action: :new, on: :member
         end
       end
 
@@ -95,6 +95,10 @@ module Doorkeeper
         routes.resources :authorized_applications,
                          only: %i[index destroy],
                          controller: mapping[:controllers]
+      end
+
+      def native_authorization_code_route
+        Doorkeeper.configuration.native_authorization_code_route
       end
     end
   end

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -646,6 +646,38 @@ RSpec.describe Doorkeeper::AuthorizationsController do
     it "does not issue a token" do
       expect(Doorkeeper::AccessToken.count).to be 0
     end
+
+    context 'with use_url_path_for_native_authorization' do
+      around(:each) do |example|
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          use_url_path_for_native_authorization
+        end
+
+        Rails.application.reload_routes!
+
+        example.run
+
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+        end
+
+        Rails.application.reload_routes!
+      end
+
+      it 'should redirect immediately' do
+        expect(response).to be_redirect
+        expect(response.location).to match(/oauth\/authorize\/#{Doorkeeper::AccessGrant.first.token}/)
+      end
+
+      it 'should issue a grant' do
+        expect(Doorkeeper::AccessGrant.count).to be 1
+      end
+
+      it 'should not issue a token' do
+        expect(Doorkeeper::AccessToken.count).to be 0
+      end
+    end
   end
 
   describe "GET #new with skip_authorization true" do

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -41,6 +41,11 @@ Doorkeeper.configure do
   #
   # enforce_configured_scopes
 
+  # Use the url path for the native authorization code flow. Enabling this flag sets the authorization
+  # code response route for native redirect uris to oauth/authorize/<code>. The default is oauth/authorize/native?code=<code>.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1143
+  # use_url_path_for_native_authorization
+
   # Provide support for an owner to be assigned to each registered application (disabled by default)
   # Optional parameter confirmation: true (default false) if you want to enforce ownership of
   # a registered application

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -253,6 +253,31 @@ RSpec.describe Doorkeeper::Config do
     end
   end
 
+  describe 'use_url_path_for_native_authorization' do
+    around(:each) do |example|
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        use_url_path_for_native_authorization
+      end
+
+      Rails.application.reload_routes!
+
+      subject { Doorkeeper.configuration }
+
+      example.run
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+      end
+
+      Rails.application.reload_routes!
+    end
+
+    it 'sets the native authorization code route /:code' do
+      expect(subject.native_authorization_code_route).to eq('/:code')
+    end
+  end
+
   describe "client_credentials" do
     it "has defaults order" do
       expect(config.client_credentials_methods)


### PR DESCRIPTION
### Summary

Provide the same option to opt out of the breaking api change introduced in https://github.com/doorkeeper-gem/doorkeeper/pull/1003 that was provided in the 4.x branch via this pr(https://github.com/doorkeeper-gem/doorkeeper/pull/1144).   

Added comments regarding this issue to the original issue https://github.com/doorkeeper-gem/doorkeeper/issues/1143

### Other Information

The reason for pulling this option forward is that there are users who are stuck on the 4.x branch because they have clients that rely on this legacy behavior. 
