### PR TITLE
Fix unknown pkce method error when configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ User-visible changes worth mentioning.
 
 Add your entry here.
 
+- [#1747] Fix unknown pkce method error when configured
+
 ## 5.8.0
 
 - [#1739] Add support for dynamic scopes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,9 +101,9 @@ en:
         access_denied: 'The resource owner or authorization server denied the request.'
         invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
         invalid_code_challenge_method:
-          zero: 'The authorization server does not support PKCE as there are no accepted code_challenge methods'
-          one: 'The code challenge method must be %{challenge_methods}.'
-          other: 'The code challenge method must be one of %{challenge_methods}.'
+          zero: 'The authorization server does not support PKCE as there is no accepted code_challenge_method'
+          one: 'The code_challenge_method must be %{challenge_methods}.'
+          other: 'The code_challenge_method must be one of %{challenge_methods}.'
         server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
         temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,10 @@ en:
         unauthorized_client: 'The client is not authorized to perform this request using this method.'
         access_denied: 'The resource owner or authorization server denied the request.'
         invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
-        invalid_code_challenge_method: 'The code challenge method must be one of %{challenge_methods}.'
+        invalid_code_challenge_method:
+          zero: 'There are no acceptable code_challenge methods'
+          one: 'The code challenge method must be %{challenge_methods}.'
+          other: 'The code challenge method must be one of %{challenge_methods}.'
         server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
         temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,7 @@ en:
         unauthorized_client: 'The client is not authorized to perform this request using this method.'
         access_denied: 'The resource owner or authorization server denied the request.'
         invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
-        invalid_code_challenge_method: 'The code challenge method must be plain or S256.'
+        invalid_code_challenge_method: 'The code challenge method must be one of %{challenge_methods}.'
         server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
         temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,7 +101,7 @@ en:
         access_denied: 'The resource owner or authorization server denied the request.'
         invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
         invalid_code_challenge_method:
-          zero: 'The authorization server does not support PKCE as there is no accepted code_challenge_method'
+          zero: 'The authorization server does not support PKCE as there are no accepted code_challenge_method values.'
           one: 'The code_challenge_method must be %{challenge_methods}.'
           other: 'The code_challenge_method must be one of %{challenge_methods}.'
         server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,7 +101,7 @@ en:
         access_denied: 'The resource owner or authorization server denied the request.'
         invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
         invalid_code_challenge_method:
-          zero: 'There are no acceptable code_challenge methods'
+          zero: 'The authorization server does not support PKCE as there are no accepted code_challenge methods'
           one: 'The code challenge method must be %{challenge_methods}.'
           other: 'The code challenge method must be one of %{challenge_methods}.'
         server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -6,6 +6,10 @@ module Doorkeeper
       def type
         message
       end
+
+      def self.translate_options
+        {}
+      end
     end
 
     class InvalidGrantReuse < DoorkeeperError
@@ -45,6 +49,14 @@ module Doorkeeper
       end
     end
 
+    class InvalidCodeChallengeMethod < BaseResponseError
+      def self.translate_options
+        {
+          challenge_methods: Doorkeeper.config.pkce_code_challenge_methods_supported.join(", ")
+        }
+      end
+    end
+
     UnableToGenerateToken = Class.new(DoorkeeperError)
     TokenGeneratorNotFound = Class.new(DoorkeeperError)
     NoOrmCleaner = Class.new(DoorkeeperError)
@@ -55,7 +67,6 @@ module Doorkeeper
     InvalidScope = Class.new(BaseResponseError)
     InvalidRedirectUri = Class.new(BaseResponseError)
     InvalidCodeChallenge = Class.new(BaseResponseError)
-    InvalidCodeChallengeMethod = Class.new(BaseResponseError)
     InvalidGrant = Class.new(BaseResponseError)
 
     UnauthorizedClient = Class.new(BaseResponseError)

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -51,8 +51,10 @@ module Doorkeeper
 
     class InvalidCodeChallengeMethod < BaseResponseError
       def self.translate_options
+        challenge_methods = Doorkeeper.config.pkce_code_challenge_methods_supported
         {
-          challenge_methods: Doorkeeper.config.pkce_code_challenge_methods_supported.join(", ")
+          challenge_methods: challenge_methods.join(", "),
+          count: challenge_methods.length
         }
       end
     end

--- a/lib/doorkeeper/oauth/error.rb
+++ b/lib/doorkeeper/oauth/error.rb
@@ -2,13 +2,14 @@
 
 module Doorkeeper
   module OAuth
-    Error = Struct.new(:name, :state) do
+    Error = Struct.new(:name, :state, :translate_options) do
       def description
-        I18n.translate(
-          name,
+        options = (translate_options || {}).merge(
           scope: %i[doorkeeper errors messages],
           default: :server_error,
         )
+
+        I18n.translate(name, **options)
       end
     end
   end

--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -12,6 +12,7 @@ module Doorkeeper
           attributes.merge(
             name: error_name_for(request.error),
             exception_class: exception_class_for(request.error),
+            translate_options: request.error.try(:translate_options),
             state: request.try(:state),
             redirect_uri: request.try(:redirect_uri),
           ),
@@ -33,7 +34,7 @@ module Doorkeeper
       delegate :name, :description, :state, to: :@error
 
       def initialize(attributes = {})
-        @error = OAuth::Error.new(*attributes.values_at(:name, :state))
+        @error = OAuth::Error.new(*attributes.values_at(:name, :state, :translate_options))
         @exception_class = attributes[:exception_class]
         @redirect_uri = attributes[:redirect_uri]
         @response_on_fragment = attributes[:response_on_fragment]

--- a/spec/lib/oauth/error_spec.rb
+++ b/spec/lib/oauth/error_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Doorkeeper::OAuth::Error do
       end
 
       it "is translated from translation messages with variables" do
-        expect(error.description).to eq("The code challenge method must be one of foo, bar.")
+        expect(error.description).to eq("The code_challenge_method must be one of foo, bar.")
       end
     end
   end

--- a/spec/lib/oauth/error_spec.rb
+++ b/spec/lib/oauth/error_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Doorkeeper::OAuth::Error do
           :invalid_code_challenge_method,
           :some_state,
           {
-            challenge_methods: "foo, bar"
+            challenge_methods: "foo, bar",
+            count: 2,
           }
         )
       end

--- a/spec/lib/oauth/error_spec.rb
+++ b/spec/lib/oauth/error_spec.rb
@@ -3,10 +3,11 @@
 require "spec_helper"
 
 RSpec.describe Doorkeeper::OAuth::Error do
-  subject(:error) { described_class.new(:some_error, :some_state) }
+  subject(:error) { described_class.new(:some_error, :some_state, nil) }
 
   it { expect(error).to respond_to(:name) }
   it { expect(error).to respond_to(:state) }
+  it { expect(error).to respond_to(:translate_options) }
 
   describe "#description" do
     it "is translated from translation messages" do
@@ -16,6 +17,22 @@ RSpec.describe Doorkeeper::OAuth::Error do
         default: :server_error,
       )
       error.description
+    end
+
+    context "when there are variables" do
+      subject(:error) do
+        described_class.new(
+          :invalid_code_challenge_method,
+          :some_state,
+          {
+            challenge_methods: "foo, bar"
+          }
+        )
+      end
+
+      it "is translated from translation messages with variables" do
+        expect(error.description).to eq("The code challenge method must be one of foo, bar.")
+      end
     end
   end
 end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -343,7 +343,9 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
           attributes[:code_challenge_method] = "plain"
 
           expect(pre_auth).to_not be_authorizable
-          expect(pre_auth.error_response.description).to eq("There are no acceptable code_challenge methods")
+          expect(pre_auth.error_response.description).to eq(
+            "The authorization server does not support PKCE as there are no accepted code_challenge methods"
+          )
         end
       end
 

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -350,7 +350,16 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
           attributes[:code_challenge_method] = "plain"
 
           expect(pre_auth).to_not be_authorizable
+          expect(pre_auth.error_response.description).to eq("The code challenge method must be one of S256.")
         end
+      end
+
+      it "rejects unknown as a code_challenge_method" do
+        attributes[:code_challenge] = "a45a9fea-0676-477e-95b1-a40f72ac3cfb"
+        attributes[:code_challenge_method] = "unknown"
+
+        expect(pre_auth).to_not be_authorizable
+        expect(pre_auth.error_response.description).to eq("The code challenge method must be one of plain, S256.")
       end
     end
 

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
 
           expect(pre_auth).to_not be_authorizable
           expect(pre_auth.error_response.description).to eq(
-            "The authorization server does not support PKCE as there is no accepted code_challenge_method"
+            "The authorization server does not support PKCE as there are no accepted code_challenge_method values."
           )
         end
       end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
 
           expect(pre_auth).to_not be_authorizable
           expect(pre_auth.error_response.description).to eq(
-            "The authorization server does not support PKCE as there are no accepted code_challenge methods"
+            "The authorization server does not support PKCE as there is no accepted code_challenge_method"
           )
         end
       end
@@ -368,7 +368,7 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
           attributes[:code_challenge_method] = "plain"
 
           expect(pre_auth).to_not be_authorizable
-          expect(pre_auth.error_response.description).to eq("The code challenge method must be S256.")
+          expect(pre_auth.error_response.description).to eq("The code_challenge_method must be S256.")
         end
       end
 
@@ -377,7 +377,7 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
         attributes[:code_challenge_method] = "unknown"
 
         expect(pre_auth).to_not be_authorizable
-        expect(pre_auth.error_response.description).to eq("The code challenge method must be one of plain, S256.")
+        expect(pre_auth.error_response.description).to eq("The code_challenge_method must be one of plain, S256.")
       end
     end
 

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -331,6 +331,22 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
         expect(pre_auth).not_to be_authorizable
       end
 
+      context "when pkce_code_challenge_methods is set to none" do
+        before do
+          Doorkeeper.configure do
+            pkce_code_challenge_methods []
+          end
+        end
+
+        it "rejects plain as a code_challenge_method" do
+          attributes[:code_challenge] = "a45a9fea-0676-477e-95b1-a40f72ac3cfb"
+          attributes[:code_challenge_method] = "plain"
+
+          expect(pre_auth).to_not be_authorizable
+          expect(pre_auth.error_response.description).to eq("There are no acceptable code_challenge methods")
+        end
+      end
+
       context "when pkce_code_challenge_methods is set to only S256" do
         before do
           Doorkeeper.configure do
@@ -350,7 +366,7 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
           attributes[:code_challenge_method] = "plain"
 
           expect(pre_auth).to_not be_authorizable
-          expect(pre_auth.error_response.description).to eq("The code challenge method must be one of S256.")
+          expect(pre_auth.error_response.description).to eq("The code challenge method must be S256.")
         end
       end
 

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -428,7 +428,7 @@ feature "Authorization Code Flow" do
 
       scenario "expects to set code_challenge_method explicitly without fallback" do
         visit authorization_endpoint_url(client: @client, code_challenge: code_challenge)
-        expect(page).to have_content("The code challenge method must be one of plain, S256.")
+        expect(page).to have_content("The code_challenge_method must be one of plain, S256.")
       end
     end
   end

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -426,9 +426,9 @@ feature "Authorization Code Flow" do
         )
       end
 
-      scenario "expects to set code_challenge_method explicitely without fallback" do
+      scenario "expects to set code_challenge_method explicitly without fallback" do
         visit authorization_endpoint_url(client: @client, code_challenge: code_challenge)
-        expect(page).to have_content("The code challenge method must be plain or S256.")
+        expect(page).to have_content("The code challenge method must be one of plain, S256.")
       end
     end
   end


### PR DESCRIPTION
### Summary

I am upgrading to get the configuration update from https://github.com/doorkeeper-gem/doorkeeper/pull/1735 but noticed that the error message is not correct when it is configured in that it makes it sound like we accept `plain`.

https://github.com/doorkeeper-gem/doorkeeper/issues/1746