### PR TITLE
Use ruby/setup-ruby and bundler-cache

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -14,15 +14,10 @@ jobs:
       (github.event_name  == 'pull_request')
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7'
-    - uses: actions/cache@v3
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - uses: MeilCli/danger-action@v5
       with:
         plugins_file: 'Gemfile'


### PR DESCRIPTION
### Summary

This PR is use ruby/setup-ruby and bundler-cache.

The following warnings have been resolved:
https://github.com/doorkeeper-gem/doorkeeper/actions/runs/3882097161/jobs/6627208374#step:3:9
```
------------------------
NOTE: This action is deprecated and is no longer maintained.
Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
------------------------
```