### PR TITLE
Memoize authentication failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 Add your entry here.
 - [#1755] Fix the error message for force_pkce
+- [#1761] Memoize authentication failure
 
 ## 5.8.1
 

--- a/lib/doorkeeper/rails/helpers.rb
+++ b/lib/doorkeeper/rails/helpers.rb
@@ -70,7 +70,9 @@ module Doorkeeper
       end
 
       def doorkeeper_token
-        @doorkeeper_token ||= OAuth::Token.authenticate(
+        return @doorkeeper_token if defined?(@doorkeeper_token)
+
+        @doorkeeper_token = OAuth::Token.authenticate(
           request,
           *Doorkeeper.config.access_token_methods,
         )


### PR DESCRIPTION
`Doorkeeper::Rails::Helpers#doorkeeper_token` uses memoization, but only when authentication is successful (positive hits).

Let it memoize authentication failures as well.