### PR TITLE
Require code_challenge in PKCE flow

### DIFF
--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -33,6 +33,23 @@
     <h4><%= t('.confidential') %>:</h4>
     <p><code class="bg-light" id="confidential"><%= @application.confidential? %></code></p>
 
+    <% unless @application.confidential? %>
+      <p>
+        code_verifier:
+        <code class="bg-light">
+          <%= code_verifier = SecureRandom.hex(32) %>
+        </code>
+        <br/>
+        code_challenge:
+        <code class="bg-light">
+          <%= code_challenge = Base64.urlsafe_encode64(
+                                 OpenSSL::Digest::SHA256.digest(code_verifier)
+                               ).gsub(/=/, '') %>
+        </code>
+      </p>
+    <% end %>
+
+
     <h4><%= t('.callback_urls') %>:</h4>
 
     <% if @application.redirect_uri.present? %>
@@ -43,7 +60,8 @@
               <code class="bg-light"><%= uri %></code>
             </td>
             <td>
-              <%= link_to t('doorkeeper.applications.buttons.authorize'), oauth_authorization_path(client_id: @application.uid, redirect_uri: uri, response_type: 'code', scope: @application.scopes), class: 'btn btn-success', target: '_blank' %>
+              <% pkce_params = @application.confidential? ? {} : { code_challenge:, code_challenge_method: "S256" } %>
+              <%= link_to t('doorkeeper.applications.buttons.authorize'), oauth_authorization_path({client_id: @application.uid, redirect_uri: uri, response_type: 'code', scope: @application.scopes}.merge(pkce_params)), class: 'btn btn-success', target: '_blank' %>
             </td>
           </tr>
         <% end %>

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -111,6 +111,8 @@ module Doorkeeper
                            :response_type
                          elsif @scope.blank? && server.default_scopes.blank?
                            :scope
+                         elsif code_challenge.blank? && !client.application.confidential?
+                           :code_challenge
                          end
 
         @missing_param.nil?


### PR DESCRIPTION
### Summary

This is my first PR in this repo so please be nice :smiley:

I understand the specification of the PKCE flow so that the specification of the `code_challenge` and the `code_challenge_method` is mandatory for public clients, although it is not formulated very clearly https://www.rfc-editor.org/rfc/rfc7636#section-4.4.1

I wanted to at least make it required in my OAuth Provider App and couldn't find a built-in function for it on Doorkeeper.

What do you think of my suggestion? These changes force a `code_challenge` to be specified for applications that are `confidential == false`.

Is that a way that seems fitting? Or should there be a config `require_code_challenge_for_unconfidential_applications` for that?

Let me know what you think. If this goes in the right direction, then I'll try to write a corresponding test and change the `Changelog.md`.