### PR TITLE
load the session if the session is not preloaded already

### DIFF
--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -6,6 +6,7 @@ module Doorkeeper
 
     def create
       headers.merge!(authorize_response.headers)
+      session.send(:load!) if session.id.nil?
       render json: authorize_response.body,
              status: authorize_response.status
     rescue Errors::DoorkeeperError => e


### PR DESCRIPTION
### Summary

When I upgraded an app to rails 7, the token controller was not pre loading the session which is necessary for the creation of the token.  This is just to make sure the session is created if its not pre loaded.

