### PR TITLE
Fix bugs for error response in the form_post and error view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#1696] Add missing `#issued_token` method to `OAuth::TokenResponse`
 - [#1697] Allow a TokenResponse body to be customized.
+- [#1702] Fix bugs for error response in the form_post and error view
 
 ## 5.6.9
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -77,7 +77,7 @@ module Doorkeeper
             )
           end
         elsif pre_auth.form_post_response?
-          render :form_post
+          render :form_post, locals: { auth: auth }
         else
           redirect_to auth.redirect_uri, allow_other_host: true
         end

--- a/app/views/doorkeeper/authorizations/error.html.erb
+++ b/app/views/doorkeeper/authorizations/error.html.erb
@@ -4,6 +4,6 @@
 
 <main role="main">
   <pre>
-    <%= (respond_to?(:error_response) ? error_response : @pre_auth.error_response).body[:error_description] %>
+    <%= (local_assigns[:error_response] ? error_response : @pre_auth.error_response).body[:error_description] %>
   </pre>
 </main>

--- a/app/views/doorkeeper/authorizations/form_post.html.erb
+++ b/app/views/doorkeeper/authorizations/form_post.html.erb
@@ -3,7 +3,7 @@
 </header>
 
 <%= form_tag @pre_auth.redirect_uri, method: :post, name: :redirect_form, authenticity_token: false do %>
-  <% @authorize_response&.body&.compact&.each do |key, value| %>
+  <% auth.body.compact.each do |key, value| %>
     <%= hidden_field_tag key, value %>
   <% end %>
 <% end %>


### PR DESCRIPTION
**Bug**
When the `form_post.html.erb` view attempts to render an error, it 
incorrectly posts an empty form rather than displaying the appropriate 
error and error_description.

**Root cause**
The form_post view used the body of `@authorize_response`. This 
issue arose when the `redirect_or_render` method was invoked with 
either `authorization.deny` or `pre_auth.error_response`, resulting in 
`@authorize_response` containing only an empty body, failing to 
display the error details as intended.

**Fix**
Instead of using `@authorize_response`, we now introduce a local 
variable `auth`, which represents the authorization object passed to 
the `redirect_or_render` function. This ensures that the correct error 
information is provided to the view. Additionally, I have backfilled 
tests in the authorizations controller spec to verify the fix.

**Additional Findings During Testing**
During the test phase, I discovered `error.html.erb` always renders an
incorrect error description. It turns out that 
`respond_to(:error_response)` always return false in the view. I changed 
it to use `local_assigns` as the correct condition.