### PR TITLE
delete `TestFixtures.fixture_path=` DEPRECATION WARNING (for support Rails 7.2)

### DIFF
--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -6,7 +6,7 @@ gem "rails", "~> 7.1.0"
 gem "rspec-core"
 gem "rspec-expectations"
 gem "rspec-mocks"
-gem "rspec-rails", "~> 5.0"
+gem "rspec-rails", "~> 6.1"
 gem "rspec-support"
 gem "rubocop", "~> 1.4"
 gem "rubocop-performance", require: false


### PR DESCRIPTION
## Why?
rspec-rails 5.x does not work with Rails 7.2.

```
$ BUNDLE_GEMFILE=gemfiles/rails_7_1.gemfile bundle exec rake
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's 'rails' settings.
====> Doorkeeper ORM: 'active_record'
====> Doorkeeper version: 5.8.0
====> Rails version: 7.1.5
====> Ruby version: 3.2.2 on arm64-darwin22
DEPRECATION WARNING: TestFixtures.fixture_path= is deprecated and will be removed in Rails 7.2. Use .fixture_paths= instead. (called from <top (required)> at ...
```

https://github.com/rspec/rspec-rails/blob/v6.1.0/Changelog.md
> 6.1.0 / 2023-11-21
> Support for Rails 7.1

> 6.0.2 / 2023-05-04
> Support Rails 7.1's #fixtures_paths in example groups (removes a deprecation warning). (Nicholas Simmons, #2664)