### PR TITLE
Fix outdated ruby version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,19 @@
 FROM ruby:3.3.4-alpine
 
+# Linux UID (user id) for the doorkeeper user, change with [--build-arg UID=1234]
+ARG UID="991"
+# Linux GID (group id) for the doorkeeper user, change with [--build-arg GID=1234]
+ARG GID="991"
+# Timezone used by the Docker container and runtime, change with [--build-arg TZ=Europe/Berlin]
+ARG TZ="Etc/UTC"
+
+# Apply timezone
+ENV TZ=${TZ}
+
+RUN addgroup -g "${GID}" doorkeeper; \
+  adduser -u "${UID}" -G "doorkeeper" -h /srv doorkeeper; \
+  echo "${TZ}" > /etc/localtime;
+
 RUN apk add --no-cache \
   ca-certificates \
   wget \
@@ -25,5 +39,10 @@ COPY lib/doorkeeper/version.rb /srv/lib/doorkeeper/version.rb
 RUN bundle install
 
 COPY . /srv/
+
+RUN chown -R doorkeeper:doorkeeper /srv/coverage
+
+# Set the running user for resulting container
+USER doorkeeper
 
 CMD ["rake"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5-alpine
+FROM ruby:3.3.4-alpine
 
 RUN apk add --no-cache \
   ca-certificates \
@@ -14,7 +14,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-ENV BUNDLER_VERSION 2.1.4
+ENV BUNDLER_VERSION 2.5.11
 RUN gem install bundler -v ${BUNDLER_VERSION} -i /usr/local/lib/ruby/gems/$(ls /usr/local/lib/ruby/gems) --force
 
 WORKDIR /srv

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ RUN apk add --no-cache \
   sqlite-dev \
   tzdata
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
-ENV BUNDLER_VERSION 2.5.11
+ENV BUNDLER_VERSION=2.5.11
 RUN gem install bundler -v ${BUNDLER_VERSION} -i /usr/local/lib/ruby/gems/$(ls /usr/local/lib/ruby/gems) --force
 
 WORKDIR /srv


### PR DESCRIPTION
### Summary

This is the Dockerfile changes I needed in #1721 to get the Dockerfile to build on the latest Docker for Mac (and likely other docker versions)

It seems the Dockerfile is still using ruby 2.6, when the project dropped 2.6 support 19 months ago in https://github.com/doorkeeper-gem/doorkeeper/pull/1622

I've gone straight ahead to Ruby 3.3.4 (latest stable), despite Doorkeeper not yet officially supporting Ruby 3.3 (I'll open a separate PR to add that to the testing matrix).