### PR TITLE
Implement helper method to retrieve token_endpoint_auth_methods

### DIFF
--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -583,6 +583,16 @@ module Doorkeeper
       @client_credentials_methods ||= %i[from_basic from_params]
     end
 
+    def token_endpoint_auth_methods
+      return @token_endpoint_auth_methods if instance_variable_defined?(:@token_endpoint_auth_methods)
+
+      methods = ['none']
+      methods << 'client_secret_basic' if client_credentials_methods.include? :from_basic
+      methods << 'client_secret_post' if client_credentials_methods.include? :from_params
+
+      @token_endpoint_auth_methods = methods
+    end
+
     def access_token_methods
       @access_token_methods ||= %i[
         from_bearer_authorization

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -287,11 +287,56 @@ RSpec.describe Doorkeeper::Config do
     it "can change the value" do
       Doorkeeper.configure do
         orm DOORKEEPER_ORM
-        client_credentials :from_digest, :from_params
+        client_credentials :from_basic
       end
 
       expect(config.client_credentials_methods)
-        .to eq(%i[from_digest from_params])
+        .to eq(%i[from_basic])
+    end
+  end
+
+  # Returns token endpoint auth methods based on client_credentials per
+  # https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#token-endpoint-auth-method
+  describe 'token_endpoint_auth_methods' do
+    it 'returns methods according to defaults' do
+      expect(config.client_credentials_methods).to eq(%i[from_basic from_params])
+      expect(config.token_endpoint_auth_methods).to contain_exactly('none', 'client_secret_post', 'client_secret_basic')
+    end
+
+    it "returns none even if no methods are configured" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        client_credentials
+      end
+
+      expect(config.client_credentials_methods)
+        .to eq([])
+
+      expect(config.token_endpoint_auth_methods).to contain_exactly('none')
+    end
+
+    it 'returns client_secret_post if configured' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        client_credentials :from_params
+      end
+
+      expect(config.client_credentials_methods)
+        .to eq(%i[from_params])
+
+      expect(config.token_endpoint_auth_methods).to contain_exactly('none', 'client_secret_post')
+    end
+
+    it 'returns client_secret_basic if configured' do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        client_credentials :from_basic
+      end
+
+      expect(config.client_credentials_methods)
+        .to eq(%i[from_basic])
+
+      expect(config.token_endpoint_auth_methods).to contain_exactly('none', 'client_secret_basic')
     end
   end
 


### PR DESCRIPTION
### Summary

Whilst getting back to Mastodon OAuth work, I remembered that we didn't have a method to retrieve the configured `token_endpoint_auth_methods` for OAuth Authorization Server Metadata ([RFC 8414](https://www.rfc-editor.org/rfc/rfc8414.html)), and we needed [to hard-code this](https://github.com/mastodon/mastodon/blob/main/app/presenters/oauth_metadata_presenter.rb#L63) in mastodon.

Having a helper to determine which client authentication methods are supported is helpful for implementing RFC 8414 (there's WIP for this in #1587 / PR #1737 )

Essentially the `client_credentials` option maps to `token_endpoint_auth_methods` in the OAuth Authorization Server Metadata  per the [IANA registry](https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#token-endpoint-auth-method) and the Dynamic Client Registration RFC (linked below)

I do note that this current implementation doesn't really support extensibility, even though additional methods like `private_key_jwt` have been registered.

(The dynamic client registration spec is the thing that actually defined `none`, `client_secret_basic`, and `client_secret_post` as methods: https://www.rfc-editor.org/rfc/rfc7591.html#section-2 )

### Other Information

I'm not sure if this documentation page is correct, which implies `client_credentials` option can be a proc/method: https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated

If that is the case, we may need an alternative mechanism for this.