### PR TITLE
Simplify PreAuthorization class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#ID] Add your PR description here.
 - [#1605] Fix URI validation for Ruby 3.2+.
+- [#1608] Simplify PreAuthorization class (avoid passing `Doorkeeper.config` into initializer).
 
 ## 5.6.2
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -76,11 +76,7 @@ module Doorkeeper
     end
 
     def pre_auth
-      @pre_auth ||= OAuth::PreAuthorization.new(
-        Doorkeeper.configuration,
-        pre_auth_params,
-        current_resource_owner,
-      )
+      @pre_auth ||= OAuth::PreAuthorization.new(pre_auth_params, current_resource_owner)
     end
 
     def pre_auth_params

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -20,8 +20,7 @@ module Doorkeeper
                   :redirect_uri, :resource_owner, :response_type, :state,
                   :authorization_response_flow, :response_mode
 
-      def initialize(server, parameters = {}, resource_owner = nil)
-        @server                = server
+      def initialize(parameters = {}, resource_owner = nil)
         @client_id             = parameters[:client_id]
         @response_type         = parameters[:response_type]
         @response_mode         = parameters[:response_mode]
@@ -42,7 +41,7 @@ module Doorkeeper
       end
 
       def scope
-        @scope.presence || (server.default_scopes.presence && build_scopes)
+        @scope.presence || (Doorkeeper.config.default_scopes.presence && build_scopes)
       end
 
       def error_response
@@ -66,14 +65,14 @@ module Doorkeeper
 
       private
 
-      attr_reader :client_id, :server
+      attr_reader :client_id
 
       def build_scopes
         client_scopes = client.scopes
         if client_scopes.blank?
-          server.default_scopes.to_s
+          Doorkeeper.config.default_scopes.to_s
         else
-          (server.default_scopes & client_scopes).to_s
+          (Doorkeeper.config.default_scopes & client_scopes).to_s
         end
       end
 
@@ -108,7 +107,7 @@ module Doorkeeper
       def validate_params
         @missing_param = if response_type.blank?
                            :response_type
-                         elsif @scope.blank? && server.default_scopes.blank?
+                         elsif @scope.blank? && Doorkeeper.config.default_scopes.blank?
                            :scope
                          end
 
@@ -116,7 +115,7 @@ module Doorkeeper
       end
 
       def validate_response_type
-        server.authorization_response_flows.any? do |flow|
+        Doorkeeper.config.authorization_response_flows.any? do |flow|
           if flow.matches_response_type?(response_type)
             @authorization_response_flow = flow
             true
@@ -136,7 +135,7 @@ module Doorkeeper
       def validate_scopes
         Helpers::ScopeChecker.valid?(
           scope_str: scope,
-          server_scopes: server.scopes,
+          server_scopes: Doorkeeper.config.scopes,
           app_scopes: client.scopes,
           grant_type: grant_type,
         )

--- a/spec/lib/oauth/code_request_spec.rb
+++ b/spec/lib/oauth/code_request_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe Doorkeeper::OAuth::CodeRequest do
     application = FactoryBot.create(:application, scopes: "public")
     client = Doorkeeper::OAuth::Client.new(application)
 
-    attributes = {
+    params = {
       client_id: client.uid,
       response_type: "code",
       redirect_uri: "https://app.com/callback",
       response_mode: response_mode,
     }.compact
 
-    pre_auth = Doorkeeper::OAuth::PreAuthorization.new(Doorkeeper.config, attributes)
+    pre_auth = Doorkeeper::OAuth::PreAuthorization.new(params)
     pre_auth.authorizable?
     pre_auth
   end

--- a/spec/lib/oauth/token_request_spec.rb
+++ b/spec/lib/oauth/token_request_spec.rb
@@ -12,19 +12,18 @@ RSpec.describe Doorkeeper::OAuth::TokenRequest do
   end
 
   let(:pre_auth) do
-    server = Doorkeeper.config
-    allow(server).to receive(:default_scopes).and_return(Doorkeeper::OAuth::Scopes.from_string("public"))
-    allow(server).to receive(:grant_flows).and_return(Doorkeeper::OAuth::Scopes.from_string("implicit"))
+    allow(Doorkeeper.config).to receive(:default_scopes).and_return(Doorkeeper::OAuth::Scopes.from_string("public"))
+    allow(Doorkeeper.config).to receive(:grant_flows).and_return(Doorkeeper::OAuth::Scopes.from_string("implicit"))
 
     client = Doorkeeper::OAuth::Client.new(application)
 
-    attributes = {
+    params = {
       client_id: client.uid,
       response_type: "token",
       redirect_uri: "https://app.com/callback",
     }
 
-    pre_auth = Doorkeeper::OAuth::PreAuthorization.new(server, attributes)
+    pre_auth = Doorkeeper::OAuth::PreAuthorization.new(params)
     pre_auth.authorizable?
     pre_auth
   end


### PR DESCRIPTION
 Simplify `PreAuthorization` class (no need to pass Doorkeeper config it, it's accessible in the class itself)