### PR TITLE
Feat: Implement oauth authorization server metadata

### DIFF
--- a/app/controllers/doorkeeper/discovery_controller.rb
+++ b/app/controllers/doorkeeper/discovery_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  class DiscoveryController < Doorkeeper::ApplicationMetalController
+    def show
+      render json: {}, status: 200
+    end
+  end
+end

--- a/app/controllers/doorkeeper/discovery_controller.rb
+++ b/app/controllers/doorkeeper/discovery_controller.rb
@@ -3,7 +3,18 @@
 module Doorkeeper
   class DiscoveryController < Doorkeeper::ApplicationMetalController
     def show
-      render json: {}, status: 200
+      headers.merge!(discovery_response.headers)
+      render json: discovery_response.body,
+             status: discovery_response.status
+    end
+
+    private
+
+    def discovery_response
+      @discovery_response ||= Doorkeeper::OAuth::DiscoveryResponse.new(
+        root_url,
+        -> (**args) { url_for(**args) }
+      )
     end
   end
 end

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -47,6 +47,7 @@ module Doorkeeper
     autoload :Client, "doorkeeper/oauth/client"
     autoload :ClientCredentialsRequest, "doorkeeper/oauth/client_credentials_request"
     autoload :CodeRequest, "doorkeeper/oauth/code_request"
+    autoload :DiscoveryResponse, "doorkeeper/oauth/discovery_response"
     autoload :ErrorResponse, "doorkeeper/oauth/error_response"
     autoload :Error, "doorkeeper/oauth/error"
     autoload :InvalidTokenResponse, "doorkeeper/oauth/invalid_token_response"

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -321,6 +321,9 @@ module Doorkeeper
     #
     option :realm,                          default: "Doorkeeper"
 
+    # Issuer URL for the OAuth Authorization Server
+    option :issuer,                         default: nil
+
     # Forces the usage of the HTTPS protocol in non-native redirect uris
     # (enabled by default in non-development environments). OAuth2
     # delegates security in communication to the HTTPS protocol so it is
@@ -396,6 +399,10 @@ module Doorkeeper
 
     option :application_class,
            default: "Doorkeeper::Application"
+
+    # Allows setting a hash of custom data on the OAuth 2.0 Authorization
+    # Server Metadata discovery response.
+    option :custom_discovery_data, default: {}
 
     # Allows to set blank redirect URIs for Applications in case
     # server configured to use URI-less grant flows.

--- a/lib/doorkeeper/config/validations.rb
+++ b/lib/doorkeeper/config/validations.rb
@@ -12,6 +12,7 @@ module Doorkeeper
         validate_token_reuse_limit
         validate_secret_strategies
         validate_pkce_code_challenge_methods
+        validate_custom_discovery_data
       end
 
       private
@@ -59,6 +60,17 @@ module Doorkeeper
         )
 
         @pkce_code_challenge_methods = ['plain', 'S256']
+      end
+
+      def validate_custom_discovery_data
+        return if custom_discovery_data.is_a? Hash
+
+        ::Rails.logger.warn(
+          "[DOORKEEPER] You have configured an invalid value for custom_discovery_data option. " \
+          "It must be a Hash, and will be overridden with an empty hash.",
+        )
+
+        @custom_discovery_data = {}
       end
     end
   end

