### PR TITLE
Fix refresh tokens with dynamic scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Add your entry here.
 - [#1752] Bump the range of supported Ruby and Rails versions
 - [#1747] Fix unknown pkce method error when configured
 - [#1744] Allow for expired refresh tokens to be revoked
+- [#1754] Fix refresh tokens with dynamic scopes
 
 ## 5.8.0
 

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -59,7 +59,8 @@ module Doorkeeper
           client_scopes = @client&.scopes
           return default_scopes if client_scopes.blank?
 
-          default_scopes & client_scopes
+          # Avoid using Scope#& for dynamic scopes
+          client_scopes.allowed(default_scopes)
         end
       end
     end

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -75,7 +75,7 @@ module Doorkeeper
         if client_scopes.blank?
           server.default_scopes.to_s
         else
-          (server.default_scopes & client_scopes).to_s
+          server.default_scopes.allowed(client_scopes).to_s
         end
       end
 

--- a/lib/doorkeeper/oauth/scopes.rb
+++ b/lib/doorkeeper/oauth/scopes.rb
@@ -70,8 +70,26 @@ module Doorkeeper
         end
       end
 
+      # DEPRECATED: With dynamic scopes, #allowed should be called because
+      # A & B doesn't really make sense with dynamic scopes.
+      #
+      # For example, if A = user:* and B is user:1, A & B = [].
+      # If we modified this method to take dynamic scopes into an account, then order
+      # becomes important, and this would violate the principle that A & B = B & A.
       def &(other)
+        return allowed(other) if dynamic_scopes_enabled?
+
         self.class.from_array(all & to_array(other))
+      end
+
+      # Returns a set of scopes that are allowed, taking dynamic
+      # scopes into account. This instance's scopes is taken as the allowed set,
+      # and the passed value is the set to filter.
+      #
+      # @param other The set of scopes to filter
+      def allowed(other)
+        filtered_scopes = other.select { |scope| self.exists?(scope) }
+        self.class.from_array(filtered_scopes)
       end
 
       private

--- a/spec/lib/oauth/scopes_spec.rb
+++ b/spec/lib/oauth/scopes_spec.rb
@@ -118,6 +118,13 @@ RSpec.describe Doorkeeper::OAuth::Scopes do
     end
   end
 
+  describe "#allowed" do
+    it "can get intersection with another scope object" do
+      scopes = described_class.from_string("public admin").allowed(described_class.from_string("write admin"))
+      expect(scopes.all).to eq(%w[admin])
+    end
+  end
+
   describe "#has_scopes?" do
     subject(:scopes) { described_class.from_string("public admin") }
 
@@ -191,6 +198,40 @@ RSpec.describe Doorkeeper::OAuth::Scopes do
 
         it "returns false if dynamic scope does not match" do
           expect(scopes).not_to have_scopes(described_class.from_string("public userA:1"))
+        end
+
+        describe "#&" do
+          it "allows user:1 scope" do
+            scopes = described_class.from_string("public user:*") & (described_class.from_string("public user:1"))
+            expect(scopes.all).to eq(%w[public user:1])
+          end
+
+          it "does not allow user:2 scope" do
+            scopes = described_class.from_string("public user:1") & (described_class.from_string("public user:2"))
+            expect(scopes.all).to eq(%w[public])
+          end
+
+          it "does not allow user:* scope" do
+            scopes = described_class.from_string("public user:1") & (described_class.from_string("public user:*"))
+            expect(scopes.all).to eq(%w[public])
+          end
+        end
+
+        describe "#allowed" do
+          it "allows user:1 scope" do
+            scopes = described_class.from_string("public user:*").allowed(described_class.from_string("public user:1"))
+            expect(scopes.all).to eq(%w[public user:1])
+          end
+
+          it "does not allow user:2 scope" do
+            scopes = described_class.from_string("public user:1").allowed(described_class.from_string("public user:2"))
+            expect(scopes.all).to eq(%w[public])
+          end
+
+          it "does not allow user:* scope" do
+            scopes = described_class.from_string("public user:1").allowed(described_class.from_string("public user:*"))
+            expect(scopes.all).to eq(%w[public])
+          end
         end
       end
 


### PR DESCRIPTION
### Summary

Suppose your OAuth application supports the scopes `public user:*`. Previously a refresh token with the `public user:1` scope returned a scope of `public` by default, unless `user:1` were explicitly requested. This happened because `Doorkeeper::Oauth::BaseRequest` does a set intersection:

```
"public user:*" & "public user:1" = "public"
```

With dynamic scopes, this doesn't work because the wildcard `user:*` doesn't match `user:1`.

To fix this, introduce `Scopes#allowed` and deprecate the use of `&`.
