### PR TITLE
Stop auto-creation of AccessGrant when a matching token is found if custom access token attributes are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ User-visible changes worth mentioning.
 - [#1696] Add missing `#issued_token` method to `OAuth::TokenResponse`
 - [#1697] Allow a TokenResponse body to be customized.
 - [#1702] Fix bugs for error response in the form_post and error view
+- [#1660] Custom access token attributes are now considered when finding matching tokens (fixes #1665).
+  Introduce `revoke_previous_client_credentials_token` configuration option.
 
 ## 5.6.9
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -106,6 +106,13 @@ module Doorkeeper
         @config.instance_variable_set(:@revoke_previous_client_credentials_token, true)
       end
 
+      # Only allow one valid access token obtained via authorization code
+      # per client. If a new access token is obtained before the old one
+      # expired, the old one gets revoked (disabled by default)
+      def revoke_previous_authorization_code_token
+        @config.instance_variable_set(:@revoke_previous_authorization_code_token, true)
+      end
+
       # Use an API mode for applications generated with --api argument
       # It will skip applications controller, disable forgery protection
       def api_only
@@ -479,6 +486,10 @@ module Doorkeeper
 
     def revoke_previous_client_credentials_token?
       option_set? :revoke_previous_client_credentials_token
+    end
+
+    def revoke_previous_authorization_code_token?
+      option_set? :revoke_previous_authorization_code_token
     end
 
     def enforce_configured_scopes?

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -29,6 +29,10 @@ module Doorkeeper
           grant.lock!
           raise Errors::InvalidGrantReuse if grant.revoked?
 
+          if Doorkeeper.config.revoke_previous_authorization_code_token?
+            revoke_previous_tokens(grant.application, resource_owner)
+          end
+
           grant.revoke
 
           find_or_create_access_token(
@@ -108,6 +112,10 @@ module Doorkeeper
           .with_indifferent_access
           .slice(*Doorkeeper.config.custom_access_token_attributes)
           .symbolize_keys
+      end
+
+      def revoke_previous_tokens(application, resource_owner)
+        Doorkeeper.config.access_token_model.revoke_all_for(application.id, resource_owner)
       end
     end
   end

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -8,7 +8,7 @@ module Doorkeeper
           existing_token = nil
 
           if lookup_existing_token?
-            existing_token = find_active_existing_token_for(client, scopes)
+            existing_token = find_active_existing_token_for(client, scopes, attributes)
             return existing_token if Doorkeeper.config.reuse_access_token && existing_token&.reusable?
           end
 
@@ -44,8 +44,11 @@ module Doorkeeper
             Doorkeeper.config.revoke_previous_client_credentials_token?
         end
 
-        def find_active_existing_token_for(client, scopes)
-          Doorkeeper.config.access_token_model.matching_token_for(client, nil, scopes, include_expired: false)
+        def find_active_existing_token_for(client, scopes, attributes)
+          custom_attributes = Doorkeeper.config.access_token_model.
+            extract_custom_attributes(attributes).presence
+          Doorkeeper.config.access_token_model.matching_token_for(
+            client, nil, scopes, custom_attributes: custom_attributes, include_expired: false)
         end
       end
     end

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -31,7 +31,7 @@ module Doorkeeper
         @code_challenge = parameters[:code_challenge]
         @code_challenge_method = parameters[:code_challenge_method]
         @resource_owner = resource_owner
-        @custom_access_token_attributes = parameters.slice(*Doorkeeper.config.custom_access_token_attributes)
+        @custom_access_token_attributes = parameters.slice(*Doorkeeper.config.custom_access_token_attributes).to_h
       end
 
       def authorizable?

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -167,6 +167,12 @@ Doorkeeper.configure do
   #
   # revoke_previous_client_credentials_token
 
+  # Only allow one valid access token obtained via authorization code
+  # per client. If a new access token is obtained before the old one
+  # expired, the old one gets revoked (disabled by default)
+  #
+  # revoke_previous_authorization_code_token
+
   # Hash access and refresh tokens before persisting them.
   # This will disable the possibility to use +reuse_access_token+
   # since plain values can no longer be retrieved.

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -220,4 +220,40 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
       end
     end
   end
+
+  context "when revoke_previous_authorization_code_token is false" do
+    before do
+      allow(Doorkeeper.config).to receive(:revoke_previous_authorization_code_token?).and_return(false)
+    end
+
+    it "does not revoke the previous token" do
+      previous_token = FactoryBot.create(
+        :access_token,
+        application_id: client.id,
+        resource_owner_id: grant.resource_owner_id,
+        resource_owner_type: grant.resource_owner_type,
+        scopes: grant.scopes.to_s,
+      )
+
+      expect { request.authorize }.not_to(change { previous_token.reload.revoked_at })
+    end
+  end
+
+  context "when revoke_previous_authorization_code_token is true" do
+    before do
+      allow(Doorkeeper.config).to receive(:revoke_previous_authorization_code_token?).and_return(true)
+    end
+
+    it "revokes the previous token" do
+      previous_token = FactoryBot.create(
+        :access_token,
+        application_id: client.id,
+        resource_owner_id: grant.resource_owner_id,
+        resource_owner_type: grant.resource_owner_type,
+        scopes: grant.scopes.to_s,
+      )
+
+      expect { request.authorize }.to(change { previous_token.reload.revoked_at })
+    end
+  end
 end


### PR DESCRIPTION
### Summary

There are two changes in this PR, discussed in more detail below:
1. Prevent new access grants being created automatically when a matching token is found if `custom_access_token_attributes` are used.
2. Added another config option `revoke_previous_authorization_code_token` to mirror `revoke_previous_client_credentials_token`.

#### Change 1:
What happens currently is that when you authorize an application, and you already have a valid access token (not expired or revoked) for that application, then a new access grant is created immediately. This happens in `AuthorizationsController#render_success`, which checks for `matching_token?` and then calls `authorize_response`, which creates the new grant. 

This is a problem if `custom_access_token_attributes` are used, since those attributes from the existing token aren't copied into the new grant. In my case, I need to display the custom attributes (tenant ids) from the existing token so I can allow the user to edit them if necessary before the new access grant is created. I did this by loading the custom attributes from the existing token into the `@pre_auth` object, which is the accessible in the view, and can be used as needed.

I also needed the existing token to be revoked once a token is generated from the new access grant, which leads to the next change.

#### Change 2:
We already have a config option `revoke_previous_client_credentials_token`. That's only available for the `client_credentials` grant type though. I need the same behaviour for the `authorization_code` grant type, so I've added another config option for it. 

There is a TODO to make `revoke_previous_client_credentials_token` more generic for the other flows, but I don't really understand the other ones and I just need this grant type, so I opted add a new config option rather than refactor the existing one.