### PR TITLE
Apply ORM configuration in #to_prepare block to avoid autoloading errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#ID] Add your PR description here.
+- [#1633] Apply ORM configuration in #to_prepare block to avoid autoloading errors.
 
 # 5.6.3
 

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -137,8 +137,6 @@ module Doorkeeper
 
     def setup
       setup_orm_adapter
-      run_orm_hooks
-      config.clear_cache!
 
       # Deprecated, will be removed soon
       unless configuration.orm == :active_record
@@ -160,6 +158,8 @@ module Doorkeeper
     end
 
     def run_orm_hooks
+      config.clear_cache!
+
       if @orm_adapter.respond_to?(:run_hooks)
         @orm_adapter.run_hooks
       else

--- a/lib/doorkeeper/engine.rb
+++ b/lib/doorkeeper/engine.rb
@@ -21,7 +21,7 @@ module Doorkeeper
     end
 
     config.to_prepare do
-      Doorkeeper.setup
+      Doorkeeper.run_orm_hooks
     end
 
     if defined?(Sprockets) && Sprockets::VERSION.chr.to_i >= 4

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -372,6 +372,8 @@ RSpec.describe Doorkeeper::Config do
 
           application_class "ApplicationWithOwner"
         end
+
+        Doorkeeper.run_orm_hooks
       end
 
       it "adds support for application owner" do
@@ -398,6 +400,8 @@ RSpec.describe Doorkeeper::Config do
 
           application_class "ApplicationWithOwner"
         end
+
+        Doorkeeper.run_orm_hooks
       end
 
       it "adds support for application owner" do

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -106,8 +106,9 @@ RSpec.describe Doorkeeper::Application do
           orm DOORKEEPER_ORM
           enable_application_owner
         end
-      end
 
+        Doorkeeper.run_orm_hooks
+      end
 
       it "is valid given valid attributes" do
         expect(new_application).to be_valid
@@ -120,6 +121,8 @@ RSpec.describe Doorkeeper::Application do
           orm DOORKEEPER_ORM
           enable_application_owner confirmation: true
         end
+
+        Doorkeeper.run_orm_hooks
       end
 
       it "is invalid without an owner" do
@@ -495,6 +498,8 @@ RSpec.describe Doorkeeper::Application do
           orm DOORKEEPER_ORM
           enable_application_owner confirmation: false
         end
+
+        Doorkeeper.run_orm_hooks
       end
 
       it "includes all the attributes" do
@@ -527,6 +532,8 @@ RSpec.describe Doorkeeper::Application do
           application_class "CustomApp"
           enable_application_owner confirmation: false
         end
+
+        Doorkeeper.run_orm_hooks
       end
 
       it "is valid given valid attributes" do
@@ -541,6 +548,8 @@ RSpec.describe Doorkeeper::Application do
           application_class "CustomApp"
           enable_application_owner confirmation: true
         end
+
+        Doorkeeper.run_orm_hooks
       end
 
       it "is invalid without owner" do


### PR DESCRIPTION
Addresses  https://github.com/doorkeeper-gem/doorkeeper/pull/1627#issuecomment-1409084547