### PR TITLE
require pluginified versions of rubocop and its extensions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,11 @@
 inherit_from: .rubocop_todo.yml
 plugins:
+  - rubocop-capybara
+  - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
 AllCops:
   TargetRubyVersion: 3.1
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,12 @@ gem "rspec-rails", "~> 8.0"
 gem "rspec-support"
 
 gem "rubocop", "~> 1.72"
+gem "rubocop-capybara", "~> 2.22", require: false
+gem "rubocop-factory_bot", "~> 2.27", require: false
 gem "rubocop-performance", "~> 1.24", require: false
 gem "rubocop-rails", "~> 2.30", require: false
 gem "rubocop-rspec", "~> 3.5", require: false
+gem "rubocop-rspec_rails", "~> 2.31", require: false
 
 gem "bcrypt", "~> 3.1", require: false
 


### PR DESCRIPTION
### summary

switch all configs from `require:` to `plugins:` and raise minimum versions of `rubocop` and its extensions to the first pluginified release for each. 

add explicit dependencies for the `capybara`, `factory_bot`, and `rspec-rails` plugins that  have since been broken out of `rubocop-rspec`.

### other information

out of the box, bundle installing and running rubocop i get a slew of warnings:

```
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in ./.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in ./.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in ./.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```

and a fatal error:

```
Error: The `RSpec/FilePath` cop has been split into `RSpec/SpecFilePathFormat` and `RSpec/SpecFilePathSuffix`.
(obsolete configuration found in .rubocop.yml, please update it)
```

