### PR TITLE
Add support for dynamic scopes

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+exclude_patterns:
+- "lib/doorkeeper/config.rb"
+- "spec/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 Add your entry here.
 
+- [#1739] Add support for dynamic scopes
 - [#1715] Fix token introspection invalid request reason
 - [#1714] Fix `Doorkeeper::AccessToken.find_or_create_for` with empty scopes which raises NoMethodError
 - [#1712] Add `Pragma: no-cache` to token response

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -31,6 +31,16 @@ module Doorkeeper
         @config.instance_variable_set(:@confirm_application_owner, true)
       end
 
+      # Provide support for dynamic scopes (e.g. user:*) (disabled by default)
+      # Optional parameter delimiter (default ":") if you want to customize
+      # the delimiter separating the scope name and matching value.
+      #
+      # @param opts [Hash] the options to configure dynamic scopes
+      def enable_dynamic_scopes(opts = {})
+        @config.instance_variable_set(:@enable_dynamic_scopes, true)
+        @config.instance_variable_set(:@dynamic_scopes_delimiter, opts[:delimiter] || ':')
+      end
+
       # Define default access token scopes for your provider
       #
       # @param scopes [Array] Default set of access (OAuth::Scopes.new)
@@ -509,6 +519,14 @@ module Doorkeeper
 
     def enable_application_owner?
       option_set? :enable_application_owner
+    end
+
+    def enable_dynamic_scopes?
+      option_set? :enable_dynamic_scopes
+    end
+
+    def dynamic_scopes_delimiter
+      @dynamic_scopes_delimiter
     end
 
     def polymorphic_resource_owner?

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -355,6 +355,38 @@ RSpec.describe Doorkeeper::Config do
     end
   end
 
+  describe "enable_dynamic_scopes" do
+    it "is disabled by default" do
+      expect(Doorkeeper.config.enable_dynamic_scopes?).not_to be(true)
+    end
+
+    context "when enabled with default delimiter" do
+      before do
+        Doorkeeper.configure do
+          enable_dynamic_scopes
+        end
+      end
+
+      it 'returns true' do
+        expect(Doorkeeper.config.enable_dynamic_scopes?).to be(true)
+        expect(Doorkeeper.config.dynamic_scopes_delimiter).to eq(":")
+      end
+    end
+
+    context "when enabled with custom delimiter" do
+      before do
+        Doorkeeper.configure do
+          enable_dynamic_scopes(delimiter: "-")
+        end
+      end
+
+      it 'returns true' do
+        expect(Doorkeeper.config.enable_dynamic_scopes?).to be(true)
+        expect(Doorkeeper.config.dynamic_scopes_delimiter).to eq("-")
+      end
+    end
+  end
+
   describe "enable_application_owner" do
     it "is disabled by default" do
       expect(Doorkeeper.config.enable_application_owner?).not_to be(true)


### PR DESCRIPTION
This commit adds support for dynamic scopes, which are disabled by default.

As discussed in https://github.com/keycloak/keycloak/discussions/8486, a dynamic scope notation is in the form:

```
<static-part>:<variable-part>
```

The objective of this feature is to have a static part of the scope that represents an entity and a variable part that identifies the entity.

For example, a scope of `user:1` could be interpreted as allowing access to perform actions of user 1. A wildcard (`*`) is allowed in the variable part, such as `user:*`. This scope allows the request to perform actions as any users.

Dynamic scopes can be enabled via:

```ruby
Doorkeeper.configure do
  enable_dynamic_scopes
end
```

A custom delimiter can also be configured:

```ruby
Doorkeeper.configure do
  enable_dynamic_scopes(delimiter: '-')
end
```

Relates to https://github.com/doorkeeper-gem/doorkeeper/issues/431


