### PR TITLE
Allow for expired refresh tokens to be revoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ User-visible changes worth mentioning.
 Add your entry here.
 
 - [#1747] Fix unknown pkce method error when configured
+- [#1744] Allow for expired refresh tokens to be revoked
 
 ## 5.8.0
 

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -34,6 +34,11 @@ module Doorkeeper
     autoload :Token, "doorkeeper/request/token"
   end
 
+  module RevocableTokens
+    autoload :RevocableAccessToken, "doorkeeper/revocable_tokens/revocable_access_token"
+    autoload :RevocableRefreshToken, "doorkeeper/revocable_tokens/revocable_refresh_token"
+  end
+
   module OAuth
     autoload :BaseRequest, "doorkeeper/oauth/base_request"
     autoload :AuthorizationCodeRequest, "doorkeeper/oauth/authorization_code_request"

--- a/lib/doorkeeper/revocable_tokens/revocable_access_token.rb
+++ b/lib/doorkeeper/revocable_tokens/revocable_access_token.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module RevocableTokens
+    class RevocableAccessToken
+      attr_reader :token
+
+      def initialize(token)
+        @token = token
+      end
+
+      def revocable?
+        token.accessible?
+      end
+
+      def revoke
+        token.revoke
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/revocable_tokens/revocable_refresh_token.rb
+++ b/lib/doorkeeper/revocable_tokens/revocable_refresh_token.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module RevocableTokens
+    class RevocableRefreshToken
+      attr_reader :token
+
+      def initialize(token)
+        @token = token
+      end
+
+      def revocable?
+        !token.revoked?
+      end
+
+      def revoke
+        token.revoke
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

This alters the revocation endpoint so that when a refresh token is revoked, we check `revoked?` rather than `accessible?` since the extra `expired?` check in `accessible?` does not apply to refresh tokens since they never expire.

https://github.com/doorkeeper-gem/doorkeeper/issues/1743