### PR TITLE
Add Ruby 3.3 to GitHub Actions testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ubuntu-latest]
         ruby:
-          - '3.0'
-          - '3.1'
-          - '3.2'
+          - "3.0"
+          - "3.1"
+          - "3.2"
+          - "3.3"
         gemfile:
           - gemfiles/rails_6_0.gemfile
           - gemfiles/rails_6_1.gemfile
@@ -53,7 +54,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: "3.3"
           bundler-cache: true
       - run: bundle exec rake spec || echo "Rails edge test is done."
 
@@ -73,6 +74,6 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 'ruby-head'
+          ruby-version: "ruby-head"
           bundler-cache: true
       - run: bundle exec rake spec || echo "Ruby edge test is done."


### PR DESCRIPTION
### Summary

Ruby 3.3.4 is the current latest stable version of Ruby, however, we are currently not testing it in GitHub Actions (we were only going up to ruby 3.2)

This adds support for 3.3 to the testing matrix.

I do note that according to the Gemspec, we support `>= 2.7`, so we should probably also include Ruby 2.7 in the testing matrix at least.