### PR TITLE
Improve AuthorizationsController error response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ User-visible changes worth mentioning.
 - [#1652] Add custom attributes support to token generator.
 - [#1667] Pass `client` instead of `grant.application` to `find_or_create_access_token`.
 - [#1673] Honor `custom_access_token_attributes` in client credentials grant flow.
+- [#1676] Improve AuthorizationsController error response handling
 
 ## 5.6.6
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -43,14 +43,12 @@ module Doorkeeper
     def render_error
       pre_auth.error.raise_exception! if Doorkeeper.config.raise_on_errors?
 
-      if Doorkeeper.configuration.api_only
+      if Doorkeeper.configuration.redirect_on_error && pre_auth.error_response.redirectable?
+        redirect_or_render(pre_auth.error_response)
+      elsif Doorkeeper.configuration.api_only
         render json: pre_auth.error_response.body, status: pre_auth.error_response.status
       else
-        if pre_auth.error_response.redirectable?
-          redirect_or_render(pre_auth.error_response)
-        else
-          render :error, locals: { error_response: pre_auth.error_response }, status: pre_auth.error_response.status
-        end
+        render :error, locals: { error_response: pre_auth.error_response }, status: pre_auth.error_response.status
       end
     end
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -44,13 +44,12 @@ module Doorkeeper
       pre_auth.error.raise_exception! if Doorkeeper.config.raise_on_errors?
 
       if Doorkeeper.configuration.api_only
-        render json: pre_auth.error_response.body,
-               status: :bad_request
+        render json: pre_auth.error_response.body, status: pre_auth.error_response.status
       else
         if pre_auth.error_response.redirectable?
           redirect_or_render(pre_auth.error_response)
         else
-          render :error, locals: { error_response: pre_auth.error_response }
+          render :error, locals: { error_response: pre_auth.error_response }, status: pre_auth.error_response.status
         end
       end
     end

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -43,7 +43,7 @@ module Doorkeeper
     def render_error
       pre_auth.error_response.raise_exception! if Doorkeeper.config.raise_on_errors?
 
-      if Doorkeeper.configuration.redirect_on_error && pre_auth.error_response.redirectable?
+      if Doorkeeper.configuration.redirect_on_errors? && pre_auth.error_response.redirectable?
         redirect_or_render(pre_auth.error_response)
       elsif Doorkeeper.configuration.api_only
         render json: pre_auth.error_response.body, status: pre_auth.error_response.status

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -41,7 +41,7 @@ module Doorkeeper
     end
 
     def render_error
-      pre_auth.error.raise_exception! if Doorkeeper.config.raise_on_errors?
+      pre_auth.error_response.raise_exception! if Doorkeeper.config.raise_on_errors?
 
       if Doorkeeper.configuration.redirect_on_error && pre_auth.error_response.redirectable?
         redirect_or_render(pre_auth.error_response)

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -41,6 +41,8 @@ module Doorkeeper
     end
 
     def render_error
+      pre_auth.error.raise_exception! if Doorkeeper.config.raise_on_errors?
+
       if Doorkeeper.configuration.api_only
         render json: pre_auth.error_response.body,
                status: :bad_request

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -47,7 +47,11 @@ module Doorkeeper
         render json: pre_auth.error_response.body,
                status: :bad_request
       else
-        render :error, locals: { error_response: pre_auth.error_response }
+        if pre_auth.error_response.redirectable?
+          redirect_or_render(pre_auth.error_response)
+        else
+          render :error, locals: { error_response: pre_auth.error_response }
+        end
       end
     end
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -112,11 +112,6 @@ module Doorkeeper
         @config.instance_variable_set(:@api_only, true)
       end
 
-      # Redirect on error instead of rendering error response
-      def redirect_on_error
-        @config.instance_variable_set(:@redirect_on_error, true)
-      end
-
       # Enables polymorphic Resource Owner association for Access Grant and
       # Access Token models. Requires additional database columns to be setup.
       def use_polymorphic_resource_owner
@@ -459,10 +454,6 @@ module Doorkeeper
       @api_only ||= false
     end
 
-    def redirect_on_error
-      @redirect_on_error ||= false
-    end
-
     def enforce_content_type
       @enforce_content_type ||= false
     end
@@ -508,6 +499,10 @@ module Doorkeeper
 
     def raise_on_errors?
       handle_auth_errors == :raise
+    end
+
+    def redirect_on_errors?
+      handle_auth_errors == :redirect
     end
 
     def application_secret_hashed?

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -112,6 +112,11 @@ module Doorkeeper
         @config.instance_variable_set(:@api_only, true)
       end
 
+      # Redirect on error instead of rendering error response
+      def redirect_on_error
+        @config.instance_variable_set(:@redirect_on_error, true)
+      end
+
       # Enables polymorphic Resource Owner association for Access Grant and
       # Access Token models. Requires additional database columns to be setup.
       def use_polymorphic_resource_owner
@@ -452,6 +457,10 @@ module Doorkeeper
 
     def api_only
       @api_only ||= false
+    end
+
+    def redirect_on_error
+      @redirect_on_error ||= false
     end
 
     def enforce_content_type

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -45,6 +45,7 @@ module Doorkeeper
     TokenGeneratorNotFound = Class.new(DoorkeeperError)
     NoOrmCleaner = Class.new(DoorkeeperError)
 
+    InvalidRequest = Class.new(BaseResponseError)
     InvalidToken = Class.new(BaseResponseError)
     TokenExpired = Class.new(InvalidToken)
     TokenRevoked = Class.new(InvalidToken)

--- a/lib/doorkeeper/oauth/invalid_request_response.rb
+++ b/lib/doorkeeper/oauth/invalid_request_response.rb
@@ -35,6 +35,10 @@ module Doorkeeper
         )
       end
 
+      def exception_class
+        Doorkeeper::Errors::InvalidRequest
+      end
+
       def redirectable?
         super && @missing_param != :client_id
       end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -312,16 +312,12 @@ Doorkeeper.configure do
   #   Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
   #
   # handle_auth_errors :raise
-
-  # If an exception occurs during the authorization request, Doorkeeper will, by
-  # default, render an HTML error response with the exception message and HTTP
-  # status code. If you want to redirect back to the client application in accordance
-  # with https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1, you can
-  # enable this option.
   #
-  # This will have no effect if handle_auth_errors is set to :raise.
+  # If you want to redirect back to the client application in accordance with
+  # https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1, you can set
+  # +handle_auth_errors+ to :redirect
   #
-  # redirect_on_error
+  # handle_auth_errors :redirect
 
   # Customize token introspection response.
   # Allows to add your own fields to default one that are required by the OAuth spec

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -313,6 +313,16 @@ Doorkeeper.configure do
   #
   # handle_auth_errors :raise
 
+  # If an exception occurs during the authorization request, Doorkeeper will, by
+  # default, render an HTML error response with the exception message and HTTP
+  # status code. If you want to redirect back to the client application in accordance
+  # with https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1, you can
+  # enable this option.
+  #
+  # This will have no effect if handle_auth_errors is set to :raise.
+  #
+  # redirect_on_error
+
   # Customize token introspection response.
   # Allows to add your own fields to default one that are required by the OAuth spec
   # for the introspection response. It could be `sub`, `aud` and so on.

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -985,7 +985,7 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
       end
 
       it "renders bad request" do
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:unauthorized)
       end
 
       it "includes error in body" do

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -1044,6 +1044,124 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
     end
   end
 
+  describe "GET #new with errors with redirect_on_error" do
+    before { config_is_set(:redirect_on_error, true) }
+
+    context "without valid params" do
+      before do
+        default_scopes_exist :public
+        get :new, params: { an_invalid: "request" }
+      end
+
+      it "does not redirect" do
+        expect(response).not_to be_redirect
+      end
+
+      it "does not issue any token" do
+        expect(Doorkeeper::AccessGrant.count).to eq 0
+        expect(Doorkeeper::AccessToken.count).to eq 0
+      end
+    end
+
+    context "invalid scope" do
+      before do
+        default_scopes_exist :public
+        get :new, params: {
+          client_id: client.uid,
+          response_type: "token",
+          scope: "invalid",
+          redirect_uri: client.redirect_uri,
+        }
+      end
+
+      it "redirects to client redirect uri" do
+        expect(response).to be_redirect
+        expect(response.location).to match(/^#{client.redirect_uri}/)
+      end
+
+      it "includes error in fragment" do
+        expect(response.query_params["error"]).to eq("invalid_scope")
+      end
+
+      it "includes error description in fragment" do
+        expect(response.query_params["error_description"]).to eq(translated_error_message(:invalid_scope))
+      end
+
+      it "does not issue any token" do
+        expect(Doorkeeper::AccessGrant.count).to eq 0
+        expect(Doorkeeper::AccessToken.count).to eq 0
+      end
+    end
+
+    context "invalid redirect_uri" do
+      before do
+        default_scopes_exist :public
+        get :new, params: {
+          client_id: client.uid,
+          response_type: "token",
+          redirect_uri: "invalid",
+        }
+      end
+
+      it "does not redirect" do
+        expect(response).not_to be_redirect
+      end
+
+      it "does not issue any token" do
+        expect(Doorkeeper::AccessGrant.count).to eq 0
+        expect(Doorkeeper::AccessToken.count).to eq 0
+      end
+    end
+
+    context "with client_id and redirect_uri" do
+      before do
+        default_scopes_exist :public
+        get :new, params: {
+          client_id: client.uid,
+          redirect_uri: client.redirect_uri,
+          response_mode: "fragment"
+        }
+      end
+
+      it "redirects to client redirect uri" do
+        expect(response).to be_redirect
+        expect(response.location).to match(/^#{client.redirect_uri}/)
+      end
+
+      it "includes error in fragment" do
+        expect(response.query_params["error"]).to eq("invalid_request")
+      end
+
+      it "includes error description in fragment" do
+        expect(response.query_params["error_description"]).to eq(translated_invalid_request_error_message(:missing_param, :response_type))
+      end
+
+      it "does not issue any token" do
+        expect(Doorkeeper::AccessGrant.count).to eq 0
+        expect(Doorkeeper::AccessToken.count).to eq 0
+      end
+    end
+  end
+
+  describe "GET #new with errors with handle_auth_errors :raise" do
+    before { config_is_set(:handle_auth_errors, :raise) }
+
+    context "without valid params" do
+      before do
+        default_scopes_exist :public
+      end
+
+      it "does not redirect" do
+        expect { get :new, params: { an_invalid: "request" } }.to raise_error(Doorkeeper::Errors::InvalidRequest)
+      end
+
+      it "does not issue any token" do
+        expect(Doorkeeper::AccessGrant.count).to eq 0
+        expect(Doorkeeper::AccessToken.count).to eq 0
+      end
+    end
+  end
+
   describe "GET #new with callbacks" do
     after do
       client.update_attribute :redirect_uri, "urn:ietf:wg:oauth:2.0:oob"

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -1071,6 +1071,7 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
           response_type: "token",
           scope: "invalid",
           redirect_uri: client.redirect_uri,
+          state: "return-this",
         }
       end
 
@@ -1085,6 +1086,11 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
 
       it "includes error description in fragment" do
         expect(response.query_params["error_description"]).to eq(translated_error_message(:invalid_scope))
+      end
+
+      it "includes state in fragment" do
+        pry
+        expect(response.query_params["state"]).to eq("return-this")
       end
 
       it "does not issue any token" do

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -1044,8 +1044,8 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
     end
   end
 
-  describe "GET #new with errors with redirect_on_error" do
-    before { config_is_set(:redirect_on_error, true) }
+  describe "GET #new with errors with handle_auth_errors :redirect" do
+    before { config_is_set(:handle_auth_errors, :redirect) }
 
     context "without valid params" do
       before do
@@ -1089,7 +1089,6 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
       end
 
       it "includes state in fragment" do
-        pry
         expect(response.query_params["state"]).to eq("return-this")
       end
 

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -984,7 +984,7 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
         }
       end
 
-      it "renders bad request" do
+      it "renders unauthorized" do
         expect(response).to have_http_status(:unauthorized)
       end
 

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -441,7 +441,7 @@ feature "Authorization Code Flow" do
     scenario "scope is invalid because default scope is different from application scope" do
       default_scopes_exist :admin
       visit authorization_endpoint_url(client: @client)
-      response_status_should_be 200
+      response_status_should_be 400
       i_should_not_see "Authorize"
       i_should_see_translated_error_message :invalid_scope
     end

--- a/spec/requests/flows/implicit_grant_spec.rb
+++ b/spec/requests/flows/implicit_grant_spec.rb
@@ -29,7 +29,7 @@ feature "Implicit Grant Flow (feature spec)" do
     scenario "scope is invalid because default scope is different from application scope" do
       default_scopes_exist :admin
       visit authorization_endpoint_url(client: @client, response_type: "token")
-      response_status_should_be 200
+      response_status_should_be 400
       i_should_not_see "Authorize"
       i_should_see_translated_error_message :invalid_scope
     end


### PR DESCRIPTION
### Summary
Hey, first time contributing, hope this is welcome

This PR has three changes to `AuthorizationsController`'s error response, explained in more detail below:
- Returns the proper status code instead of `200`
- Redirects back to the client with error (if `redirectable?`)
- Honors the `raise_on_errors?` setting

-----

I noticed that Doorkeeper returns a `200` response code when an error occurs, and also does not redirect back to the client on errors as my understanding of the spec indicates it should:

https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1

**Non-redirecting**
> If the request fails due to a missing, invalid, or mismatching
   redirection URI, or if the client identifier is missing or invalid,
   the authorization server SHOULD inform the resource owner of the
   error and MUST NOT automatically redirect the user-agent to the
   invalid redirection URI.

**Redirecting**
> If the resource owner denies the access request or if the request
   fails for reasons other than a missing or invalid redirection URI,
   the authorization server informs the client by adding the following
   parameters to the query component of the redirection URI using the
   "application/x-www-form-urlencoded" format

There is already the concept of `redirectable?` in Doorkeeper which adheres to this, but it seems like this isn't actually used for errors in `authorizations_controller`.

The status code change is applied normally, but I feel like the redirection bit is probably a breaking change since it adds redirects where there wasn't any before, so I added it as a config option via `handle_auth_errors :redirect`

Fixes #1643 