### PR TITLE
Provide an option to skip orm hooks

### DIFF
--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -158,6 +158,8 @@ module Doorkeeper
     end
 
     def run_orm_hooks
+      return if config.skip_orm_hooks
+
       config.clear_cache!
 
       if @orm_adapter.respond_to?(:run_hooks)

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -228,6 +228,7 @@ module Doorkeeper
     option :custom_access_token_expires_in, default: ->(_context) { nil }
     option :authorization_code_expires_in,  default: 600
     option :orm,                            default: :active_record
+    option :skip_orm_hooks,                 default: false
     option :native_redirect_uri,            default: "urn:ietf:wg:oauth:2.0:oob", deprecated: true
     option :grant_flows,                    default: %w[authorization_code client_credentials]
     option :handle_auth_errors,             default: :render

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -99,6 +99,29 @@ RSpec.describe Doorkeeper::Application do
     expect(new_application.secret).to eq("custom_application_secret")
   end
 
+  context "when precompiling assets" do
+    let(:precompiling_assets) { true }
+    let(:orm_adapter) { Doorkeeper.orm_adapter }
+
+    context "when skip orm hooks is true" do
+      before do
+        assets_compiling = precompiling_assets
+
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          skip_orm_hooks true if assets_compiling
+        end
+
+        allow(orm_adapter).to receive(:run_hooks)
+        Doorkeeper.run_orm_hooks
+      end
+
+      it "skips running orm hooks" do
+        expect(orm_adapter).not_to have_received(:run_hooks)
+      end
+    end
+  end
+
   context "when application_owner is enabled" do
     context "when application owner is not required" do
       before do


### PR DESCRIPTION
### Summary

Currently trying to dockerize an application that contains doorkeeper and upon running assets precompilation it wants ~~a database connection~~ to evaluate database.yml config. 
This provides a way to skip the orm hooks. 


