### PR TITLE
Fix the error message for force_pkce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 Add your entry here.
+- [#1755] Fix the error message for force_pkce
 
 ## 5.8.1
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,7 @@ en:
           unknown: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
           missing_param: 'Missing required parameter: %{value}.'
           request_not_authorized: 'Request need to be authorized. Required parameter for authorizing request is missing or invalid.'
+          invalid_code_challenge: 'Code challenge is required.'
         invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
         unauthorized_client: 'The client is not authorized to perform this request using this method.'
         access_denied: 'The resource owner or authorization server denied the request.'

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -68,7 +68,6 @@ module Doorkeeper
     InvalidClient = Class.new(BaseResponseError)
     InvalidScope = Class.new(BaseResponseError)
     InvalidRedirectUri = Class.new(BaseResponseError)
-    InvalidCodeChallenge = Class.new(BaseResponseError)
     InvalidGrant = Class.new(BaseResponseError)
 
     UnauthorizedClient = Class.new(BaseResponseError)

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -427,6 +427,7 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
           attributes[:code_challenge] = " "
 
           expect(pre_auth).not_to be_authorizable
+          expect(pre_auth.error_response.description).to eq(translated_invalid_request_error_message(:invalid_code_challenge, nil))
         end
 
         it "accepts a code challenge" do


### PR DESCRIPTION
### Summary

#### Bug
When the `force_pkce` option is enabled for a public client, and the authorization code request doesn't include a code_challenge, the error message returned is

"The authorization server encountered an unexpected condition which prevented it from fulfilling the request."

#### Root cause
[#1705] didn't add the error message in the locales.

#### Fix
Base on RFC https://datatracker.ietf.org/doc/html/rfc7636#section-4.4.1, we should return an "invalid_request" error with a proper description. I added a new entry for the error message and included a test to verify the proper message is returned.
