### PR TITLE
Add pkce_code_challenge_methods option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,21 +28,23 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
-ENV BUNDLER_VERSION=2.5.11
-RUN gem install bundler -v ${BUNDLER_VERSION} -i /usr/local/lib/ruby/gems/$(ls /usr/local/lib/ruby/gems) --force
-
 WORKDIR /srv
-
-COPY Gemfile doorkeeper.gemspec /srv/
-COPY lib/doorkeeper/version.rb /srv/lib/doorkeeper/version.rb
-
-RUN bundle install
 
 COPY . /srv/
 
-RUN chown -R doorkeeper:doorkeeper /srv/coverage
+RUN chown -R doorkeeper:doorkeeper /srv
 
 # Set the running user for resulting container
 USER doorkeeper
 
-CMD ["rake"]
+RUN mkdir -p /srv/.local/gem/share
+ENV GEM_HOME=/srv/.local/gem/share
+
+ENV BUNDLER_VERSION=2.5.11
+RUN gem install bundler -v ${BUNDLER_VERSION}
+
+# This is a fix for sqlite alpine issues
+RUN bundle config force_ruby_platform true
+RUN bundle install
+
+CMD ["bundle", "exec", "rake"]

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "rubocop-rspec", require: false
 gem "bcrypt", "~> 3.1", require: false
 
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
-gem "sqlite3", "~> 2.0", platform: %i[ruby mswin mingw x64_mingw]
+gem "sqlite3", "~> 1.7", platform: %i[ruby mswin mingw x64_mingw]
 
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw]
 gem "timecop"

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -243,6 +243,7 @@ module Doorkeeper
     option :orm,                            default: :active_record
     option :native_redirect_uri,            default: "urn:ietf:wg:oauth:2.0:oob", deprecated: true
     option :grant_flows,                    default: %w[authorization_code client_credentials]
+    option :pkce_code_challenge_methods,    default: %w[plain S256]
     option :handle_auth_errors,             default: :render
     option :token_lookup_batch_size,        default: 10_000
     # Sets the token_reuse_limit
@@ -552,6 +553,12 @@ module Doorkeeper
 
     def scopes_by_grant_type
       @scopes_by_grant_type ||= {}
+    end
+
+    def pkce_code_challenge_methods_supported
+      return [] unless access_grant_model.pkce_supported?
+      
+      pkce_code_challenge_methods
     end
 
     def client_credentials_methods

--- a/lib/doorkeeper/config/validations.rb
+++ b/lib/doorkeeper/config/validations.rb
@@ -11,6 +11,7 @@ module Doorkeeper
         validate_reuse_access_token_value
         validate_token_reuse_limit
         validate_secret_strategies
+        validate_pkce_code_challenge_methods
       end
 
       private
@@ -47,6 +48,17 @@ module Doorkeeper
           "It will be set to default 100",
         )
         @token_reuse_limit = 100
+      end
+
+      def validate_pkce_code_challenge_methods
+        return if pkce_code_challenge_methods.all? {|method| method =~ /^plain$|^S256$/ }
+
+        ::Rails.logger.warn(
+          "[DOORKEEPER] You have configured an invalid value for pkce_code_challenge_methods option. " \
+          "It will be set to default ['plain', 'S256']",
+        )
+
+        @pkce_code_challenge_methods = ['plain', 'S256']
       end
     end
   end

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -154,7 +154,7 @@ module Doorkeeper
         return true unless Doorkeeper.config.access_grant_model.pkce_supported?
 
         code_challenge.blank? ||
-          (code_challenge_method.present? && code_challenge_method =~ /^plain$|^S256$/)
+          (code_challenge_method.present? && Doorkeeper.config.pkce_code_challenge_methods_supported.include?(code_challenge_method))
       end
 
       def response_on_fragment?

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -231,6 +231,28 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
 
         expect(request.error).to eq(Doorkeeper::Errors::InvalidGrant)
       end
+
+      context "when PKCE code challenge methods is set to only S256" do
+        before do
+          Doorkeeper.configure do
+            pkce_code_challenge_methods ["S256"]
+          end
+        end
+
+        it "validates when code_verifier is S256" do
+          params[:code_verifier] = grant.code_challenge = "S256"
+          request.validate
+
+          expect(request.error).to eq(nil)
+        end
+
+        it "invalidates when code_verifier is plain" do
+          params[:code_verifier] = "plain"
+          request.validate
+
+          expect(request.error).to eq(Doorkeeper::Errors::InvalidGrant)
+        end
+      end
     end
 
     context "when PKCE is not supported" do

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -330,6 +330,28 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
 
         expect(pre_auth).not_to be_authorizable
       end
+
+      context "when pkce_code_challenge_methods is set to only S256" do
+        before do
+          Doorkeeper.configure do
+            pkce_code_challenge_methods ["S256"]
+          end
+        end
+
+        it "accepts S256 as a code_challenge_method" do
+          attributes[:code_challenge] = "a45a9fea-0676-477e-95b1-a40f72ac3cfb"
+          attributes[:code_challenge_method] = "S256"
+
+          expect(pre_auth).to be_authorizable
+        end
+
+        it "rejects plain as a code_challenge_method" do
+          attributes[:code_challenge] = "a45a9fea-0676-477e-95b1-a40f72ac3cfb"
+          attributes[:code_challenge_method] = "plain"
+
+          expect(pre_auth).to_not be_authorizable
+        end
+      end
     end
 
     context "when PKCE is not supported" do


### PR DESCRIPTION
### Summary

This fixes #1717, allowing a user to prevent using the `plain` method for PKCE code challenges, since using `plain` is deemed insecure (as noted in the PKCE RFC)

This is based off of #1732, I also have some local changes that pull in irb and debug gems for interactive debugging, which I found helpful when testing in the console via:

```sh
$ docker run -it --rm doorkeeper:test /srv/bin/console
```

### Other Information

In `validate_pkce_code_challenge_methods` I did want to log an error if the database hadn't been configured for PKCE, however, due to how this code is instantiated, I wasn't able to get that working due to the model class not yet being loaded by `bin/console` (so I'm assuming issues may happen in actual usage too).

The [error message does list](https://github.com/doorkeeper-gem/doorkeeper/blob/de0fb1fc0cbe8b9ac2a3ba49c21a0730ea21dd0b/config/locales/en.yml#L103) the supported methods always as `plain or S256` — to fix that, we'd need to parameterize the localisation message to receive the supported code challenge methods. I wasn't sure if I should make such a change here.

This also limits us to only ever supporting plain or S256, but to [my knowledge no other PKCE code challenge methods exist](https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#pkce-code-challenge-method), and doorkeeper wouldn't have support for them anyway due to how it [hardcodes which ones it supports](https://github.com/doorkeeper-gem/doorkeeper/blob/5bf9d406dd710209cb2bc0600a20aa52178ff32b/lib/doorkeeper/oauth/authorization_code_request.rb#L98).
