### PR TITLE
Allow a TokenResponse body to be customized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#PR ID] Allow a TokenResponse body to be customized.
 - [#1696] Add missing `#issued_token` method to `OAuth::TokenResponse`
 
 ## 5.6.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ User-visible changes worth mentioning.
 
 ## main
 
-- [#PR ID] Allow a TokenResponse body to be customized.
 - [#1696] Add missing `#issued_token` method to `OAuth::TokenResponse`
+- [#1697] Allow a TokenResponse body to be customized.
 
 ## 5.6.9
 

--- a/lib/doorkeeper/oauth/token_response.rb
+++ b/lib/doorkeeper/oauth/token_response.rb
@@ -12,7 +12,7 @@ module Doorkeeper
       end
 
       def body
-        {
+        @body ||= {
           "access_token" => token.plaintext_token,
           "token_type" => token.token_type,
           "expires_in" => token.expires_in_seconds,

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -55,6 +55,28 @@ RSpec.describe Doorkeeper::OAuth::TokenResponse do
     end
   end
 
+  describe ".body attributes" do
+    subject(:token_response) { described_class.new(access_token) }
+
+    let(:access_token) do
+      double :access_token,
+             plaintext_token: "some-token",
+             expires_in: "3600",
+             expires_in_seconds: "300",
+             scopes_string: "two scopes",
+             plaintext_refresh_token: "some-refresh-token",
+             token_type: "Bearer",
+             custom_parameter: "custom_value",
+             created_at: 0
+    end
+
+    it "can be augmented" do
+      token_response.body["custom_parameter"] = access_token.custom_parameter
+
+      expect(token_response.body["custom_parameter"]).to eq("custom_value")
+    end
+  end
+
   describe ".body filters out empty values" do
     subject(:body) { described_class.new(access_token).body }
 


### PR DESCRIPTION
We have a use case where we need to include some additional information in the token response body to help the client applications with our multi-tenant setup.

Adding the memoization allows us to modify the body object during the after_successful_authorization callback:

```ruby
  after_successful_authorization do |controller, context|
    case context.auth
    when Doorkeeper::OAuth::TokenResponse
      context.auth.body["tenant_id"] = context.auth.token.tenant_id
    end
  end
```

(Assuming that `tenant_id` was added to `custom_access_token_attributes`.)

I considered adding attributes via `custom_access_token_attributes` in `#body` directly, but that would change the existing behavior of the `TokenResponse` everywhere.