### PR TITLE
Fix Doorkeeper::AccessToken.find_or_create_for with empty scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ User-visible changes worth mentioning.
 
 Add your entry here.
 
+- [#1714] Fix `Doorkeeper::AccessToken.find_or_create_for` with empty scopes which raises NoMethodError 
+
 ## 5.7.1
 
 - [#1705] Add `force_pkce` option that requires non-confidential clients to use PKCE when requesting an access_token using an authorization code

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -214,6 +214,8 @@ module Doorkeeper
       # @return [Doorkeeper::AccessToken] existing record or a new one
       #
       def find_or_create_for(application:, resource_owner:, scopes:, **token_attributes)
+        scopes = Doorkeeper::OAuth::Scopes.from_string(scopes) if scopes.is_a?(String)
+
         if Doorkeeper.config.reuse_access_token
           custom_attributes = extract_custom_attributes(token_attributes).presence
           access_token = matching_token_for(


### PR DESCRIPTION
Fixes #1699
 