### PR TITLE
fix: changes regex for basic auth to be case-insensitive and adds tests for mixed case prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 Add your entry here.
+- [#1788] Fix regex for basic auth to be case-insensitive
 - [#1775] Fix Applications Secret Not Null Constraint generator
 - [#1779] Only lock previous access token model when creating a new token from its refresh token if revoke_previous_refresh_token_on_use is false
 - [#1778] Ensure that token revocation is idempotent by checking that that token has not already been revoked before revoking.

--- a/lib/doorkeeper/oauth/client/credentials.rb
+++ b/lib/doorkeeper/oauth/client/credentials.rb
@@ -19,7 +19,7 @@ module Doorkeeper
 
           def from_basic(request)
             authorization = request.authorization
-            if authorization.present? && authorization =~ /^Basic (.*)/m
+            if authorization.present? && authorization =~ /^Basic (.*)/im
               Base64.decode64(Regexp.last_match(1)).split(/:/, 2)
             end
           end

--- a/spec/lib/oauth/client/credentials_spec.rb
+++ b/spec/lib/oauth/client/credentials_spec.rb
@@ -85,6 +85,22 @@ class Doorkeeper::OAuth::Client
         expect(uid).to be_blank
         expect(secret).to be_blank
       end
+
+      it "decodes credentials with lowercase 'basic' prefix" do
+        request = double authorization: "basic #{credentials}"
+        uid, secret = described_class.from_basic(request)
+
+        expect(uid).to eq("some-uid")
+        expect(secret).to eq("some-secret")
+      end
+
+      it "decodes credentials with mixed case 'BaSiC' prefix" do
+        request = double authorization: "BaSiC #{credentials}"
+        uid, secret = described_class.from_basic(request)
+
+        expect(uid).to eq("some-uid")
+        expect(secret).to eq("some-secret")
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

The [RFC](https://www.rfc-editor.org/rfc/rfc7617.html) for `basic` authentication specifies that the "scheme" should be matched case-insensitively, so I changed the regex and added some specs.

### Other Information

N/A

