### PR TITLE
Move the created_at and revoked_at columns at the end.

### DIFF
--- a/lib/generators/doorkeeper/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/migration.rb.erb
@@ -24,9 +24,9 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
       t.string   :token,             null: false
       t.integer  :expires_in,        null: false
       t.text     :redirect_uri,      null: false
+      t.string   :scopes,            null: false, default: ''
       t.datetime :created_at,        null: false
       t.datetime :revoked_at
-      t.string   :scopes,            null: false, default: ''
     end
 
     add_index :oauth_access_grants, :token, unique: true
@@ -53,9 +53,9 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
 
       t.string   :refresh_token
       t.integer  :expires_in
-      t.datetime :revoked_at
-      t.datetime :created_at, null: false
       t.string   :scopes
+      t.datetime :created_at, null: false
+      t.datetime :revoked_at
 
       # The authorization server MAY issue a new refresh token, in which case
       # *the client MUST discard the old refresh token* and replace it with the


### PR DESCRIPTION
Timestamp columns like `created_at` and `updated_at` are usually in a Rails application the last columns of a db table. This commit wants to respect this "convention" by moving the columns `created_at` and `revoked_at` at the end of the tables in the generated doorkeeper migration file.
