### PR TITLE
Fix not null migration generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 Add your entry here.
+- [#1775] Fix Applications Secret Not Null Constraint generator
 
 ## 5.8.2
 
@@ -31,7 +32,7 @@ Add your entry here.
 - [#1712] Add `Pragma: no-cache` to token response
 - [#1726] Refactor token introspection class.
 - [#1727] Allow to set null secret value for Applications if they are public.
-- [#1735] Add `pkce_code_challenge_methods` config option. 
+- [#1735] Add `pkce_code_challenge_methods` config option.
 
 ## 5.7.1
 

--- a/lib/generators/doorkeeper/remove_applications_secret_not_null_constraint_generator.rb
+++ b/lib/generators/doorkeeper/remove_applications_secret_not_null_constraint_generator.rb
@@ -7,12 +7,12 @@ module Doorkeeper
   # Generates migration with which drops NOT NULL constraint and allows not
   # to bloat the database with redundant secret value.
   #
-  class RemoveApplicationSecretNotNullConstraint < ::Rails::Generators::Base
+  class RemoveApplicationsSecretNotNullConstraintGenerator < ::Rails::Generators::Base
     include ::Rails::Generators::Migration
     source_root File.expand_path("templates", __dir__)
     desc "Removes NOT NULL constraint for OAuth2 applications."
 
-    def enable_polymorphic_resource_owner
+    def remove_applications_secret_not_null_constraint
       migration_template(
         "remove_applications_secret_not_null_constraint.rb.erb",
         "db/migrate/remove_applications_secret_not_null_constraint.rb",

--- a/spec/generators/remove_applications_secret_not_null_constraint_generator_spec.rb
+++ b/spec/generators/remove_applications_secret_not_null_constraint_generator_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "generators/doorkeeper/remove_applications_secret_not_null_constraint_generator"
 
-RSpec.describe Doorkeeper::RemoveApplicationSecretNotNullConstraint do
+RSpec.describe Doorkeeper::RemoveApplicationsSecretNotNullConstraintGenerator do
   include GeneratorSpec::TestCase
 
   tests described_class


### PR DESCRIPTION
### Summary

The generator added in https://github.com/doorkeeper-gem/doorkeeper/pull/1727 wasn't named consistently with the other generators, and the method within the generator was misnamed, so it couldn't run. This normalizes the naming schema of the generator and allows it to function. 
