### PR TITLE
Honor custom_access_token_attributes in client credentials grant flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-visible changes worth mentioning.
 - [#1662] Specify uri_redirect validation class explicitly.
 - [#1652] Add custom attributes support to token generator.
 - [#1667] Pass `client` instead of `grant.application` to `find_or_create_access_token`.
+- [#1673] Honor `custom_access_token_attributes` in client credentials grant flow.
 
 ## 5.6.6
 

--- a/lib/doorkeeper/oauth/client_credentials/issuer.rb
+++ b/lib/doorkeeper/oauth/client_credentials/issuer.rb
@@ -11,9 +11,9 @@ module Doorkeeper
           @validator = validator
         end
 
-        def create(client, scopes, creator = Creator.new)
+        def create(client, scopes, attributes = {}, creator = Creator.new)
           if validator.valid?
-            @token = create_token(client, scopes, creator)
+            @token = create_token(client, scopes, attributes, creator)
             @error = :server_error unless @token
           else
             @token = false
@@ -25,7 +25,7 @@ module Doorkeeper
 
         private
 
-        def create_token(client, scopes, creator)
+        def create_token(client, scopes, attributes, creator)
           context = Authorization::Token.build_context(
             client,
             Doorkeeper::OAuth::CLIENT_CREDENTIALS,
@@ -39,6 +39,7 @@ module Doorkeeper
             scopes,
             use_refresh_token: false,
             expires_in: ttl,
+            **attributes
           )
         end
       end

--- a/lib/doorkeeper/oauth/client_credentials_request.rb
+++ b/lib/doorkeeper/oauth/client_credentials_request.rb
@@ -3,7 +3,7 @@
 module Doorkeeper
   module OAuth
     class ClientCredentialsRequest < BaseRequest
-      attr_reader :client, :original_scopes, :response
+      attr_reader :client, :original_scopes, :parameters, :response
 
       alias error_response response
 
@@ -14,6 +14,7 @@ module Doorkeeper
         @server = server
         @response = nil
         @original_scopes = parameters[:scope]
+        @parameters = parameters.except(:scope)
       end
 
       def access_token
@@ -30,7 +31,14 @@ module Doorkeeper
       private
 
       def valid?
-        issuer.create(client, scopes)
+        issuer.create(client, scopes, custom_token_attributes_with_data)
+      end
+
+      def custom_token_attributes_with_data
+        parameters
+          .with_indifferent_access
+          .slice(*Doorkeeper.config.custom_access_token_attributes)
+          .symbolize_keys
       end
     end
   end

--- a/spec/lib/oauth/client_credentials/issuer_spec.rb
+++ b/spec/lib/oauth/client_credentials/issuer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
 
     it "creates and sets the token" do
       expect(creator).to receive(:call).and_return("token")
-      issuer.create client, scopes, creator
+      issuer.create client, scopes, {}, creator
 
       expect(issuer.token).to eq("token")
     end
@@ -37,12 +37,24 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
         use_refresh_token: false,
       )
 
-      issuer.create client, scopes, creator
+      issuer.create client, scopes, {}, creator
+    end
+
+    it "creates with custom token parameters" do
+      expect(creator).to receive(:call).with(
+        client,
+        scopes,
+        expires_in: 100,
+        use_refresh_token: false,
+        tenant_id: 9000
+      )
+
+      issuer.create client, scopes, { tenant_id: 9000 }, creator
     end
 
     it "has error set to :server_error if creator fails" do
       expect(creator).to receive(:call).and_return(false)
-      issuer.create client, scopes, creator
+      issuer.create client, scopes, {}, creator
 
       expect(issuer.error).to eq(:server_error)
     end
@@ -55,12 +67,12 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
 
       it "has error set from validator" do
         expect(creator).not_to receive(:create)
-        issuer.create client, scopes, creator
+        issuer.create client, scopes, {}, creator
         expect(issuer.error).to eq(:validation_error)
       end
 
       it "returns false" do
-        expect(issuer.create(client, scopes, creator)).to be_falsey
+        expect(issuer.create(client, scopes, {}, creator)).to be_falsey
       end
     end
 
@@ -93,7 +105,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
           expires_in: custom_ttl_grant,
           use_refresh_token: false,
         )
-        issuer.create client, scopes, creator
+        issuer.create client, scopes, {}, creator
       end
 
       it "respects scope based rules" do
@@ -103,7 +115,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Issuer do
           expires_in: custom_ttl_scope,
           use_refresh_token: false,
         )
-        issuer.create client, custom_scope, creator
+        issuer.create client, custom_scope, {}, creator
       end
     end
   end


### PR DESCRIPTION
### Summary

This change supports the `custom_access_token_attributes` configuration for Client Credentials grant_flow type.

Without this change, the custom configured attributes are not passed along during the token creation for client credentials requests, which leads to an error similar to:

> Mysql2::Error - Field 'tenant_id' doesn't have a default value

If a default of null is provided for the field instead, the result will be the column is not populated with the tenant_id provided during the client credentials request. 

### Other Information

Steps to reproduce:

1. Install doorkeeper following standard instructions for Rails application
2. Configure the initializer with:
    `grant_flows %w[client_credentials]` and
    `custom_access_token_attributes [:tenant_id]`
4. Modify the `oauth_access_tokens` and `oauth_access_grants` tables with the `tenant_id` field as described by the initializer comment for custom_access_token_attributes.
5. Create a Doorkeeper::Application and obtain the client id and client secret.
6. Make a credentials request to obtain a token, i.e.
   ```
   curl -H 'Content-Type: application/json' -XPOST 'http://localhost:3000/oauth/token' \
      -d '{ "client_id": "[client id]", "client_secret": "[client secret]", "grant_type": "client_credentials", "tenant_id": "1" }'
7. Observe the database exception above which happens because the `tenant_id` field is not passed along during token creation.