--- a/lib/doorkeeper/oauth/discovery_response.rb
+++ b/lib/doorkeeper/oauth/discovery_response.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    class DiscoveryResponse < BaseResponse
+      def initialize(root_url, url_builder)
+        @root_url = root_url
+        @url_builder = url_builder
+      end
+
+      def body
+        @body ||= {
+          issuer: issuer || @root_url,
+          authorization_endpoint: authorization_endpoint,
+          token_endpoint: token_endpoint,
+          revocation_endpoint: revocation_endpoint,
+          userinfo_endpoint: userinfo_endpoint,
+          scopes_supported: scopes_supported,
+          response_types_supported: response_types_supported,
+          response_modes_supported: response_modes_supported,
+          grant_types_supported: grant_types_supported,
+          token_endpoint_auth_methods_supported: token_endpoint_auth_methods_supported,
+          code_challenge_methods_supported: code_challenge_methods_supported,
+        }.merge(custom_discovery_data)
+      end
+
+      def status
+        :ok
+      end
+
+      def headers
+        {
+          "Cache-Control" => "public",
+          "Content-Type" => "application/json; charset=utf-8",
+        }
+      end
+
+      private
+
+      def config
+        @config ||= Doorkeeper.configuration
+      end
+
+      def url_for(**args)
+        @url_builder.call(**args)
+      end
+
+      def custom_discovery_data
+        config.custom_discovery_data.symbolize_keys
+      end
+
+      def issuer
+        config.issuer
+      end
+
+      def authorization_endpoint
+        mapping = Doorkeeper::Rails::Routes.mapping[:authorizations] || {}
+
+        url_for(
+          controller: mapping[:controllers] || "doorkeeper/authorizations",
+          action: 'new'
+        )
+      end
+
+      def token_endpoint
+        mapping = Doorkeeper::Rails::Routes.mapping[:tokens] || {}
+        
+        url_for(
+          controller: mapping[:controllers] || "doorkeeper/tokens",
+          action: 'create'
+        )
+      end
+
+      def userinfo_endpoint
+        nil
+      end
+
+      def revocation_endpoint
+        mapping = Doorkeeper::Rails::Routes.mapping[:tokens] || {}
+        
+        url_for(
+          controller: mapping[:controllers] || "doorkeeper/tokens",
+          action: 'revoke'
+        )
+      end
+
+      def scopes_supported
+        config.scopes.to_a
+      end
+
+      def response_types_supported
+        config.authorization_response_types
+      end
+
+      def response_modes_supported
+        config.authorization_response_flows.flat_map(&:response_mode_matches).uniq
+      end
+
+      def grant_types_supported
+        grant_types_supported = config.grant_flows.dup
+        grant_types_supported << 'refresh_token' if !!config.refresh_token_enabled?
+        grant_types_supported
+      end
+
+      # FIXME: https://github.com/doorkeeper-gem/doorkeeper/pull/1770
+      def token_endpoint_auth_methods_supported
+        %w(none client_secret_basic client_secret_post)
+      end
+
+      def code_challenge_methods_supported
+        config.pkce_code_challenge_methods_supported
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/rails/routes.rb
+++ b/lib/doorkeeper/rails/routes.rb
@@ -41,9 +41,15 @@ module Doorkeeper
           map_route(:authorized_applications, :authorized_applications_routes)
           map_route(:token_info, :token_info_routes)
         end
+
+        map_route(:discovery, :discovery_routes)
       end
 
       private
+
+      def discovery_routes(mapping)
+        routes.get ".well-known/oauth-authorization-server", controller: mapping[:controllers], action: :show
+      end
 
       def authorization_routes(mapping)
         routes.resource(

--- a/lib/doorkeeper/rails/routes/mapping.rb
+++ b/lib/doorkeeper/rails/routes/mapping.rb
@@ -11,6 +11,7 @@ module Doorkeeper
             authorizations: "doorkeeper/authorizations",
             applications: "doorkeeper/applications",
             authorized_applications: "doorkeeper/authorized_applications",
+            discovery: "doorkeeper/discovery",
             tokens: "doorkeeper/tokens",
             token_info: "doorkeeper/token_info",
           }

--- a/spec/dummy/app/controllers/custom_discovery_controller.rb
+++ b/spec/dummy/app/controllers/custom_discovery_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CustomDiscoveryController < ::ApplicationController
+  def show
+    render nothing: true
+  end
+end

--- a/spec/requests/endpoints/discovery_spec.rb
+++ b/spec/requests/endpoints/discovery_spec.rb
@@ -3,12 +3,78 @@
 require "spec_helper"
 
 RSpec.describe "Discovery endpoint" do
+  before do
+    default_scopes_exist :read
+    optional_scopes_exist :write, :publish
+  end
+
   it "returns json" do
     get "/.well-known/oauth-authorization-server"
 
     response_status_should_be(200)
 
