### PR TITLE
Add custom attributes support to token generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#ID] Add your PR description here.
+- [#1652] Add custom attributes support to token generator
 
 ## 5.6.6
 

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -435,6 +435,10 @@ module Doorkeeper
         if Doorkeeper.config.polymorphic_resource_owner?
           attributes[:resource_owner] = resource_owner
         end
+
+        Doorkeeper.config.custom_access_token_attributes.each do |attribute_name|
+          attributes[attribute_name] = public_send(attribute_name)
+        end
       end
     end
 

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -206,6 +206,23 @@ RSpec.describe Doorkeeper::AccessToken do
       expect(token.token).to eq "custom_generator_token_#{created_at.to_i}"
     end
 
+    it "allows the custom generator to access the custom attributes" do
+      module CustomGeneratorArgs
+        def self.generate(opts = {})
+          "custom_generator_token_#{opts[:tenant_name]}"
+        end
+      end
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        access_token_generator "CustomGeneratorArgs"
+        custom_access_token_attributes [:tenant_name]
+      end
+
+      token = FactoryBot.create :access_token, tenant_name: "Tenant 1"
+      expect(token.token).to eq "custom_generator_token_Tenant 1"
+    end
+
     it "raises an error if the custom object does not support generate" do
       module NoGenerate
       end


### PR DESCRIPTION
### Summary

Adds support to the custom attributes added by the PR https://github.com/doorkeeper-gem/doorkeeper/pull/1602 in the custom access_token_generator. It's now possible to use the custom attributes in the JWT payload for example.

### Other Information

Related PR https://github.com/doorkeeper-gem/doorkeeper/pull/1602
