### PR TITLE
Remove obsolete post_install_message in gemspec

### DIFF
--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -34,18 +34,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "railties", ">= 5"
   gem.required_ruby_version = ">= 2.7"
 
-  gem.post_install_message = <<~MSG.strip
-    Starting from 5.5.0 RC1 Doorkeeper requires client authentication for Resource Owner Password Grant
-    as stated in the OAuth RFC. You have to create a new OAuth client (Doorkeeper::Application) if you didn't
-    have it before and use client credentials in HTTP Basic auth if you previously used this grant flow without
-    client authentication. 
-
-    To opt out of this you could set the "skip_client_authentication_for_password_grant" configuration option
-    to "true", but note that this is in violation of the OAuth spec and represents a security risk.
-
-    Read https://github.com/doorkeeper-gem/doorkeeper/issues/561#issuecomment-612857163 for more details.
-  MSG
-
   gem.add_development_dependency "appraisal"
   gem.add_development_dependency "capybara"
   gem.add_development_dependency "coveralls_reborn"


### PR DESCRIPTION
Hello there!

First of all, thank you for maintaining this great gem, it has been very helpful to out team.

I am opening this PR because I believe this post install message has been out there for enough time now for devs to notice it. This how it looks from my end: my team adopted this gem last year and this warning about a new default behavior introduced years ago does not provide any valuable information.

So maybe the time has come to remove that warning, and maybe release 6.0.0 to invite devs to checkout the changelog.

I could be missing some info, of course, so this need confirmation from a maintainer.

Thanks! :slightly_smiling_face: 