### PR TITLE
Bump the range of supported Ruby and Rails versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby:
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
         gemfile:
-          - gemfiles/rails_6_0.gemfile
-          - gemfiles/rails_6_1.gemfile
           - gemfiles/rails_7_0.gemfile
           - gemfiles/rails_7_1.gemfile
+          - gemfiles/rails_7_2.gemfile
+          - gemfiles/rails_8_0.gemfile
+        exclude:
+          - ruby: 3.1
+            gemfile: gemfiles/rails_8_0.gemfile
     steps:
       - name: Repo checkout
         uses: actions/checkout@v4
@@ -62,10 +64,10 @@ jobs:
     strategy:
       matrix:
         gemfile:
-          - gemfiles/rails_6_0.gemfile
-          - gemfiles/rails_6_1.gemfile
           - gemfiles/rails_7_0.gemfile
           - gemfiles/rails_7_1.gemfile
+          - gemfiles/rails_7_2.gemfile
+          - gemfiles/rails_8_0.gemfile
     runs-on: ubuntu-latest
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   Exclude:
     - "spec/generators/tmp/**/*"
     - "spec/dummy/db/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 Add your entry here.
 
+- [#1752] Bump the range of supported Ruby and Rails versions
 - [#1747] Fix unknown pkce method error when configured
 
 ## 5.8.0

--- a/Gemfile
+++ b/Gemfile
@@ -5,14 +5,14 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-gem "rails", ">= 6.0", "< 8.1"
+gem "rails", ">= 7.0", "< 8.1"
 
 gem "sprockets-rails"
 
 gem "rspec-core"
 gem "rspec-expectations"
 gem "rspec-mocks"
-gem "rspec-rails", "~> 7.0"
+gem "rspec-rails", "~> 7.1"
 gem "rspec-support"
 
 gem "rubocop", "~> 1.4"
@@ -23,7 +23,7 @@ gem "rubocop-rspec", require: false
 gem "bcrypt", "~> 3.1", require: false
 
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
-gem "sqlite3", "~> 2.2", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+gem "sqlite3", "~> 2.3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw]
 gem "timecop"

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -6,7 +6,7 @@ gem "rails", "~> 7.1.0"
 gem "rspec-core"
 gem "rspec-expectations"
 gem "rspec-mocks"
-gem "rspec-rails", "~> 5.0"
+gem "rspec-rails", "~> 7.1"
 gem "rspec-support"
 gem "rubocop", "~> 1.4"
 gem "rubocop-performance", require: false

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -2,11 +2,11 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.1.0"
+gem "rails", "~> 7.2.0"
 gem "rspec-core"
 gem "rspec-expectations"
 gem "rspec-mocks"
-gem "rspec-rails", "~> 5.0"
+gem "rspec-rails", "~> 7.1"
 gem "rspec-support"
 gem "rubocop", "~> 1.4"
 gem "rubocop-performance", require: false
@@ -14,6 +14,7 @@ gem "rubocop-rails", require: false
 gem "rubocop-rspec", require: false
 gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
+gem "sprockets-rails"
 gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -2,11 +2,11 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0.0"
+gem "rails", "~> 8.0.0"
 gem "rspec-core"
 gem "rspec-expectations"
 gem "rspec-mocks"
-gem "rspec-rails", "~> 5.0"
+gem "rspec-rails", "~> 7.1"
 gem "rspec-support"
 gem "rubocop", "~> 1.4"
 gem "rubocop-performance", require: false
@@ -14,7 +14,8 @@ gem "rubocop-rails", require: false
 gem "rubocop-rspec", require: false
 gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
-gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+gem "sprockets-rails"
+gem "sqlite3", "~> 2.3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
 

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -6,7 +6,7 @@ gem "rails", git: "https://github.com/rails/rails"
 gem "rspec-core"
 gem "rspec-expectations"
 gem "rspec-mocks"
-gem "rspec-rails", "~> 5.0"
+gem "rspec-rails", "~> 7.1"
 gem "rspec-support"
 gem "rubocop", "~> 1.4"
 gem "rubocop-performance", require: false
@@ -15,7 +15,7 @@ gem "rubocop-rspec", require: false
 gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sprockets-rails"
-gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+gem "sqlite3", "~> 2.3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
 


### PR DESCRIPTION
Ruby 3.0 has reached the EOL:
https://www.ruby-lang.org/en/downloads/branches/

Also since Rails 6 has been dropped support for and Rails 7.2, 8.0 are out
corresponding gemfiles are now dispensable to ci.
https://rubyonrails.org/maintenance
