### PR TITLE
Improve developer experience

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,3 +27,8 @@ gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw]
 gem "timecop"
+
+gem 'irb', '~> 1.8'
+
+# Interactive Debugging tools
+gem 'debug', '~> 1.8'

--- a/bin/console
+++ b/bin/console
@@ -4,14 +4,9 @@
 require "bundler/setup"
 require "rails/all"
 require "active_support/all"
+require "irb"
+require "debug"
 require "doorkeeper"
-
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
 
 Rails.logger = Logger.new(STDOUT)
 
@@ -32,5 +27,4 @@ ActiveRecord::Base.establish_connection(
 # Load database schema
 load File.expand_path("../spec/dummy/db/schema.rb", __dir__)
 
-require "irb"
 IRB.start(__FILE__)

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -23,7 +23,7 @@ Dummy::Application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
### Summary

Whilst working on #1735, I noticed it was hard to debug the code, this change adds a fairly opinionated way to debug the code when developing the doorkeeper gem. Additionally I've fixed the warning in the tests that I mentioned in #1732.

Now when developing in either the code or the specs, you can use the `debugger` keyword to jump into an interactive debugging session.

### Other Information

Why include irb in the Gemfile? That's been recommended by the irb authors, due to irb bundled with ruby frequently being out of date with the state of irb development.