### PR TITLE
Fix broken tests for older Rails versions

### DIFF
--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -23,7 +23,10 @@ Dummy::Application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions = :none
+  # Rails 7.1 deprecated false in favor of :none, but we need to use false for
+  # backwards compatibility: https://github.com/rails/rails/pull/45867
+  config.action_dispatch.show_exceptions =
+    Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0') ? :none : false
 
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
### Summary

https://github.com/doorkeeper-gem/doorkeeper/pull/1736 broke tests for Rails < 7.1 because these versions compared
`config.action_dispatch.show_exceptions == false`. Conditionally set this value in the test set up to fix the broken tests.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating CHANGELOG.md file or are asked to update it by reviewers,
please add the changelog entry at the top of the file.

Thanks for contributing to Doorkeeper project!
