### PR TITLE
fix: ensure that token revocation is idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 Add your entry here.
 - [#1775] Fix Applications Secret Not Null Constraint generator
+- [TODO] Ensure that token revocation is idempotent by checking that that token has not already been revoked before revoking.
 
 ## 5.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ User-visible changes worth mentioning.
 
 Add your entry here.
 - [#1775] Fix Applications Secret Not Null Constraint generator
-- [TODO] Ensure that token revocation is idempotent by checking that that token has not already been revoked before revoking.
+- [#1778] Ensure that token revocation is idempotent by checking that that token has not already been revoked before revoking.
 
 ## 5.8.2
 

--- a/lib/doorkeeper/models/concerns/revocable.rb
+++ b/lib/doorkeeper/models/concerns/revocable.rb
@@ -9,6 +9,7 @@ module Doorkeeper
       # @param clock [Time] time object
       #
       def revoke(clock = Time)
+        return if revoked?
         update_attribute(:revoked_at, clock.now.utc)
       end
 

--- a/spec/lib/models/revocable_spec.rb
+++ b/spec/lib/models/revocable_spec.rb
@@ -10,11 +10,25 @@ RSpec.describe Doorkeeper::Models::Revocable do
   end
 
   describe "#revoke" do
+    let(:revoked_at) { nil }
+
+    before do
+      allow(fake_object).to receive(:revoked_at).and_return(revoked_at)
+    end
+
     it "updates :revoked_at attribute with current time" do
       utc = double utc: double
       clock = double now: utc
       expect(fake_object).to receive(:update_attribute).with(:revoked_at, clock.now.utc)
       fake_object.revoke(clock)
+    end
+
+    context "when the object is already revoked" do
+      let(:revoked_at) { Time.now.utc - 1000 }
+
+      it "does not update :revoked_at attribute" do
+        expect(fake_object).not_to receive(:update_attribute)
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

We were debugging an issue related to how we lock the access tokens table when we refresh an access token, and in this process, we found that revoking an access token is not idempotent. In the existing implementation, the `revoked_at` timestamp will continue to be updated each time `revoke!` is called on the same access token. Since a token can only be revoked once, this should be enforced in code.

