### PR TITLE
Refactor token introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Add your entry here.
 - [#1715] Fix token introspection invalid request reason
 - [#1714] Fix `Doorkeeper::AccessToken.find_or_create_for` with empty scopes which raises NoMethodError
 - [#1712] Add `Pragma: no-cache` to token response
+- [#1726] Refactor token introspection class.
 
 ## 5.7.1
 

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -418,7 +418,7 @@ module Doorkeeper
            default: (lambda do |token, authorized_client, authorized_token|
              if authorized_token
                authorized_token.application == token&.application
-             elsif token.application
+             elsif token&.application
                authorized_client == token.application
              else
                true

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe Doorkeeper::TokensController, type: :controller do
         end
       end
 
-      it "responds with invalid_token error" do
+      it "responds with invalid_token error for bearer auth" do
         request.headers["Authorization"] = "Bearer #{access_token.token}"
 
         post :introspect, params: { token: token_for_introspection.token }
@@ -281,6 +281,16 @@ RSpec.describe Doorkeeper::TokensController, type: :controller do
 
         expect(json_response).not_to include("active")
         expect(json_response).to include("error" => "invalid_token")
+      end
+
+      it "responds with access_denied error for basic auth" do
+        request.headers["Authorization"] = basic_auth_header_for_client(client)
+
+        post :introspect, params: { token: token_for_introspection.token }
+
+        response_status_should_be 200
+
+        expect(json_response).to include("active" => false)
       end
     end
 


### PR DESCRIPTION
RFC:

> If the protected resource uses an OAuth 2.0 bearer token to authorize
   its call to the introspection endpoint and the token used for
   authorization does not contain sufficient privileges or is otherwise
   invalid for this request, the authorization server responds with an
   HTTP 401 code as described in [Section 3](https://datatracker.ietf.org/doc/html/rfc7662#section-3) of OAuth 2.0 Bearer Token
   Usage [[RFC6750](https://datatracker.ietf.org/doc/html/rfc6750)].

>  Note that a properly formed and authorized query for an inactive or
   otherwise invalid token (or a token the protected resource is not
   allowed to know about) is not considered an error response by this
   specification.  In these cases, the authorization server MUST instead
   respond with an introspection response with the "active" field set to
   "false" as described in [Section 2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2).

Fixes #1716
