### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
     "source_code_uri" => "https://github.com/doorkeeper-gem/doorkeeper",
     "bug_tracker_uri" => "https://github.com/doorkeeper-gem/doorkeeper/issues",
     "documentation_uri" => "https://doorkeeper.gitbook.io/guides/",
+    "funding_uri" => "https://opencollective.com/doorkeeper-gem",
   }
 
   gem.add_dependency "railties", ">= 5"


### PR DESCRIPTION
I noticed that the project already has a FUNDING.yml. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.