### PR TITLE
Use validates_with rather than validates to validate URI

### DIFF
--- a/lib/doorkeeper/orm/active_record/mixins/application.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/application.rb
@@ -22,7 +22,7 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
 
       validates :name, :secret, :uid, presence: true
       validates :uid, uniqueness: { case_sensitive: true }
-      validates :redirect_uri, "doorkeeper/redirect_uri": true
+      validates_with Doorkeeper::RedirectUriValidator, attributes: [:redirect_uri]
       validates :confidential, inclusion: { in: [true, false] }
 
       validate :scopes_match_configured, if: :enforce_scopes?


### PR DESCRIPTION
### Summary

Today my project upgraded from Doorkeeper 5.3.2 to 5.6.6. In the process, we started encountering errors like the following:
```
ArgumentError: Unknown validator: 'Doorkeeper::RedirectURIValidator'
```

After much investigating, we determined that we have an inflection configured in a Rails initializer for the string `URI`:
```
ActiveSupport::Inflector.inflections(:en) do |inflect|
  inflect.acronym 'URI' # Uniform Resource Identifier
end
```

This causes ActiveModel to attempt to load `Doorkeeper::RedirectURIValidator` rather than the correct `Doorkeeper::RedirectUriValidator`, [here](https://github.com/rails/rails/blob/e88857bbb9d4e1dd64555c34541301870de4a45b/activemodel/lib/active_model/validations/validates.rb#L115-L122). The fix I'm suggesting in this PR is to avoid ActiveModel's attempt to guess the proper constant name, and instead use the constant directly by providing it to `validates_with`, [which is what `validates` does anyways](https://github.com/rails/rails/blob/e88857bbb9d4e1dd64555c34541301870de4a45b/activemodel/lib/active_model/validations/validates.rb#L126). I'm absolutely open to other suggestions on how to make this more resistant to custom inflection configurations.