-    # WIP: currently empty
-    expect(json_response).to eq({})
+    expect(json_response).to have_key("issuer")
+    expect(json_response).to have_key("authorization_endpoint")
+    expect(json_response).to have_key("token_endpoint")
+    expect(json_response).to have_key("revocation_endpoint")
+    expect(json_response).to have_key("userinfo_endpoint")
+    expect(json_response).to have_key("scopes_supported")
+    expect(json_response).to have_key("response_types_supported")
+    expect(json_response).to have_key("response_modes_supported")
+    expect(json_response).to have_key("grant_types_supported")
+    expect(json_response).to have_key("token_endpoint_auth_methods_supported")
+    expect(json_response).to have_key("code_challenge_methods_supported")
+
+    expect(json_response["issuer"]).to be_a(String)
+
+    expect(json_response["scopes_supported"]).to be_a(Array)
+    expect(json_response["response_types_supported"]).to be_a(Array)
+    expect(json_response["response_modes_supported"]).to be_a(Array)
+    expect(json_response["grant_types_supported"]).to be_a(Array)
+    expect(json_response["token_endpoint_auth_methods_supported"]).to be_a(Array)
+    expect(json_response["code_challenge_methods_supported"]).to be_a(Array)
+  end
+
+  context 'With custom issuer' do
+    before do
+      config_is_set(:issuer, "http://example.test/")
+    end
+
+    it "returns json" do
+      get "/.well-known/oauth-authorization-server"
+      
+      response_status_should_be(200)
+      expect(json_response["issuer"]).to eq "http://example.test/"
+    end
+  end
+
+  context 'With code challenge methods' do
+    before do
+      config_is_set(:pkce_code_challenge_methods, ["S256"])
+    end
+
+    it "returns json" do
+      get "/.well-known/oauth-authorization-server"
+      
+      response_status_should_be(200)
+      expect(json_response["code_challenge_methods_supported"]).to eq(["S256"])
+    end
+  end
+
+  context 'With custom discovery attributes' do
+    before do
+      config_is_set(:custom_discovery_data, {
+        userinfo_endpoint: '/userinfo',
+        app_registration_url: 'app_registration_url.example'
+      })
+    end
+
+    it "returns json" do
+      get "/.well-known/oauth-authorization-server"
+
+      response_status_should_be(200)
+      expect(json_response["userinfo_endpoint"]).to eq("/userinfo")
+      expect(json_response["app_registration_url"]).to eq("app_registration_url.example")
+    end
   end
 end

--- a/spec/requests/endpoints/discovery_spec.rb
+++ b/spec/requests/endpoints/discovery_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Discovery endpoint" do
+  it "returns json" do
+    get "/.well-known/oauth-authorization-server"
+
+    response_status_should_be(200)
+
+    # WIP: currently empty
+    expect(json_response).to eq({})
+  end
+end

--- a/spec/routing/custom_controller_routes_spec.rb
+++ b/spec/routing/custom_controller_routes_spec.rb
@@ -83,6 +83,11 @@ RSpec.describe "Custom controller for routes" do
     expect(get("/inner_space/scope/token/info")).to route_to("custom_authorizations#show")
   end
 
+  it "GET /inner_space/.well-known/oauth-authorization-server route to show Discovery controller" do
+    expect(get("/space/.well-known/oauth-authorization-server")).to route_to("doorkeeper/discovery#show")
+  end
+
+
   it "GET /space/oauth/authorize routes to custom authorizations controller" do
     expect(get("/space/oauth/authorize")).to route_to("custom_authorizations#new")
   end
@@ -115,6 +120,10 @@ RSpec.describe "Custom controller for routes" do
     expect(get("/space/oauth/token/info")).to route_to("custom_authorizations#show")
   end
 
+  it "GET /space/.well-known/oauth-authorization-server route to show Discovery controller" do
+    expect(get("/space/.well-known/oauth-authorization-server")).to route_to("doorkeeper/discovery#show")
+  end
+
   it "POST /outer_space/oauth/token is not be routable" do
     expect(post("/outer_space/oauth/token")).not_to be_routable
   end
@@ -129,5 +138,9 @@ RSpec.describe "Custom controller for routes" do
 
   it "GET /outer_space/oauth/token_info is not routable" do
     expect(get("/outer_space/oauth/token/info")).not_to be_routable
+  end
+
+  it "GET /outer_space/.well-known/oauth-authorization-server route to show Discovery controller" do
+    expect(get("/outer_space/.well-known/oauth-authorization-server")).to route_to("doorkeeper/discovery#show")
   end
 end

--- a/spec/routing/custom_controller_routes_spec.rb
+++ b/spec/routing/custom_controller_routes_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe "Custom controller for routes" do
           controllers authorizations: "custom_authorizations",
                       tokens: "custom_authorizations",
                       applications: "custom_authorizations",
-                      token_info: "custom_authorizations"
+                      token_info: "custom_authorizations",
+                      discovery: "custom_discovery"
 
           as authorizations: "custom_auth",
              tokens: "custom_token",
