### PR TITLE
Make sure error handling happens on a controller level opposed to action level to account for the controller being extended

### DIFF
--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -4,12 +4,14 @@ module Doorkeeper
   class TokensController < Doorkeeper::ApplicationMetalController
     before_action :validate_presence_of_client, only: [:revoke]
 
+    rescue_from Errors::DoorkeeperError do |e|
+      handle_token_exception(e)
+    end
+
     def create
       headers.merge!(authorize_response.headers)
       render json: authorize_response.body,
              status: authorize_response.status
-    rescue Errors::DoorkeeperError => e
-      handle_token_exception(e)
     end
 
     # OAuth 2.0 Token Revocation - https://datatracker.ietf.org/doc/html/rfc7009


### PR DESCRIPTION
### Summary

When extending the `TokensController` for any purpose, if any helper method is called and ends up raising an error, that error wasn't being handled by the controller since the rescue was happening at the action level.
Turning an action level `rescue` into a controller `rescue_from` will ensure controllers extending `TokensController` will have the same error handling while enabling it to keep calling the helper methods without worrying about error handling.
