### PR TITLE
Remove deprecated active_record_options config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-visible changes worth mentioning.
 - [#1622] Drop support for Rubies 2.5 and 2.6
 - [#1605] Fix URI validation for Ruby 3.2+.
 - [#1625] Exclude endless access tokens from `StaleRecordsCleaner`.
+- [#1626] Remove deprecated `active_record_options` config option.
 
 ## 5.6.2
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -324,11 +324,6 @@ module Doorkeeper
     option :skip_client_authentication_for_password_grant,
            default: false
 
-    # TODO: remove the option
-    option :active_record_options,
-           default: {},
-           deprecated: { message: "Customize Doorkeeper models instead" }
-
     # Hook to allow arbitrary user-client authorization
     option :authorize_resource_owner_for_client,
            default: ->(_client, _resource_owner) { true }

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -29,20 +29,7 @@ module Doorkeeper
       end
 
       def self.run_hooks
-        # Deprecated, will be removed soon
-        return unless (options = Doorkeeper.config.active_record_options[:establish_connection])
-
-        Doorkeeper::Orm::ActiveRecord.models.each do |model|
-          model.establish_connection(options)
-        end
-      end
-
-      def self.models
-        [
-          Doorkeeper.config.access_grant_model,
-          Doorkeeper.config.access_token_model,
-          Doorkeeper.config.application_model,
-        ]
+        # nop
       end
     end
   end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -626,33 +626,6 @@ RSpec.describe Doorkeeper::Config do
   if DOORKEEPER_ORM == :active_record
     class FakeCustomModel; end
 
-    describe "active_record_options" do
-      let(:models) { [Doorkeeper::AccessGrant, Doorkeeper::AccessToken, Doorkeeper::Application] }
-
-      before do
-        models.each do |model|
-          allow(model).to receive(:establish_connection).and_return(true)
-        end
-      end
-
-      it "establishes connection for Doorkeeper models based on options" do
-        expect(models).to all(receive(:establish_connection))
-
-        expect(Kernel).to receive(:warn).with(
-          /\[DOORKEEPER\] active_record_options has been deprecated and will soon be removed/,
-        )
-
-        Doorkeeper.configure do
-          orm DOORKEEPER_ORM
-          active_record_options(
-            establish_connection: Rails.configuration.database_configuration[Rails.env],
-          )
-        end
-
-        Doorkeeper.setup
-      end
-    end
-
     describe "access_token_class" do
       it "uses default doorkeeper value" do
         expect(config.access_token_class).to eq("Doorkeeper::AccessToken")


### PR DESCRIPTION
Deprecated since 2019-2020, not used anymore and could be customized more flexible and in a native way via custom classes.