### PR TITLE
Add custom token attributes to Refresh Token Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#ID] Add your PR description here.
+- [#1648] Add custom token attributes to Refresh Token Request
 - [#1644] Update HTTP headers.
 
 # 5.6.5

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -49,7 +49,7 @@ module Doorkeeper
       end
 
       def create_access_token
-        attributes = {}
+        attributes = {}.merge(custom_token_attributes_with_data)
 
         resource_owner =
           if Doorkeeper.config.polymorphic_resource_owner?
@@ -118,6 +118,14 @@ module Doorkeeper
         else
           true
         end
+      end
+
+      def custom_token_attributes_with_data
+        refresh_token
+        .attributes
+        .with_indifferent_access
+        .slice(*Doorkeeper.config.custom_access_token_attributes)
+        .symbolize_keys
       end
     end
   end


### PR DESCRIPTION
### Summary

In #1602 the ability to specify custom token attributes was created. However, that PR only affects access tokens - it doesn't cover refresh tokens, so refresh tokens are created without the custom token attribute(s) that the original access token had.

This PR adds those missing custom token attributes (if specified) to the refresh token request process, copying them over from the original access token.