### PR TITLE
Allow custom data to be sent inside access tokens

### DIFF
--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -88,7 +88,7 @@ module Doorkeeper
     end
 
     def pre_auth_param_fields
-      %i[
+      Doorkeeper.configuration.custom_access_token_fields + %i[
         client_id
         code_challenge
         code_challenge_method

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -88,7 +88,7 @@ module Doorkeeper
     end
 
     def pre_auth_param_fields
-      Doorkeeper.configuration.custom_access_token_fields + %i[
+      Doorkeeper.configuration.custom_access_token_attributes + %i[
         client_id
         code_challenge
         code_challenge_method

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -321,6 +321,15 @@ module Doorkeeper
     option :access_token_generator,
            default: "Doorkeeper::OAuth::Helpers::UniqueToken"
 
+    # Allows additional data to be received when granting access to an Application, and for this
+    # additional data to be sent with subsequently generated access tokens. The access grant and
+    # access token models will both need to respond to the specified field names.
+    #
+    # @param fields [Array] The array of custom field names to be saved
+    #
+    option :custom_access_token_fields,
+           default: []
+
     # Use a custom class for generating the application secret.
     # https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-application-secret-generator
     #

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -323,11 +323,11 @@ module Doorkeeper
 
     # Allows additional data to be received when granting access to an Application, and for this
     # additional data to be sent with subsequently generated access tokens. The access grant and
-    # access token models will both need to respond to the specified field names.
+    # access token models will both need to respond to the specified attribute names.
     #
-    # @param fields [Array] The array of custom field names to be saved
+    # @param attributes [Array] The array of custom attribute names to be saved
     #
-    option :custom_access_token_fields,
+    option :custom_access_token_attributes,
            default: []
 
     # Use a custom class for generating the application secret.

--- a/lib/doorkeeper/config/validations.rb
+++ b/lib/doorkeeper/config/validations.rb
@@ -48,6 +48,18 @@ module Doorkeeper
         )
         @token_reuse_limit = 100
       end
+
+      def validate_custom_access_token_attributes
+        # Validate that the access_token and access_grant models
+        # both respond to all of the custom attributes
+        Doorkeeper.config.custom_access_token_attributes.each do |attribute_name|
+          [Doorkeeper.config.access_token_model, Doorkeeper.config.access_grant_model].each do |model|
+            unless model.has_attribute?(attribute_name)
+              raise NotImplementedError, "#{model} does not recognize custom attribute: #{attribute_name}."
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -45,14 +45,10 @@ module Doorkeeper
             attributes[:resource_owner_id] = resource_owner.id
           end
 
-          # Custom access token fields are saved into the access grant,
+          # Custom access token attributes are saved into the access grant,
           # and then included in subsequently generated access tokens.
-          Doorkeeper.config.custom_access_token_fields.each do |field_name|
-            unless Doorkeeper.config.access_grant_model.has_attribute?(field_name)
-              raise NotImplementedError, "#{Doorkeeper.config.access_grant_model} does not recognize field: #{field_name}."
-            end
-
-            attributes[field_name] = @pre_auth.custom_access_token_fields[field_name]
+          Doorkeeper.config.custom_access_token_attributes.each do |attribute_name|
+            attributes[attribute_name] = @pre_auth.custom_access_token_attributes[attribute_name]
           end
 
           pkce_attributes.merge(attributes)

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -45,6 +45,16 @@ module Doorkeeper
             attributes[:resource_owner_id] = resource_owner.id
           end
 
+          # Custom access token fields are saved into the access grant,
+          # and then included in subsequently generated access tokens.
+          Doorkeeper.config.custom_access_token_fields.each do |field_name|
+            unless Doorkeeper.config.access_grant_model.has_attribute?(field_name)
+              raise NotImplementedError, "#{Doorkeeper.config.access_grant_model} does not recognize field: #{field_name}."
+            end
+
+            attributes[field_name] = @pre_auth.custom_access_token_fields[field_name]
+          end
+
           pkce_attributes.merge(attributes)
         end
 

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -35,7 +35,7 @@ module Doorkeeper
             grant.application,
             resource_owner,
             grant.scopes,
-            custom_token_fields_with_data,
+            custom_token_attributes_with_data,
             server,
           )
         end
@@ -101,14 +101,8 @@ module Doorkeeper
         server_config.access_grant_model.generate_code_challenge(code_verifier)
       end
 
-      private def custom_token_fields_with_data
-        Doorkeeper.config.custom_access_token_fields.each do |field_name|
-          unless Doorkeeper.config.access_token_model.has_attribute?(field_name)
-            raise NotImplementedError, "#{Doorkeeper.config.access_token_model} does not recognize field: #{field_name}."
-          end
-        end
-
-        grant.attributes.with_indifferent_access.slice(*Doorkeeper.config.custom_access_token_fields).symbolize_keys
+      private def custom_token_attributes_with_data
+        grant.attributes.with_indifferent_access.slice(*Doorkeeper.config.custom_access_token_attributes).symbolize_keys
       end
     end
   end

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -35,6 +35,7 @@ module Doorkeeper
             grant.application,
             resource_owner,
             grant.scopes,
+            custom_token_fields_with_data,
             server,
           )
         end
@@ -98,6 +99,16 @@ module Doorkeeper
 
       def generate_code_challenge(code_verifier)
         server_config.access_grant_model.generate_code_challenge(code_verifier)
+      end
+
+      private def custom_token_fields_with_data
+        Doorkeeper.config.custom_access_token_fields.each do |field_name|
+          unless Doorkeeper.config.access_token_model.has_attribute?(field_name)
+            raise NotImplementedError, "#{Doorkeeper.config.access_token_model} does not recognize field: #{field_name}."
+          end
+        end
+
+        grant.attributes.with_indifferent_access.slice(*Doorkeeper.config.custom_access_token_fields).symbolize_keys
       end
     end
   end

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -26,12 +26,12 @@ module Doorkeeper
         @scopes ||= build_scopes
       end
 
-      def find_or_create_access_token(client, resource_owner, scopes, custom_fields, server)
+      def find_or_create_access_token(client, resource_owner, scopes, custom_attributes, server)
         context = Authorization::Token.build_context(client, grant_type, scopes, resource_owner)
         token_model = server_config.access_token_model
         application = client.is_a?(server_config.application_model) ? client : client&.application
 
-        token_params = {
+        token_attributes = {
           application: application,
           resource_owner: resource_owner,
           scopes: scopes,
@@ -39,7 +39,7 @@ module Doorkeeper
           use_refresh_token: Authorization::Token.refresh_token_enabled?(server, context),
         }
 
-        @access_token = token_model.find_or_create_for(token_params.merge(custom_fields))
+        @access_token = token_model.find_or_create_for(**token_attributes.merge(custom_attributes))
       end
 
       def before_successful_response

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -26,15 +26,20 @@ module Doorkeeper
         @scopes ||= build_scopes
       end
 
-      def find_or_create_access_token(client, resource_owner, scopes, server)
+      def find_or_create_access_token(client, resource_owner, scopes, custom_fields, server)
         context = Authorization::Token.build_context(client, grant_type, scopes, resource_owner)
-        @access_token = server_config.access_token_model.find_or_create_for(
-          application: client.is_a?(server_config.application_model) ? client : client&.application,
+        token_model = server_config.access_token_model
+        application = client.is_a?(server_config.application_model) ? client : client&.application
+
+        token_params = {
+          application: application,
           resource_owner: resource_owner,
           scopes: scopes,
           expires_in: Authorization::Token.access_token_expires_in(server, context),
           use_refresh_token: Authorization::Token.refresh_token_enabled?(server, context),
-        )
+        }
+
+        @access_token = token_model.find_or_create_for(token_params.merge(custom_fields))
       end
 
       def before_successful_response

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -25,7 +25,7 @@ module Doorkeeper
       private
 
       def before_successful_response
-        find_or_create_access_token(client, resource_owner, scopes, server)
+        find_or_create_access_token(client, resource_owner, scopes, {}, server)
         super
       end
 

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -18,7 +18,7 @@ module Doorkeeper
 
       attr_reader :client, :code_challenge, :code_challenge_method, :missing_param,
                   :redirect_uri, :resource_owner, :response_type, :state,
-                  :authorization_response_flow, :response_mode
+                  :authorization_response_flow, :response_mode, :custom_access_token_fields
 
       def initialize(server, parameters = {}, resource_owner = nil)
         @server                = server
@@ -31,6 +31,11 @@ module Doorkeeper
         @code_challenge        = parameters[:code_challenge]
         @code_challenge_method = parameters[:code_challenge_method]
         @resource_owner        = resource_owner
+
+        @custom_access_token_fields = {}
+        Doorkeeper.config.custom_access_token_fields.each do |field|
+          @custom_access_token_fields[field] = parameters[field]
+        end
       end
 
       def authorizable?

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -18,7 +18,7 @@ module Doorkeeper
 
       attr_reader :client, :code_challenge, :code_challenge_method, :missing_param,
                   :redirect_uri, :resource_owner, :response_type, :state,
-                  :authorization_response_flow, :response_mode, :custom_access_token_fields
+                  :authorization_response_flow, :response_mode, :custom_access_token_attributes
 
       def initialize(server, parameters = {}, resource_owner = nil)
         @server                = server
@@ -32,9 +32,9 @@ module Doorkeeper
         @code_challenge_method = parameters[:code_challenge_method]
         @resource_owner        = resource_owner
 
-        @custom_access_token_fields = {}
-        Doorkeeper.config.custom_access_token_fields.each do |field|
-          @custom_access_token_fields[field] = parameters[field]
+        @custom_access_token_attributes = {}
+        Doorkeeper.config.custom_access_token_attributes.each do |field|
+          @custom_access_token_attributes[field] = parameters[field]
         end
       end
 

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -391,6 +391,23 @@ Doorkeeper.configure do
   #   resource_owner.admin? || client.owners_allowlist.include?(resource_owner)
   # end
 
+  # Allows additional data fields to be sent while granting access to an application,
+  # and for this additional data to be included in subsequently generated access tokens.
+  # The 'authorizations/new' page will need to be overridden to include this additional data
+  # in the request params when granting access. The access grant and access token models
+  # will both need to respond to these additional data fields, and have a database column
+  # to store them in.
+  #
+  # Example:
+  # You have a multi-tenanted platform and want to be able to grant access to a specific
+  # tenant, rather than all the tenants a user has access to. You can use this config
+  # option to specify that a ':tenant_id' will be passed when authorizing. This tenant_id
+  # will be included in the access tokens. When a request is made with one of these access
+  # tokens, you can check that the requested data belongs to the specified tenant.
+  #
+  # Default value is an empty Array: []
+  # custom_access_token_fields [:tenant_id]
+
   # Hook into the strategies' request & response life-cycle in case your
   # application needs advanced customization or logging:
   #

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -406,7 +406,7 @@ Doorkeeper.configure do
   # tokens, you can check that the requested data belongs to the specified tenant.
   #
   # Default value is an empty Array: []
-  # custom_access_token_fields [:tenant_id]
+  # custom_access_token_attributes [:tenant_id]
 
   # Hook into the strategies' request & response life-cycle in case your
   # application needs advanced customization or logging:

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -521,6 +521,20 @@ RSpec.describe Doorkeeper::Config do
     end
   end
 
+  describe "custom_access_token_fields" do
+    it "is '[]' by default" do
+      expect(Doorkeeper.configuration.custom_access_token_fields).to(eq([]))
+    end
+
+    it "can change the value" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        custom_access_token_fields [:added_field_1, :added_field_2]
+      end
+      expect(config.custom_access_token_fields).to eq([:added_field_1, :added_field_2])
+    end
+  end
+
   describe "application_secret_generator" do
     it "is 'Doorkeeper::OAuth::Helpers::UniqueToken' by default" do
       expect(Doorkeeper.configuration.application_secret_generator).to(

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -521,17 +521,17 @@ RSpec.describe Doorkeeper::Config do
     end
   end
 
-  describe "custom_access_token_fields" do
+  describe "custom_access_token_attributes" do
     it "is '[]' by default" do
-      expect(Doorkeeper.configuration.custom_access_token_fields).to(eq([]))
+      expect(Doorkeeper.configuration.custom_access_token_attributes).to(eq([]))
     end
 
     it "can change the value" do
       Doorkeeper.configure do
         orm DOORKEEPER_ORM
-        custom_access_token_fields [:added_field_1, :added_field_2]
+        custom_access_token_attributes [:added_field_1, :added_field_2]
       end
-      expect(config.custom_access_token_fields).to eq([:added_field_1, :added_field_2])
+      expect(config.custom_access_token_attributes).to eq([:added_field_1, :added_field_2])
     end
   end
 

--- a/spec/lib/oauth/base_request_spec.rb
+++ b/spec/lib/oauth/base_request_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         client,
         resource_owner,
         "public",
+        {},
         server,
       )
 
@@ -144,6 +145,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         client,
         resource_owner,
         "public",
+        {},
         server,
       )
       expect(result.expires_in).to be(500)
@@ -165,6 +167,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         client,
         resource_owner,
         "public",
+        {},
         server,
       )
       expect(result.refresh_token).not_to be_nil
