### PR TITLE
fix: only lock previous access token model if revoke_previous_refresh_token_on_use is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ User-visible changes worth mentioning.
 
 Add your entry here.
 - [#1775] Fix Applications Secret Not Null Constraint generator
-- [#1779] only lock previous access token model when creating a new token from its refresh token if revoke_previous_refresh_token_on_use is false
+- [#1779] Only lock previous access token model when creating a new token from its refresh token if revoke_previous_refresh_token_on_use is false
 - [#1778] Ensure that token revocation is idempotent by checking that that token has not already been revoked before revoking.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 Add your entry here.
 - [#1775] Fix Applications Secret Not Null Constraint generator
+- [#1779] only lock previous access token model when creating a new token from its refresh token if revoke_previous_refresh_token_on_use is false
 
 ## 5.8.2
 

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -34,7 +34,7 @@ module Doorkeeper
 
         if refresh_token_revoked_on_use?
           # No locking needed when refresh tokens are revoked on use
-          # because multiple refresh tokens can be created
+          # because multiple access tokens can be created
           create_access_token
         else
           # Use locking when refresh tokens are NOT revoked on use

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -30,12 +30,19 @@ module Doorkeeper
       end
 
       def before_successful_response
-        refresh_token.transaction do
-          refresh_token.lock!
-          raise Errors::InvalidGrantReuse if refresh_token.revoked?
+        raise Errors::InvalidGrantReuse if refresh_token.revoked?
 
-          refresh_token.revoke unless refresh_token_revoked_on_use?
+        if refresh_token_revoked_on_use?
+          # No locking needed when refresh tokens are revoked on use
+          # because multiple refresh tokens can be created
           create_access_token
+        else
+          # Use locking when refresh tokens are NOT revoked on use
+          # to prevent race conditions
+          refresh_token.with_lock do
+            refresh_token.revoke
+            create_access_token
+          end
         end
         super
       end

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -108,6 +108,11 @@ RSpec.describe Doorkeeper::OAuth::RefreshTokenRequest do
         client.access_tokens.max_by(&:created_at).previous_refresh_token,
       ).to eq(refresh_token.refresh_token)
     end
+
+    it "does not lock the previous token model" do
+      expect(refresh_token).not_to receive(:lock!)
+      request.authorize
+    end
   end
 
   context "with clientless access tokens" do


### PR DESCRIPTION
This PR resolves lock contention issues on the OAuth access tokens table when creating new access tokens from refresh tokens.

## Problem
We were experiencing database lock contention on our `access_tokens` table during token refresh operations because it was trying to acquire a lock while there was another process that had also acquired a lock on the table. While resolving this, we noticed that was that the default behaviour was to acquire a lock on the access token record, even when the revoke_previous_access_token_on_use configuration was set to true.

## Solution
When revoke_previous_access_token_on_use is enabled, we don't need to revoke the previous access token, which means we can safely allow multiple access tokens to exist simultaneously. This eliminates the need for table locking during token creation since there's no race condition to prevent.

This change formalizes the behavior where multiple access tokens can coexist when the revocation setting is disabled, removing unnecessary locking that was causing performance bottlenecks.

## Changes
Remove table locking during access token creation when revoke_previous_access_token_on_use is true
Allow concurrent token refresh operations without acquiring a lock
Maintain existing behavior for configurations where token revocation is required
