### PR TITLE
Fix token introspection invalid request reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 Add your entry here.
 
+- [#1715] Fix token introspection invalid request reason
 - [#1714] Fix `Doorkeeper::AccessToken.find_or_create_for` with empty scopes which raises NoMethodError
 - [#1712] Add `Pragma: no-cache` to token response
 

--- a/lib/doorkeeper/oauth/token_introspection.rb
+++ b/lib/doorkeeper/oauth/token_introspection.rb
@@ -6,7 +6,7 @@ module Doorkeeper
     #
     # @see https://datatracker.ietf.org/doc/html/rfc7662
     class TokenIntrospection
-      attr_reader :error
+      attr_reader :error, :invalid_request_reason
 
       def initialize(server, token)
         @server = server
@@ -38,7 +38,6 @@ module Doorkeeper
       private
 
       attr_reader :server, :token
-      attr_reader :invalid_request_reason
 
       # If the protected resource uses OAuth 2.0 client credentials to
       # authenticate to the introspection endpoint and its credentials are

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -536,7 +536,7 @@ RSpec.describe Doorkeeper::TokensController, type: :controller do
 
         expect(json_response).to match(
           "error" => "invalid_request",
-          "error_description" => an_instance_of(String),
+          "error_description" => I18n.t("doorkeeper.errors.messages.invalid_request.request_not_authorized"),
         )
       end
     end


### PR DESCRIPTION
### Summary

I was validating the client authentication in the token introspection endpoint and got a "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed." error which was kind of confusing and so I took a look at the code and this appears to be not intentional.  The `invalid_request_reason` is a private method so when the `try(:invalid_request_reason)` runs it returns `nil` and so it falls back to the default.  I went with a quick fix but making the `attr_reader` public so that the error_description is set properly.