@@ -29,7 +30,8 @@ RSpec.describe "Custom controller for routes" do
           controllers authorizations: "custom_authorizations",
                       tokens: "custom_authorizations",
                       applications: "custom_authorizations",
-                      token_info: "custom_authorizations"
+                      token_info: "custom_authorizations",
+                      discovery: "custom_discovery"
 
           as authorizations: "custom_auth",
              tokens: "custom_token",
@@ -41,7 +43,8 @@ RSpec.describe "Custom controller for routes" do
         use_doorkeeper do
           controllers authorizations: "custom_authorizations",
                       tokens: "custom_authorizations",
-                      token_info: "custom_authorizations"
+                      token_info: "custom_authorizations",
+                      discovery: "custom_discovery"
 
           as authorizations: "custom_auth",
              tokens: "custom_token",
@@ -84,7 +87,7 @@ RSpec.describe "Custom controller for routes" do
   end
 
   it "GET /inner_space/.well-known/oauth-authorization-server route to show Discovery controller" do
-    expect(get("/space/.well-known/oauth-authorization-server")).to route_to("doorkeeper/discovery#show")
+    expect(get("/space/.well-known/oauth-authorization-server")).to route_to("custom_discovery#show")
   end
 
 
@@ -121,7 +124,7 @@ RSpec.describe "Custom controller for routes" do
   end
 
   it "GET /space/.well-known/oauth-authorization-server route to show Discovery controller" do
-    expect(get("/space/.well-known/oauth-authorization-server")).to route_to("doorkeeper/discovery#show")
+    expect(get("/space/.well-known/oauth-authorization-server")).to route_to("custom_discovery#show")
   end
 
   it "POST /outer_space/oauth/token is not be routable" do
@@ -141,6 +144,6 @@ RSpec.describe "Custom controller for routes" do
   end
 
   it "GET /outer_space/.well-known/oauth-authorization-server route to show Discovery controller" do
-    expect(get("/outer_space/.well-known/oauth-authorization-server")).to route_to("doorkeeper/discovery#show")
+    expect(get("/outer_space/.well-known/oauth-authorization-server")).to route_to("custom_discovery#show")
   end
 end

--- a/spec/routing/default_routes_spec.rb
+++ b/spec/routing/default_routes_spec.rb
@@ -38,4 +38,8 @@ RSpec.describe "Default routes" do
   it "GET /oauth/token/info route to authorized TokenInfo controller" do
     expect(get("/oauth/token/info")).to route_to("doorkeeper/token_info#show")
   end
+
+  it "GET /.well-known/oauth-authorization-server route to show Discovery controller" do
+    expect(get("/.well-known/oauth-authorization-server")).to route_to("doorkeeper/discovery#show")
+  end
 end

--- a/spec/routing/scoped_routes_spec.rb
+++ b/spec/routing/scoped_routes_spec.rb
@@ -53,4 +53,8 @@ RSpec.describe "Scoped routes" do
   it "POST /scope/introspect routes not to exist" do
     expect(post("/scope/introspect")).not_to be_routable
   end
+
+  it "GET /.well-known/oauth-authorization-server route to show Discovery controller" do
+    expect(get("/.well-known/oauth-authorization-server")).to route_to("doorkeeper/discovery#show")
+  end
 end


### PR DESCRIPTION
### Summary

This is early work on supporting #1587, it's currently based off an older commit from #1732, #1735, and #1736 since those allow me to work semi-productively on the doorkeeper codebase.

I'm unsure if we'd really need a custom controller for discovery, as I think the initializer for configuration should probably handle the "adding extra stuff to the `.well-known/oauth-authorization-server` endpoint, instead of actually overriding the controller.

I don't think it makes sense for the `scope` option with doorkeeper to affect the `.well-known/oauth-authorization-server` endpoint, however, nesting that within a scope can work (allowing multiple oauth providers on the one domain, similar to how keycloak works)

I'm still to figure out all the necessary stuff for actually building out the data for response. I think I'm probably inclined to create a `Doorkeeper::OAuth::DiscoveryResponse` class, and a `custom_discovery_response` configuration block option, then have the controller just apply that class.

There's also the question of "should this be rename-able by other plugins?", e.g., OIDC that uses `.well-known/openid-configuration` instead of `.well-known/oauth-authorization-server` — I'd probably guess maybe no, and instead the OIDC plugin could just remove the `.well-known/oauth-authorization-server` route and add its own which is calling a subclass of `Doorkeeper::OAuth::DiscoveryResponse`?