### PR TITLE
Introducing Doorkeeper Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 [![GuardRails badge](https://badges.guardrails.io/doorkeeper-gem/doorkeeper.svg?token=66768ce8f6995814df81f65a2cff40f739f688492704f973e62809e15599bb62)](https://dashboard.guardrails.io/default/gh/doorkeeper-gem/doorkeeper)
 [![Dependabot](https://img.shields.io/badge/dependabot-enabled-success.svg)](https://dependabot.com)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Doorkeeper%20Guru-006BFF)](https://gurubase.io/g/doorkeeper)
 
 Doorkeeper is a gem (Rails engine) that makes it easy to introduce OAuth 2 provider
 functionality to your Ruby on Rails or Grape application.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Doorkeeper Guru](https://gurubase.io/g/doorkeeper) to Gurubase. Doorkeeper Guru uses the data from this repo and data from the [docs](https://doorkeeper.gitbook.io/guides/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Doorkeeper Guru", which highlights that Doorkeeper now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Doorkeeper Guru in Gurubase, just let me know that's totally fine.
