### PR TITLE
Do not instantiate ActiveRecord model early

### DIFF
--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -33,12 +33,14 @@ module Doorkeeper
       end
 
       def self.initialize_configured_associations
-        if Doorkeeper.config.enable_application_owner?
-          Doorkeeper.config.application_model.include ::Doorkeeper::Models::Ownership
-        end
+        ActiveSupport.on_load(:active_record) do
+          if Doorkeeper.config.enable_application_owner?
+            Doorkeeper.config.application_model.include ::Doorkeeper::Models::Ownership
+          end
 
-        Doorkeeper.config.access_grant_model.include ::Doorkeeper::Models::PolymorphicResourceOwner::ForAccessGrant
-        Doorkeeper.config.access_token_model.include ::Doorkeeper::Models::PolymorphicResourceOwner::ForAccessToken
+          Doorkeeper.config.access_grant_model.include ::Doorkeeper::Models::PolymorphicResourceOwner::ForAccessGrant
+          Doorkeeper.config.access_token_model.include ::Doorkeeper::Models::PolymorphicResourceOwner::ForAccessToken
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary 
Do not instantiate active record models before loading active record, as it can cause several side effects.

Fixes #1703