### PR TITLE
Add Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         ruby:
-          - 2.6
           - 2.7
           - '3.0'
           - '3.1'
+          - '3.2'
           - head
         gemfile:
           - gemfiles/rails_5_2.gemfile


### PR DESCRIPTION
### Summary
Hi! Thanks for maintaining the project 👋 
I started using doorkeeper with the new version of Ruby and thought it would feel more comfortable if CI runs against it.

Also dropped 2.6 from matrix since it is already EOL as of 2022-04-12.
c.f. https://www.ruby-lang.org/en/downloads/branches/

What do you think?