### PR TITLE
Allow missing client to trigger invalid client error when force_pkce is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ User-visible changes worth mentioning.
 Add your entry here.
 - [#1755] Fix the error message for force_pkce
 - [#1761] Memoize authentication failure
+- [#1762] Allow missing client to trigger invalid client error when force_pkce is enabled
 
 ## 5.8.1
 

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -59,15 +59,11 @@ module Doorkeeper
         Doorkeeper.config.access_grant_model.pkce_supported?
       end
 
-      def confidential?
-        client&.confidential
-      end
-
       def validate_params
         @missing_param =
           if grant&.uses_pkce? && code_verifier.blank?
             :code_verifier
-          elsif !confidential? && Doorkeeper.config.force_pkce? && code_verifier.blank?
+          elsif client && !client.confidential && Doorkeeper.config.force_pkce? && code_verifier.blank?
             :code_verifier
           elsif redirect_uri.blank?
             :redirect_uri

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -194,6 +194,14 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
           end.not_to change { client.reload.access_tokens.count }
         end
       end
+
+      context "when the app is missing" do
+        it "does not assume non-confidential and forcibly validate pkce params" do
+          request = described_class.new(server, grant, nil, params)
+          request.validate
+          expect(request.error).to eq(Doorkeeper::Errors::InvalidClient)
+        end
+      end
     end
 
     context "when PKCE is supported" do


### PR DESCRIPTION
Currently, the force_pkce handling is treating a missing client as a non-confidential client and forcibly validating the code_verifier param. This updates the conditional to only force_pkce if the client is present.