### PR TITLE
Block public clients automatic authorization skip

### DIFF
--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -31,7 +31,7 @@ module Doorkeeper
     private
 
     def render_success
-      if skip_authorization? || matching_token?
+      if skip_authorization? || (matching_token? && pre_auth.client.application.confidential?)
         redirect_or_render(authorize_response)
       elsif Doorkeeper.configuration.api_only
         render json: pre_auth

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ end
 Doorkeeper::RSpec.print_configuration_info
 
 require "support/orm/#{DOORKEEPER_ORM}"
+require "support/render_with_matcher"
 
 Dir["#{File.dirname(__FILE__)}/support/{dependencies,helpers,shared}/*.rb"].sort.each { |file| require file }
 

--- a/spec/support/render_with_matcher.rb
+++ b/spec/support/render_with_matcher.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Adds the `render_with` matcher.
+# Ex:
+#   expect(controller).to render_with(template: :show, locals: { alpha: "beta" })
+#
+module RenderWithMatcher
+  def self.included(base)
+    # Setup spying for our "render_with" matcher
+    base.before do
+      allow(controller).to receive(:render).and_wrap_original do |original, *args, **kwargs, &block|
+        original.call(*args, **kwargs, &block)
+      end
+    end
+  end
+
+  RSpec::Matchers.define :render_with do |expected|
+    match do |actual|
+      have_received(:render).with(expected).matches?(actual)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include RenderWithMatcher, type: :controller
+end


### PR DESCRIPTION
Non-confidential applications should not be able to skip the authorization stop, even if they have an existing matching_token.

From the [issue](https://github.com/doorkeeper-gem/doorkeeper/issues/1589):
> According to RFC 8252 section 8.6, the authentication server should re-prompt for user consent, since the client's identity cannot be assured simply from the client_id parameter

Fixes https://github.com/doorkeeper-gem/doorkeeper/issues/1589
