### PR TITLE
Add missing method to token response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
-- [#PR ID] Add your changelog here.
+- [#1696] Add missing `#issued_token` method to `OAuth::TokenResponse`
 
 ## 5.6.9
 

--- a/lib/doorkeeper/oauth/token_response.rb
+++ b/lib/doorkeeper/oauth/token_response.rb
@@ -5,6 +5,8 @@ module Doorkeeper
     class TokenResponse
       attr_reader :token
 
+      alias issued_token token
+
       def initialize(token)
         @token = token
       end


### PR DESCRIPTION
### Summary

`Doorkeeper::OAuth::TokenResponse` should respond to `:issued_token`, as `Doorkeeper::OAuth::CodeResponse` does.

From the initializer: 
https://github.com/doorkeeper-gem/doorkeeper/blob/960f1501131683b16c2704d1b6f9597b9583b49d/lib/generators/doorkeeper/templates/initializer.rb#L443-L451

So if you implement some code in the `after_successful_authorization` hook, you should be able to use `#issued_token` regardless of the grant flow used. If you add the suggested logging code from the doc, an exception will be raised if you use client_credential grant flow.