@@ -173,6 +176,7 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
         client,
         resource_owner,
         "private",
+        {},
         server,
       )
       expect(result.refresh_token).to be_nil


### PR DESCRIPTION
### Summary

I've added a new config option - `custom_access_token_fields`. By default, this will be an empty array and have no effect, and when in use, it will be an array of symbols. This array of symbols will then be permitted parameters keys when authorising and granting access to an application. A developer can then configure their OAuth consent screen to allow custom data to be submitted during authorisation. This custom data will then be saved to the Access Grant, and will be included in any subsequently generated access tokens.

### Example Use Case

You have a multi-tenanted platform, where our example user has access to `tenant_1`, `tenant_2`, and `tenant_3`. The example user would like to grant an OAuth application access to their data, but only for `tenant_2`, and not the others. Using this new config option, the developer of the platform can specify that a `tenant_id` will be submitted when granting access - `custom_access_token_fields [:tenant_id]`. The developer can then add a `tenant_id` column to the `oauth_access_grants` and `oauth_access_tokens` database tables, and then add a tenant select dropdown to their OAuth consent screen, allowing the `tenant_id` to be selected and submitted and saved. This tenant_id is then included in access tokens. When receiving a request using one of these access tokens, then developer can add measures to check that the requested resource belongs to the tenant for which the access token was created.
