### PR TITLE
Add Pragma: no-cache to token response

### DIFF
--- a/lib/doorkeeper/oauth/token_response.rb
+++ b/lib/doorkeeper/oauth/token_response.rb
@@ -30,6 +30,7 @@ module Doorkeeper
         {
           "Cache-Control" => "no-store, no-cache",
           "Content-Type" => "application/json; charset=utf-8",
+          "Pragma" => "no-cache",
         }
       end
     end

--- a/spec/lib/oauth/token_response_spec.rb
+++ b/spec/lib/oauth/token_response_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Doorkeeper::OAuth::TokenResponse do
   it "includes access token response headers" do
     headers = response.headers
     expect(headers.fetch("Cache-Control")).to eq("no-store, no-cache")
+    expect(headers.fetch("Pragma")).to eq("no-cache")
   end
 
   it "status is ok" do

--- a/spec/requests/endpoints/token_spec.rb
+++ b/spec/requests/endpoints/token_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Token endpoint" do
 
     expect(headers["Cache-Control"]).to be_in(["no-store", "no-cache, no-store", "private, no-store"])
     expect(headers["Content-Type"]).to eq("application/json; charset=utf-8")
+    expect(headers["Pragma"]).to eq("no-cache")
   end
 
   it "accepts client credentials with basic auth header" do


### PR DESCRIPTION
### Summary

According to the [spec](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1) we should be returning a `Pragma` header in the token response.

> The authorization server MUST include the HTTP "Cache-Control"
>   response header field [[RFC2616](https://datatracker.ietf.org/doc/html/rfc2616)] with a value of "no-store" in any
>   response containing tokens, credentials, or other sensitive
>   information, as well as the "Pragma" response header field [[RFC2616](https://datatracker.ietf.org/doc/html/rfc2616)]
>   with a value of "no-cache".

When I was doing a review of our implementation I found that the `Pragma` header is missing so adding it to be compliant.