### PR TITLE
Migrate danger workflow to use ruby/setup-ruby@1

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -25,4 +25,4 @@ jobs:
         danger_file: 'Dangerfile'
         danger_id: 'danger-pr'
       env:
-        DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_TOKEN }}
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -14,15 +14,10 @@ jobs:
       (github.event_name  == 'pull_request')
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
-    - uses: actions/cache@v3
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
+        ruby-version: '3.2'
+        bundler-cache: true
     - uses: MeilCli/danger-action@v5
       with:
         plugins_file: 'Gemfile'


### PR DESCRIPTION
### Summary
Thanks for merging #1618 🚀 However I also find the danger workflow is not working and therefore propose that we do a follow-up. 

This is only to replace actions/setup-ruby@1 with ruby/setup-ruby@1, where what I did is basically followed the official readme of the latter: https://github.com/ruby/setup-ruby

This is going to resolve not only the runtime error but also (although hopefully) nodejs v12 deprecation warning, which to me seems to come incidentally with actions/setup-ruby@1.
https://github.com/doorkeeper-gem/doorkeeper/actions/runs/3882097161
