### PR TITLE
Bump the range of supported Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
         gemfile:
           - gemfiles/rails_7_0.gemfile
           - gemfiles/rails_7_1.gemfile
@@ -56,7 +57,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
       - run: bundle exec rake spec || echo "Rails edge test is done."
 

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -18,5 +18,9 @@ gem "sprockets-rails"
 gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
+gem "base64"
+gem "drb"
+gem "mutex_m"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"


### PR DESCRIPTION
## Ruby 3.4 is out

### 1. add Bundled gems for Ruby 3.4

https://bugs.ruby-lang.org/issues/20187

It has already been backported to the 7-0-stable branch, but is not included in 7.0.8.7.
- https://github.com/rails/rails/blob/7-0-stable/activesupport/activesupport.gemspec#L41-L43
- https://github.com/rails/rails/blob/v7.0.8.7/activesupport/activesupport.gemspec

### 2. Specify concurrent-ruby 1.3.4 for Rails 7.0

concurrent-ruby 1.3.5 don't work on Rails 7.0

> NameError:
>  uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
    
See: https://github.com/ruby-concurrency/concurrent-ruby/pull/1062