### PR TITLE
Drop support for Rubies 2.5 and 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
         exclude:
           - ruby: 3.0
             gemfile: gemfiles/rails_5_2.gemfile
-          - ruby: 2.6
-            gemfile: gemfiles/rails_7_0.gemfile
     steps:
       - name: Repo checkout
         uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   Exclude:
     - "spec/generators/tmp/**/*"
     - "spec/dummy/db/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#ID] Add your PR description here.
+- [#1622] Drop support for Rubies 2.5 and 2.6
 - [#1605] Fix URI validation for Ruby 3.2+.
 
 ## 5.6.2

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   }
 
   gem.add_dependency "railties", ">= 5"
-  gem.required_ruby_version = ">= 2.5"
+  gem.required_ruby_version = ">= 2.7"
 
   gem.post_install_message = <<~MSG.strip
     Starting from 5.5.0 RC1 Doorkeeper requires client authentication for Resource Owner Password Grant


### PR DESCRIPTION
### Summary
After #1618 I recognized some remaining stuff:

- Ruby 2.5 has been untested since #1502 (it says 2.4 but 2.5 was excluded from travis at this point)
- Ruby 2.6 is going to be untested from now on

So I propose that we exclude these versions. How does that sound?