### PR TITLE
Update HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#ID] Add your PR description here.
+- [#1644] Update HTTP headers.
 
 # 5.6.5
 
@@ -45,7 +46,7 @@ User-visible changes worth mentioning.
 
 ## 5.6.0.rc2
 
-- [#1558] Fixed bug: able to obtain a token with default scopes even if they are not present in the 
+- [#1558] Fixed bug: able to obtain a token with default scopes even if they are not present in the
   application scopes when using client credentials.
 - [#1567] Only filter `code` parameter if authorization_code grant flow is enabled.
 
@@ -80,7 +81,7 @@ User-visible changes worth mentioning.
 ## 5.5.1
 
 - [#1496] Revoke `old_refresh_token` if `previous_refresh_token` is present.
-- [#1495] Fix `respond_to` undefined in API-only mode 
+- [#1495] Fix `respond_to` undefined in API-only mode
 - [#1488] Verify client authentication for Resource Owner Password Grant when
   `config.skip_client_authentication_for_password_grant` is set and the client credentials
   are sent in a HTTP Basic auth header.
@@ -94,10 +95,10 @@ User-visible changes worth mentioning.
 ## 5.5.0.rc2
 
 - [#1473] Enable `Applications` and `AuthorizedApplications` controllers in API mode.
-  
-  **[IMPORTANT]** you can still skip these controllers using `skip_controllers` in 
+
+  **[IMPORTANT]** you can still skip these controllers using `skip_controllers` in
     `use_doorkeeper` inside `routes.rb`. Please do it in case you don't need them.
-  
+
 - [#1472] Fix `establish_connection` configuration for custom defined models.
 - [#1471] Add support for Ruby 3.0.
 - [#1469] Check if `redirect_uri` exists.

--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -55,8 +55,7 @@ module Doorkeeper
 
       def headers
         {
-          "Cache-Control" => "no-store",
-          "Pragma" => "no-cache",
+          "Cache-Control" => "no-store, no-cache",
           "Content-Type" => "application/json; charset=utf-8",
           "WWW-Authenticate" => authenticate_info,
         }

--- a/lib/doorkeeper/oauth/token_response.rb
+++ b/lib/doorkeeper/oauth/token_response.rb
@@ -26,8 +26,7 @@ module Doorkeeper
 
       def headers
         {
-          "Cache-Control" => "no-store",
-          "Pragma" => "no-cache",
+          "Cache-Control" => "no-store, no-cache",
           "Content-Type" => "application/json; charset=utf-8",
         }
       end

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Doorkeeper::OAuth::TokenResponse do
 
   it "includes access token response headers" do
     headers = response.headers
-    expect(headers.fetch("Cache-Control")).to eq("no-store")
-    expect(headers.fetch("Pragma")).to eq("no-cache")
+    expect(headers.fetch("Cache-Control")).to eq("no-store, no-cache")
   end
 
   it "status is ok" do

--- a/spec/requests/endpoints/token_spec.rb
+++ b/spec/requests/endpoints/token_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe "Token endpoint" do
   it "respond with correct headers" do
     post token_endpoint_url(code: @authorization.token, client: @client)
 
-    expect(headers["Pragma"]).to eq("no-cache")
-    expect(headers["Cache-Control"]).to be_in(["no-store", "private, no-store"])
+    expect(headers["Cache-Control"]).to be_in(["no-store", "no-cache, no-store", "private, no-store"])
     expect(headers["Content-Type"]).to eq("application/json; charset=utf-8")
   end
 


### PR DESCRIPTION
Pragma is a deprecated HTTP header. It changes from Cache-Control: no-store to Cache-Control: no-store, no-cache to Doorkeeper.

### Summary

Those headers are set by Doorkeeper. We have:

```
Pragma: no-cache
Cache-Control: no-store
```

which are set in https://github.com/doorkeeper-gem/doorkeeper/search?q=no-cache

Pragma is a deprecated HTTP header and Atlassian's suggestion is what is favored now so we should contribute the simple change from `Cache-Control: no-store` to `Cache-Control: no-store, no-cache` to Doorkeeper and pick that up in a gem update.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating CHANGELOG.md file or are asked to update it by reviewers,
please add the changelog entry at the top of the file.

Thanks for contributing to Doorkeeper project!
