### PR TITLE
Fix URIHelper.valid_for_authorization? breaking for non url URIs

### DIFF
--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -40,7 +40,7 @@ module Doorkeeper
 
         def self.loopback_uri?(uri)
           IPAddr.new(uri.host).loopback?
-        rescue IPAddr::Error
+        rescue IPAddr::Error, IPAddr::InvalidAddressError
           false
         end
 

--- a/spec/lib/oauth/helpers/uri_checker_spec.rb
+++ b/spec/lib/oauth/helpers/uri_checker_spec.rb
@@ -257,4 +257,18 @@ describe Doorkeeper::OAuth::Helpers::URIChecker do
       expect(described_class).not_to be_query_matches("foo=bar&bing=bang", "foo=bar&bing=banana")
     end
   end
+
+  describe ".loopback_uri?" do
+    it "is true if loopback IP" do
+      expect(described_class).to be_loopback_uri(URI.parse("http://127.0.0.1"))
+    end
+
+    it 'is false if not loopback IP' do
+      expect(described_class).not_to be_loopback_uri(URI.parse("http://example.com"))
+    end
+
+    it 'is false for non URL' do
+      expect(described_class).not_to be_loopback_uri(URI.parse("vscode://file/home/user/.vimrc"))
+    end
+  end
 end


### PR DESCRIPTION
Adds an additional except clause for validating `.loopback_uri?` since it was failing for non URL uris i.e. "vscode://file/home/user/.vimrc"

Also added tests
