### PR TITLE
add dpop (rfc 9449) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#1794] Add a minimally spec-compliant implementation of OAuth 2.0 Demonstrating Proof of Possession (DPoP, RFC 9449). DPoP is a sender-constraining mechanism that binds access tokens to a client's cryptographic key pair so an intercepted token is useless without the corresponding private key. Covers both halves of doorkeeper: issuing DPoP-bound access tokens (authorization server) and enforcing the key binding when authenticating (resource server). Fully opt-in — nothing changes for existing installations unless you run `rails generate doorkeeper:dpop` and migrate. Closes [#1655].
 - [#PR ID] Description of the change.
 
 ## 6.0.0.rc1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#1794] Add a minimally spec-compliant implementation of OAuth 2.0 Demonstrating Proof of Possession (DPoP, RFC 9449). DPoP is a sender-constraining mechanism that binds access tokens to a client's cryptographic key pair so an intercepted token is useless without the corresponding private key. Covers both halves of doorkeeper: issuing DPoP-bound access tokens (authorization server) and enforcing the key binding when authenticating (resource server). Fully opt-in — nothing changes for existing installations unless you run `rails generate doorkeeper:dpop` and migrate. Closes [#1655].
+- [#1794] Remove the private, undocumented `#config_methods` from `Helpers::Controller`. Overriding it in an engine controller (a subclass of `Doorkeeper::ApplicationMetalController` or `Doorkeeper::ApplicationController`) no longer changes the access token methods used by `doorkeeper_token`.
 - [#PR ID] Description of the change.
 
 ## 6.0.0.rc1

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Supported features:
 - [Resource Indicators](#resource-indicators)
 - [Custom Grant Flows](#custom-grant-flows)
 - [Custom Client Authentication Methods](#custom-client-authentication-methods)
+- [Demonstrating Proof of Possession (DPoP)](#demonstrating-proof-of-possession-dpop)
 - [Example Applications](#example-applications)
 - [Sponsors](#sponsors)
 - [Development](#development)
@@ -323,6 +324,116 @@ Two things are worth keeping in mind when writing one.
 
 Enabled methods are advertised in the authorization server metadata, so a registered method appears in `token_endpoint_auth_methods_supported` at `/.well-known/oauth-authorization-server` once `client_authentication` lists it.
 
+## Demonstrating Proof of Possession (DPoP)
+
+DPoP ([RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449)) is a sender-constraining mechanism that binds access tokens to a client's cryptographic key pair. Unlike a bearer token, possession of a DPoP-bound access token alone isn't enough to use it — the client must also prove possession of the corresponding private key. Doorkeeper covers both halves: issuing DPoP-bound access tokens (authorization server) and enforcing the key binding when authenticating (resource server).
+
+DPoP support is enabled by adding the `dpop_jkt` column to the access token model. Existing installations are unchanged unless you run `rails generate doorkeeper:dpop` and apply the generated migration. Once the column exists, Doorkeeper's built-in grant flows automatically honor valid DPoP proofs.
+
+DPoP proof validation requires the `jwt` gem. It is only required at runtime once DPoP is enabled.
+
+### Configuration
+
+DPoP is optional by default. When a client includes a valid DPoP proof in a token request, the issued access token is bound to that proof's public key. Bearer tokens continue to work for clients that don't use DPoP.
+
+To require DPoP for all token requests:
+
+```ruby
+Doorkeeper.configure do
+  force_dpop
+end
+```
+
+`force_dpop` applies when Doorkeeper acts as an authorization server. Requiring DPoP when accessing protected resources is configured separately; see [Protecting Resources](#protecting-resources) below.
+
+You can also configure the time window accepted for a proof's `iat` claim and the signature algorithms accepted for DPoP proofs:
+
+```ruby
+Doorkeeper.configure do
+  dpop_iat_leeway 300
+  dpop_signature_algorithms %w[ES256 PS256]
+end
+```
+
+When DPoP is supported, Doorkeeper automatically prepends `:from_dpop_authorization` to the default `access_token_methods`. If you've configured `access_token_methods` explicitly, add it yourself:
+
+```ruby
+access_token_methods :from_dpop_authorization,
+                     :from_bearer_authorization,
+                     :from_access_token_param,
+                     :from_bearer_param
+```
+
+### Limitations
+
+This is a minimally spec-compliant implementation. It intentionally omits a few optional parts of the spec:
+
+- No `jti` tracking to prevent DPoP proof replays (§11.1)
+- No server-provided nonces to prevent pre-generated proofs (§8)
+- No authorization code binding to a DPoP key (§10)
+
+The built-in grant flows validate DPoP proofs and use `BaseRequest#dpop_token_attributes` when binding newly issued tokens. `force_dpop` also uses `dpop_token_attributes` as a backstop to prevent those creation paths from issuing an unbound token.
+
+Custom grant flows need to account for both pieces themselves. In particular, a custom grant that calls `AccessToken.create_for` directly can bypass that backstop and issue Bearer tokens even when `force_dpop` is enabled.
+
+### Custom Grant Flows
+
+`Doorkeeper::Server` provides the request's DPoP proof as a `Doorkeeper::OAuth::DPoPProof`. The built-in `Doorkeeper::Request::*` strategies pass that proof to the `OAuth` request objects they construct. The built-in `OAuth` request classes validate the proof and use it when assembling the attributes for newly issued tokens.
+
+A [custom grant flow](#custom-grant-flows) should inject the proof in the same way. Building on the `SamlBearer` example above:
+
+```ruby
+module SamlBearer
+  class Strategy < Doorkeeper::Request::Strategy
+    delegate :client, :dpop_proof, :parameters, to: :server
+
+    def request
+      @request ||= TokenRequest.new(Doorkeeper.config, client, parameters).tap do |request|
+        request.dpop_proof = dpop_proof
+      end
+    end
+  end
+end
+```
+
+If the proof isn't injected, the flow can issue an unbound Bearer token when DPoP is optional, or reject the request under `force_dpop` even when the client supplied a valid proof.
+
+If your custom request subclasses `Doorkeeper::OAuth::BaseRequest`, add the DPoP validation explicitly to match the built-in flows:
+
+```ruby
+validate :dpop_proof, error: Doorkeeper::Errors::InvalidDPoPProof
+```
+
+Custom token creation should also use `dpop_token_attributes` when assembling the attributes passed to `AccessToken.create_for` so that it honors `force_dpop`.
+
+### Protecting Resources
+
+`Doorkeeper::OAuth::Token.authenticate` doesn't preserve enough context to enforce DPoP since it returns only the access token. Looking up a DPoP-bound token through the Bearer authentication scheme does not by itself enforce its sender constraint.
+
+A resource server needs to know which method extracted the token (i.e. whether it arrived under the `DPoP` scheme), and it needs the plaintext token to validate the DPoP proof's `ath` claim.
+
+In a Doorkeeper-aware controller, use the helper. `doorkeeper_authorize!` calls `valid_doorkeeper_token?`, which enforces the binding when necessary. Pass `dpop: :required` to also reject any token that isn't DPoP-bound:
+
+```ruby
+before_action { doorkeeper_authorize! :read, dpop: :required }
+```
+
+Elsewhere, resolve the token with `Doorkeeper::OAuth::Token.resolve` and validate the proof yourself. `resolve` returns a `Resolution(access_token_method, plaintext_token, access_token)` with the additional context needed to enforce DPoP:
+
+```ruby
+resolution = Doorkeeper::OAuth::Token.resolve(request, *Doorkeeper.config.access_token_methods)
+token = resolution&.access_token
+dpop_used = resolution&.access_token_method == :from_dpop_authorization
+
+if dpop_used || token&.uses_dpop?
+  proof = Doorkeeper::OAuth::DPoPProof.new(request, resolution.plaintext_token)
+
+  unless dpop_used && proof.valid? && token.dpop_binding_matches?(proof.jkt)
+    # refuse the request: a dpop-bound token was not presented with a valid proof
+  end
+end
+```
+
 ## Example Applications
 
 These applications show how Doorkeeper works and how to integrate with it. Start with the oAuth2 server and use the clients to connect with the server.
@@ -341,7 +452,7 @@ here](https://github.com/doorkeeper-gem/doorkeeper/wiki/Testing-your-provider-wi
 
 ## Sponsors
 
-[![OpenCollective](https://opencollective.com/doorkeeper-gem/backers/badge.svg)](#backers) 
+[![OpenCollective](https://opencollective.com/doorkeeper-gem/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/doorkeeper-gem/sponsors/badge.svg)](#sponsors)
 
 Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/doorkeeper-gem#sponsor)]

--- a/app/controllers/doorkeeper/token_info_controller.rb
+++ b/app/controllers/doorkeeper/token_info_controller.rb
@@ -2,6 +2,8 @@
 
 module Doorkeeper
   class TokenInfoController < Doorkeeper::ApplicationMetalController
+    include Doorkeeper::Rails::Helpers
+
     def show
       if doorkeeper_token&.accessible?
         render json: doorkeeper_token_to_json, status: :ok

--- a/app/controllers/doorkeeper/token_info_controller.rb
+++ b/app/controllers/doorkeeper/token_info_controller.rb
@@ -5,10 +5,10 @@ module Doorkeeper
     include Doorkeeper::Rails::Helpers
 
     def show
-      if doorkeeper_token&.accessible?
+      if doorkeeper_token&.accessible? && doorkeeper_token_dpop_binding_satisfied?
         render json: doorkeeper_token_to_json, status: :ok
       else
-        error = doorkeeper_token_error_response
+        error = doorkeeper_error
         response.headers.merge!(error.headers)
         render json: error_to_json(error), status: error.status
       end
@@ -22,18 +22,6 @@ module Doorkeeper
 
     def error_to_json(error)
       error.body
-    end
-
-    # RFC 6750 §3.1: transmitting the access token by more than one method is
-    # answered with invalid_request (400), not invalid_token (401). The helper
-    # answers nil for such a request and keeps the error, so the response is
-    # chosen here rather than by rescuing a raise.
-    def doorkeeper_token_error_response
-      if (error = @_doorkeeper_multiple_token_methods_error)
-        OAuth::InvalidRequestResponse.new(reason: error.reason)
-      else
-        OAuth::InvalidTokenResponse.new
-      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,6 +129,7 @@ en:
         invalid_token:
           revoked: "The access token was revoked"
           expired: "The access token expired"
+          invalid_dpop_key_binding: "Invalid DPoP key binding"
           unknown: "The access token is invalid"
         revoke:
           unauthorized: "You are not authorized to revoke this token"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,8 @@ en:
         forbidden_token:
           missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
 
+        invalid_dpop_proof: "Invalid DPoP proof"
+
     flash:
       applications:
         create:

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -22,6 +22,7 @@ gem "base64"
 gem "drb"
 gem "mutex_m"
 gem "concurrent-ruby", "1.3.4"
+gem "jwt", require: false
 
 gem "json", "< 3" # Active Support is not compatible with json 3 yet
 

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -18,6 +18,7 @@ gem "sprockets-rails"
 gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
+gem "jwt", require: false
 
 gem "json", "< 3" # Active Support is not compatible with json 3 yet
 

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -18,6 +18,7 @@ gem "sprockets-rails"
 gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
+gem "jwt", require: false
 
 gem "json", "< 3" # Active Support is not compatible with json 3 yet
 

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -18,6 +18,7 @@ gem "sprockets-rails"
 gem "sqlite3", "~> 2.3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
+gem "jwt", require: false
 
 gem "json", "< 3" # Active Support is not compatible with json 3 yet
 

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -18,5 +18,6 @@ gem "sprockets-rails"
 gem "sqlite3", "~> 2.3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
+gem "jwt", require: false
 
 gemspec path: "../"

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -53,6 +53,7 @@ module Doorkeeper
     autoload :DPoPProof, "doorkeeper/oauth/dpop_proof"
     autoload :ErrorResponse, "doorkeeper/oauth/error_response"
     autoload :Error, "doorkeeper/oauth/error"
+    autoload :InvalidDPoPProofResponse, "doorkeeper/oauth/invalid_dpop_proof_response"
     autoload :InvalidTokenResponse, "doorkeeper/oauth/invalid_token_response"
     autoload :InvalidRequestResponse, "doorkeeper/oauth/invalid_request_response"
     autoload :ForbiddenTokenResponse, "doorkeeper/oauth/forbidden_token_response"

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -100,6 +100,7 @@ module Doorkeeper
 
   module Models
     autoload :Accessible, "doorkeeper/models/concerns/accessible"
+    autoload :DPoP, "doorkeeper/models/concerns/dpop"
     autoload :Expirable, "doorkeeper/models/concerns/expirable"
     autoload :ExpirationTimeSqlMath, "doorkeeper/models/concerns/expiration_time_sql_math"
     autoload :Orderable, "doorkeeper/models/concerns/orderable"

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -50,6 +50,7 @@ module Doorkeeper
     autoload :Client, "doorkeeper/oauth/client"
     autoload :ClientCredentialsRequest, "doorkeeper/oauth/client_credentials_request"
     autoload :CodeRequest, "doorkeeper/oauth/code_request"
+    autoload :DPoPProof, "doorkeeper/oauth/dpop_proof"
     autoload :ErrorResponse, "doorkeeper/oauth/error_response"
     autoload :Error, "doorkeeper/oauth/error"
     autoload :InvalidTokenResponse, "doorkeeper/oauth/invalid_token_response"

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -182,6 +182,11 @@ module Doorkeeper
         @config.instance_variable_set(:@force_pkce, true)
       end
 
+      # Require all access token requests to include a DPoP proof (disabled by default)
+      def force_dpop
+        @config.instance_variable_set(:@force_dpop, true)
+      end
+
       # Validate the authorization request's client_id and redirect_uri before
       # authenticating the resource owner, so users are not sent through login
       # for a request that can only fail (disabled by default)
@@ -323,6 +328,8 @@ module Doorkeeper
     option :pkce_code_challenge_methods,    default: %w[plain S256]
     option :handle_auth_errors,             default: :render
     option :token_lookup_batch_size,        default: 10_000
+    option :dpop_iat_leeway,                default: 300
+    option :dpop_signature_algorithms,      default: %w[ES256 PS256]
     # Sets the token_reuse_limit
     # It will be used only when reuse_access_token option in enabled
     # By default it will be 100
@@ -636,6 +643,10 @@ module Doorkeeper
       option_set? :force_pkce
     end
 
+    def force_dpop?
+      option_set? :force_dpop
+    end
+
     def validate_client_before_resource_owner_authentication?
       option_set? :validate_client_before_resource_owner_authentication
     end
@@ -764,7 +775,7 @@ module Doorkeeper
         from_bearer_authorization
         from_access_token_param
         from_bearer_param
-      ]
+      ].tap { |it| it.prepend(:from_dpop_authorization) if access_token_model.dpop_supported? }
     end
 
     def enabled_grant_flows

--- a/lib/doorkeeper/config/validations.rb
+++ b/lib/doorkeeper/config/validations.rb
@@ -15,6 +15,7 @@ module Doorkeeper
         validate_token_reuse_limit
         validate_secret_strategies
         validate_pkce_code_challenge_methods
+        validate_dpop_signature_algorithms
         validate_custom_metadata
         validate_refresh_token_flow
         validate_issuer_format
@@ -150,6 +151,25 @@ module Doorkeeper
         )
 
         @pkce_code_challenge_methods = ["plain", "S256"]
+      end
+
+      def validate_dpop_signature_algorithms
+        return unless instance_variable_defined?(:@dpop_signature_algorithms)
+
+        algorithms = dpop_signature_algorithms.map(&:to_s)
+        allowed = Doorkeeper::OAuth::DPoPProof::ALLOWED_ALGORITHMS
+
+        if algorithms.any? && algorithms.all? { |algorithm| allowed.include?(algorithm) }
+          @dpop_signature_algorithms = algorithms
+          return
+        end
+
+        ::Rails.logger.warn(
+          "[DOORKEEPER] You have configured an invalid value for dpop_signature_algorithms option. " \
+          "Supported algorithms are #{allowed.join(", ")}. It will be set to default ['ES256', 'PS256'].",
+        )
+
+        @dpop_signature_algorithms = ["ES256", "PS256"]
       end
 
       def validate_custom_metadata

--- a/lib/doorkeeper/config/validations.rb
+++ b/lib/doorkeeper/config/validations.rb
@@ -19,6 +19,7 @@ module Doorkeeper
         validate_refresh_token_flow
         validate_issuer_format
         validate_issuer_metadata_discoverability
+        validate_force_dpop
       end
 
       private
@@ -242,6 +243,27 @@ module Doorkeeper
           "document. Use a host-only issuer, or route the derived well-known path " \
           "to Doorkeeper.",
         )
+      end
+
+      # Validate `force_dpop` should only be enabled if `access_token_model.dpop_supported?`.
+      # `force_dpop` is meant to guarantee only dpop tokens are issued, but that
+      # binding can only be stored once the `dpop_jkt` migration has been run.
+      # without the column, `BaseRequest#validate_dpop_proof` fails and every
+      # token request is rejected.
+      def validate_force_dpop
+        return unless force_dpop?
+        return if access_token_model.dpop_supported?
+
+        ::Rails.logger.warn(
+          "[DOORKEEPER] force_dpop is enabled but the #{access_token_model} model has no " \
+          "dpop_jkt column, so every token request will fail. Run the DPoP migration " \
+          "(rails generate doorkeeper:dpop) before enabling force_dpop, or disable force_dpop.",
+        )
+      rescue StandardError
+        # the schema may be unreadable during boot (before migrations run, or
+        # because there's no database connection). we cannot tell whether dpop
+        # is supported, so skip the advisory warning.
+        nil
       end
 
       # Redact any userinfo (e.g. a misconfigured user:pass@host) before the

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -103,6 +103,12 @@ module Doorkeeper
       end
     end
 
+    class InvalidDPoPProof < BaseResponseError
+      def self.name_for_response
+        :invalid_dpop_proof
+      end
+    end
+
     UnableToGenerateToken = Class.new(DoorkeeperError)
     TokenGeneratorNotFound = Class.new(DoorkeeperError)
     NoOrmCleaner = Class.new(DoorkeeperError)

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -163,5 +163,6 @@ module Doorkeeper
     TokenRevoked = Class.new(InvalidToken)
     TokenUnknown = Class.new(InvalidToken)
     TokenForbidden = Class.new(InvalidToken)
+    TokenInvalidDPoPKeyBinding = Class.new(InvalidToken)
   end
 end

--- a/lib/doorkeeper/grape/helpers.rb
+++ b/lib/doorkeeper/grape/helpers.rb
@@ -12,7 +12,7 @@ module Doorkeeper
       include Doorkeeper::Rails::Helpers
 
       # endpoint specific scopes > parameter scopes > default scopes
-      def doorkeeper_authorize!(*scopes)
+      def doorkeeper_authorize!(*scopes, dpop: nil)
         endpoint_scopes = endpoint.route_setting(:scopes) ||
                           endpoint.options[:route_options][:scopes]
 
@@ -22,7 +22,10 @@ module Doorkeeper
                    Doorkeeper::OAuth::Scopes.from_array(scopes)
                  end
 
-        super(*scopes)
+        endpoint_dpop = endpoint.route_setting(:dpop) ||
+                        endpoint.options[:route_options][:dpop]
+
+        super(*scopes, dpop: endpoint_dpop || dpop)
       end
 
       def doorkeeper_render_error_with(error)

--- a/lib/doorkeeper/grape/helpers.rb
+++ b/lib/doorkeeper/grape/helpers.rb
@@ -36,23 +36,7 @@ module Doorkeeper
         env["api.endpoint"]
       end
 
-      # Memoized with the same defined? guard as Rails::Helpers#doorkeeper_token:
-      # both a request without a usable token and a refused multi-method request
-      # leave @doorkeeper_token nil, which ||= would re-evaluate on every call —
-      # re-running authentication just to reach the same verdict again.
-      def doorkeeper_token
-        return @doorkeeper_token if defined?(@doorkeeper_token)
-
-        @doorkeeper_token = OAuth::Token.authenticate(
-          decorated_request,
-          *Doorkeeper.config.access_token_methods,
-        )
-      rescue Errors::MultipleAccessTokenMethods => e
-        @_doorkeeper_multiple_token_methods_error = e
-        @doorkeeper_token = nil
-      end
-
-      def decorated_request
+      def __doorkeeper_request__
         AuthorizationDecorator.new(request)
       end
 

--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -38,29 +38,6 @@ module Doorkeeper
         @server ||= Server.new(self)
       end
 
-      # :doc:
-      #
-      # Answers nil (not a raise) when the request transmits an access token
-      # by more than one method (RFC 6750 §2), the same token-or-nil contract
-      # Rails::Helpers#doorkeeper_token keeps. This is the doorkeeper_token a
-      # subclass of Doorkeeper::ApplicationController or
-      # Doorkeeper::ApplicationMetalController resolves to, so a raise here
-      # would turn doorkeeper_authorize! in such a controller into an
-      # unhandled 500. The error is kept so the response can still be the
-      # invalid_request (400) RFC 6750 §3.1 prescribes.
-      def doorkeeper_token
-        return @doorkeeper_token if defined?(@doorkeeper_token)
-
-        @doorkeeper_token ||= OAuth::Token.authenticate(request, *config_methods)
-      rescue Errors::MultipleAccessTokenMethods => e
-        @_doorkeeper_multiple_token_methods_error = e
-        @doorkeeper_token = nil
-      end
-
-      def config_methods
-        @config_methods ||= Doorkeeper.config.access_token_methods
-      end
-
       def get_error_response_from_exception(exception)
         if exception.respond_to?(:response)
           exception.response

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -15,6 +15,7 @@ module Doorkeeper
     include Models::ResourceOwnerable
     include Models::ExpirationTimeSqlMath
     include Models::Concerns::WriteToPrimary
+    include Models::DPoP
 
     module ClassMethods
       # Returns an instance of the Doorkeeper::AccessToken with
@@ -416,12 +417,14 @@ module Doorkeeper
       end
     end
 
-    # Access Token type: Bearer.
+    # Access Token type: Bearer or DPoP
+    #
     # @see https://datatracker.ietf.org/doc/html/rfc6750
     #   The OAuth 2.0 Authorization Framework: Bearer Token Usage
-    #
+    # @see https://datatracker.ietf.org/doc/html/rfc9449
+    #   OAuth 2.0 Demonstrating Proof of Possession (DPoP)
     def token_type
-      "Bearer"
+      uses_dpop? ? "DPoP" : "Bearer"
     end
 
     def use_refresh_token?

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -304,7 +304,8 @@ module Doorkeeper
             application, resource_owner, scopes, custom_attributes: custom_attributes, include_expired: false,
           ) do |token|
             refresh_token_matches?(token, token_attributes) &&
-              resource_indicators_match?(token, requested_resource)
+              resource_indicators_match?(token, requested_resource) &&
+              dpop_bindings_match?(token, token_attributes[:dpop_jkt])
           end
 
           return access_token if access_token&.reusable?

--- a/lib/doorkeeper/models/concerns/dpop.rb
+++ b/lib/doorkeeper/models/concerns/dpop.rb
@@ -13,6 +13,20 @@ module Doorkeeper
         def dpop_supported?
           column_names.include?("dpop_jkt")
         end
+
+        # RFC 9449: a reused token must carry the same sender constraint the
+        # request asked for. Handing a DPoP-bound token to a request with a
+        # different key makes it unusable, and handing an unbound one to a
+        # request that presented a proof silently drops the binding.
+        #
+        # @param token [Doorkeeper::AccessToken] existing token
+        # @param requested_jkt [String, nil] JWK SHA-256 thumbprint
+        # @return [Boolean]
+        def dpop_bindings_match?(token, requested_jkt)
+          return true unless dpop_supported?
+
+          token.dpop_jkt == requested_jkt
+        end
       end
 
       # Checks whether the token has been sender-constrained using DPoP. The token

--- a/lib/doorkeeper/models/concerns/dpop.rb
+++ b/lib/doorkeeper/models/concerns/dpop.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Models
+    module DPoP
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # Checks whether the token can be sender-constrained using DPoP.
+        #
+        # @see https://datatracker.ietf.org/doc/html/rfc9449
+        #   OAuth 2.0 Demonstrating Proof of Possession (DPoP)
+        def dpop_supported?
+          column_names.include?("dpop_jkt")
+        end
+      end
+
+      # Checks whether the token has been sender-constrained using DPoP. The token
+      # is never considered sender-constrained if the DPoP migration was not run.
+      #
+      # @see https://datatracker.ietf.org/doc/html/rfc9449
+      #   OAuth 2.0 Demonstrating Proof of Possession (DPoP)
+      def uses_dpop?
+        self.class.dpop_supported? && dpop_jkt.present?
+      end
+
+      # Checks whether the token is bound to the given DPoP key thumbprint (`jkt`).
+      #
+      # DPoP-bound (sender-constrained) access tokens are bound to a public key by its JWK
+      # SHA-256 thumbprint (`dpop_jkt`). This method returns `false` if the token is not DPoP-bound,
+      # otherwise it returns whether the token's stored thumbprint matches the provided `jkt`.
+      #
+      # @param jkt [String] The JWK SHA-256 thumbprint of the DPoP public key jkt
+      # @return [Boolean] True if the token is DPoP-bound and bound to the given `jkt`
+      def dpop_binding_matches?(jkt)
+        return false unless uses_dpop?
+        return false if jkt.blank?
+
+        ActiveSupport::SecurityUtils.secure_compare(dpop_jkt, jkt)
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -13,6 +13,7 @@ module Doorkeeper
       # the caller has proven possession of the code (redirect_uri + PKCE).
       validate :grant_accessible, error: Errors::InvalidGrant
       validate :resource_indicators, error: Errors::InvalidTarget
+      validate :dpop_proof, error: Errors::InvalidDPoPProof
 
       attr_reader :grant, :client, :redirect_uri, :access_token, :code_verifier,
                   :invalid_request_reason, :missing_param

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -5,9 +5,15 @@ module Doorkeeper
     class BaseRequest
       include Validations
 
+      attr_accessor :dpop_proof
       attr_reader :grant_type, :server
 
       delegate :default_scopes, to: :server
+
+      def self.inherited(subclass)
+        super
+        subclass.validate :dpop_proof, error: Errors::InvalidDPoPProof
+      end
 
       def authorize
         if valid?
@@ -39,7 +45,7 @@ module Doorkeeper
         }
 
         @access_token =
-          Doorkeeper.config.access_token_model.find_or_create_for(**token_attributes.merge(custom_attributes))
+          Doorkeeper.config.access_token_model.find_or_create_for(**token_attributes.merge(custom_attributes).merge(dpop_token_attributes))
       end
 
       def before_successful_response
@@ -61,6 +67,25 @@ module Doorkeeper
 
           client_scopes.common(default_scopes)
         end
+      end
+
+      def dpop_supported?
+        Doorkeeper.config.access_token_model.dpop_supported?
+      end
+
+      def dpop_token_attributes
+        return {} unless dpop_supported?
+
+        { dpop_jkt: dpop_proof&.jkt }.compact
+      end
+
+      def validate_dpop_proof
+        return false if !dpop_supported? &&  Doorkeeper.config.force_dpop?
+        return true  if !dpop_supported? && !Doorkeeper.config.force_dpop?
+
+        return true unless Doorkeeper.config.force_dpop? || dpop_proof.present?
+
+        dpop_proof.valid?
       end
     end
   end

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -85,7 +85,10 @@ module Doorkeeper
 
         return true unless Doorkeeper.config.force_dpop? || dpop_proof.present?
 
-        dpop_proof.valid?
+        # A third-party grant flow subclassing BaseRequest inherits this
+        # validation but never gets a proof injected, so `dpop_proof` can be nil
+        # under `force_dpop`. That's an invalid request, not a 500.
+        !!dpop_proof&.valid?
       end
     end
   end

--- a/lib/doorkeeper/oauth/base_request.rb
+++ b/lib/doorkeeper/oauth/base_request.rb
@@ -10,11 +10,6 @@ module Doorkeeper
 
       delegate :default_scopes, to: :server
 
-      def self.inherited(subclass)
-        super
-        subclass.validate :dpop_proof, error: Errors::InvalidDPoPProof
-      end
-
       def authorize
         if valid?
           before_successful_response
@@ -73,10 +68,26 @@ module Doorkeeper
         Doorkeeper.config.access_token_model.dpop_supported?
       end
 
-      def dpop_token_attributes
-        return {} unless dpop_supported?
+      def dpop_token_attributes(fallback_dpop_jkt: nil)
+        attributes = if dpop_supported?
+                       { dpop_jkt: dpop_proof&.jkt || fallback_dpop_jkt }.compact
+                     else
+                       {}
+                     end
 
-        { dpop_jkt: dpop_proof&.jkt }.compact
+        enforce_dpop_binding!(attributes)
+
+        attributes
+      end
+
+      def enforce_dpop_binding!(attributes)
+        return unless Doorkeeper.config.force_dpop?
+        return if attributes[:dpop_jkt].present?
+
+        ErrorResponse.new(
+          name: :invalid_dpop_proof,
+          exception_class: Errors::InvalidDPoPProof,
+        ).raise_exception!
       end
 
       def validate_dpop_proof

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -67,7 +67,10 @@ module Doorkeeper
             # because only the newest match is returned.
             Doorkeeper.config.access_token_model.resource_indicators_match?(
               token, attributes[:resource],
-            )
+            ) &&
+              Doorkeeper.config.access_token_model.dpop_bindings_match?(
+                token, attributes[:dpop_jkt],
+              )
           end
         end
       end

--- a/lib/doorkeeper/oauth/client_credentials_request.rb
+++ b/lib/doorkeeper/oauth/client_credentials_request.rb
@@ -35,8 +35,14 @@ module Doorkeeper
         )
       end
 
+      # The declared validations (DPoP proof, resource indicators) run first and
+      # short-circuit issuance: a request that fails one of them must never
+      # reach the creator.
       def validate
-        super && issuer.create(client, scopes, custom_token_attributes_with_data.merge(dpop_token_attributes))
+        super
+        return if @error
+
+        issuer.create(client, scopes, custom_token_attributes_with_data.merge(dpop_token_attributes))
       end
 
       private

--- a/lib/doorkeeper/oauth/client_credentials_request.rb
+++ b/lib/doorkeeper/oauth/client_credentials_request.rb
@@ -36,7 +36,7 @@ module Doorkeeper
       end
 
       def validate
-        super && issuer.create(client, scopes, custom_token_attributes_with_data)
+        super && issuer.create(client, scopes, custom_token_attributes_with_data.merge(dpop_token_attributes))
       end
 
       private

--- a/lib/doorkeeper/oauth/client_credentials_request.rb
+++ b/lib/doorkeeper/oauth/client_credentials_request.rb
@@ -3,6 +3,8 @@
 module Doorkeeper
   module OAuth
     class ClientCredentialsRequest < BaseRequest
+      validate :resource_indicators, error: Errors::InvalidTarget
+
       attr_reader :client, :original_scopes, :parameters, :response
 
       alias error_response response
@@ -23,7 +25,7 @@ module Doorkeeper
       end
 
       def error
-        @resource_indicator_error || issuer.error
+        @error || issuer.error
       end
 
       def issuer
@@ -33,11 +35,11 @@ module Doorkeeper
         )
       end
 
-      private
-
-      def valid?
-        validate_resource_indicators && issuer.create(client, scopes, custom_token_attributes_with_data)
+      def validate
+        super && issuer.create(client, scopes, custom_token_attributes_with_data)
       end
+
+      private
 
       def validate_resource_indicators
         validator = Doorkeeper.config.resource_indicator_validator
@@ -51,7 +53,6 @@ module Doorkeeper
         )
         true
       rescue Errors::InvalidTarget
-        @resource_indicator_error = Errors::InvalidTarget
         false
       end
 

--- a/lib/doorkeeper/oauth/client_credentials_request.rb
+++ b/lib/doorkeeper/oauth/client_credentials_request.rb
@@ -3,7 +3,9 @@
 module Doorkeeper
   module OAuth
     class ClientCredentialsRequest < BaseRequest
+      validate :client, error: Errors::InvalidClient
       validate :resource_indicators, error: Errors::InvalidTarget
+      validate :dpop_proof, error: Errors::InvalidDPoPProof
 
       attr_reader :client, :original_scopes, :parameters, :response
 
@@ -35,9 +37,9 @@ module Doorkeeper
         )
       end
 
-      # The declared validations (DPoP proof, resource indicators) run first and
-      # short-circuit issuance: a request that fails one of them must never
-      # reach the creator.
+      # The declared validations (client authentication, resource indicators,
+      # DPoP proof) run first and short-circuit issuance: a request that fails
+      # one of them must never reach the creator.
       def validate
         super
         return if @error
@@ -46,6 +48,10 @@ module Doorkeeper
       end
 
       private
+
+      def validate_client
+        client.present?
+      end
 
       def validate_resource_indicators
         validator = Doorkeeper.config.resource_indicator_validator

--- a/lib/doorkeeper/oauth/dpop_proof.rb
+++ b/lib/doorkeeper/oauth/dpop_proof.rb
@@ -69,7 +69,13 @@ module Doorkeeper
       end
 
       def jwk
-        @jwk ||= headers["jwk"] && JWT::JWK.import(headers["jwk"])
+        return @jwk if defined?(@jwk)
+
+        @jwk = headers["jwk"] && JWT::JWK.import(headers["jwk"])
+      rescue JWT::JWKError, TypeError
+        # `jwk` is attacker-controlled: anything that isn't an importable key
+        # is an invalid proof, not an exception.
+        @jwk = nil
       end
 
       def require_jwt!
@@ -103,7 +109,7 @@ module Doorkeeper
       end
 
       def validate_iat
-        claims["iat"].present? &&
+        claims["iat"].is_a?(Numeric) &&
           (claims["iat"] - Time.now.to_i).abs <= Doorkeeper.config.dpop_iat_leeway
       end
 

--- a/lib/doorkeeper/oauth/dpop_proof.rb
+++ b/lib/doorkeeper/oauth/dpop_proof.rb
@@ -3,6 +3,8 @@
 module Doorkeeper
   module OAuth
     class DPoPProof
+      ALLOWED_ALGORITHMS = %w[RS256 RS384 RS512 PS256 PS384 PS512 ES256 ES384 ES512].freeze
+
       include Validations
 
       validate :presence,          error: :blank
@@ -103,7 +105,8 @@ module Doorkeeper
       end
 
       def validate_signing_algorithm
-        Doorkeeper.config.dpop_signature_algorithms.include?(headers["alg"])
+        ALLOWED_ALGORITHMS.include?(headers["alg"]) &&
+          Doorkeeper.config.dpop_signature_algorithms.include?(headers["alg"])
       end
 
       def validate_jwk

--- a/lib/doorkeeper/oauth/dpop_proof.rb
+++ b/lib/doorkeeper/oauth/dpop_proof.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    class DPoPProof
+      include Validations
+
+      validate :presence,          error: :blank
+      validate :single_proof,      error: :multiple_dpop_proofs
+      validate :type,              error: :invalid_type
+      validate :signing_algorithm, error: :invalid_signing_algorithm
+      validate :jwk,               error: :invalid_jwk
+      validate :jti,               error: :invalid_jti
+      validate :iat,               error: :invalid_iat
+      validate :ath,               error: :invalid_ath
+      validate :htm,               error: :invalid_htm
+      validate :htu,               error: :invalid_htu
+      validate :signature,         error: :invalid_signature
+
+      delegate :blank?, to: :dpop
+
+      def initialize(request, access_token = nil)
+        @request = request
+        @access_token = access_token
+
+        @dpop = request.headers["DPoP"]
+      end
+
+      def validate
+        require_jwt!
+        super.tap { @valid = @error.nil? }
+      end
+
+      def valid?
+        return @valid if defined?(@valid)
+
+        super
+      end
+
+      def jkt
+        return nil unless valid?
+
+        @jkt ||= JWT::JWK::Thumbprint.new(jwk).generate
+      end
+
+      private
+
+      attr_reader :access_token, :dpop, :request
+
+      def claims
+        return @claims if defined?(@claims)
+
+        decode_without_verifying_signature
+        @claims
+      end
+
+      def headers
+        return @headers if defined?(@headers)
+
+        decode_without_verifying_signature
+        @headers
+      end
+
+      def decode_without_verifying_signature
+        @claims, @headers = JWT.decode(dpop, nil, false)
+      rescue JWT::DecodeError
+        @claims = {}
+        @headers = {}
+      end
+
+      def jwk
+        @jwk ||= headers["jwk"] && JWT::JWK.import(headers["jwk"])
+      end
+
+      def require_jwt!
+        require "jwt"
+      rescue LoadError
+        raise LoadError, "DPoP requires the 'jwt' gem (>= 2.7); add it to your Gemfile to use DPoP."
+      end
+
+      def validate_presence
+        present?
+      end
+
+      def validate_single_proof
+        dpop.split(",").size == 1 && dpop.split(";").size == 1
+      end
+
+      def validate_type
+        headers["typ"] == "dpop+jwt"
+      end
+
+      def validate_signing_algorithm
+        Doorkeeper.config.dpop_signature_algorithms.include?(headers["alg"])
+      end
+
+      def validate_jwk
+        jwk && !jwk.private?
+      end
+
+      def validate_jti
+        claims["jti"].is_a?(String) && claims["jti"].present?
+      end
+
+      def validate_iat
+        claims["iat"].present? &&
+          (claims["iat"] - Time.now.to_i).abs <= Doorkeeper.config.dpop_iat_leeway
+      end
+
+      def validate_ath
+        return true unless access_token
+
+        claims["ath"] == Base64.urlsafe_encode64(Digest::SHA256.digest(access_token), padding: false)
+      end
+
+      def validate_htm
+        claims["htm"] == request.request_method
+      end
+
+      def validate_htu
+        claims["htu"] == (request.base_url + request.path)
+      end
+
+      def validate_signature
+        JWT.decode(dpop, jwk.keypair, true, algorithms: [headers["alg"]])
+      rescue JWT::DecodeError, JWT::JWKError
+        false
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/dpop_proof.rb
+++ b/lib/doorkeeper/oauth/dpop_proof.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 module Doorkeeper
   module OAuth
     class DPoPProof
@@ -133,12 +135,24 @@ module Doorkeeper
       end
 
       def validate_htu
-        claims["htu"] == (request.base_url + request.path)
+        matches_ignoring_query_and_fragment?(request.url, claims["htu"])
       end
 
       def validate_signature
         ::JWT.decode(dpop, jwk.keypair, true, algorithms: [headers["alg"]])
       rescue ::JWT::DecodeError, ::JWT::JWKError
+        false
+      end
+
+      def matches_ignoring_query_and_fragment?(url, other_url)
+        url, other_url =
+          [URI.parse(url), URI.parse(other_url)].each do |u|
+            u.query = nil
+            u.fragment = nil
+          end
+
+        url == other_url
+      rescue URI::InvalidURIError
         false
       end
     end

--- a/lib/doorkeeper/oauth/dpop_proof.rb
+++ b/lib/doorkeeper/oauth/dpop_proof.rb
@@ -40,7 +40,7 @@ module Doorkeeper
       def jkt
         return nil unless valid?
 
-        @jkt ||= JWT::JWK::Thumbprint.new(jwk).generate
+        @jkt ||= ::JWT::JWK::Thumbprint.new(jwk).generate
       end
 
       private
@@ -62,14 +62,14 @@ module Doorkeeper
       end
 
       def decode_without_verifying_signature
-        claims, headers = JWT.decode(dpop, nil, false)
+        claims, headers = ::JWT.decode(dpop, nil, false)
 
         # A JWT segment only has to be valid JSON, so either half can decode to
         # an Array or a scalar. Anything but a Hash carries no claims we can
         # read, and indexing it would raise.
         @claims = claims.is_a?(Hash) ? claims : {}
         @headers = headers.is_a?(Hash) ? headers : {}
-      rescue JWT::DecodeError, TypeError
+      rescue ::JWT::DecodeError, TypeError
         @claims = {}
         @headers = {}
       end
@@ -77,8 +77,8 @@ module Doorkeeper
       def jwk
         return @jwk if defined?(@jwk)
 
-        @jwk = headers["jwk"] && JWT::JWK.import(headers["jwk"])
-      rescue JWT::JWKError, TypeError
+        @jwk = headers["jwk"] && ::JWT::JWK.import(headers["jwk"])
+      rescue ::JWT::JWKError, TypeError
         # `jwk` is attacker-controlled: anything that isn't an importable key
         # is an invalid proof, not an exception.
         @jwk = nil
@@ -134,8 +134,8 @@ module Doorkeeper
       end
 
       def validate_signature
-        JWT.decode(dpop, jwk.keypair, true, algorithms: [headers["alg"]])
-      rescue JWT::DecodeError, JWT::JWKError
+        ::JWT.decode(dpop, jwk.keypair, true, algorithms: [headers["alg"]])
+      rescue ::JWT::DecodeError, ::JWT::JWKError
         false
       end
     end

--- a/lib/doorkeeper/oauth/dpop_proof.rb
+++ b/lib/doorkeeper/oauth/dpop_proof.rb
@@ -23,7 +23,7 @@ module Doorkeeper
         @request = request
         @access_token = access_token
 
-        @dpop = request.headers["DPoP"]
+        @dpop = request.env["HTTP_DPOP"]
       end
 
       def validate

--- a/lib/doorkeeper/oauth/dpop_proof.rb
+++ b/lib/doorkeeper/oauth/dpop_proof.rb
@@ -62,8 +62,14 @@ module Doorkeeper
       end
 
       def decode_without_verifying_signature
-        @claims, @headers = JWT.decode(dpop, nil, false)
-      rescue JWT::DecodeError
+        claims, headers = JWT.decode(dpop, nil, false)
+
+        # A JWT segment only has to be valid JSON, so either half can decode to
+        # an Array or a scalar. Anything but a Hash carries no claims we can
+        # read, and indexing it would raise.
+        @claims = claims.is_a?(Hash) ? claims : {}
+        @headers = headers.is_a?(Hash) ? headers : {}
+      rescue JWT::DecodeError, TypeError
         @claims = {}
         @headers = {}
       end

--- a/lib/doorkeeper/oauth/dpop_proof.rb
+++ b/lib/doorkeeper/oauth/dpop_proof.rb
@@ -6,6 +6,7 @@ module Doorkeeper
   module OAuth
     class DPoPProof
       ALLOWED_ALGORITHMS = %w[RS256 RS384 RS512 PS256 PS384 PS512 ES256 ES384 ES512].freeze
+      MINIMUM_RSA_KEY_BITS = 2048
 
       include Validations
 
@@ -82,9 +83,9 @@ module Doorkeeper
         return @jwk if defined?(@jwk)
 
         @jwk = headers["jwk"] && ::JWT::JWK.import(headers["jwk"])
-      rescue ::JWT::JWKError, TypeError
-        # `jwk` is attacker-controlled: anything that isn't an importable key
-        # is an invalid proof, not an exception.
+        @jwk&.keypair # jwt < 3 defers parsing a `kid`-bearing key until first use, parse it now
+        @jwk
+      rescue ::JWT::DecodeError, OpenSSL::OpenSSLError, TypeError
         @jwk = nil
       end
 
@@ -112,7 +113,21 @@ module Doorkeeper
       end
 
       def validate_jwk
-        jwk && !jwk.private?
+        jwk && !jwk.private? && jwk_matches_signing_algorithm? && jwk_key_size_sufficient?
+      end
+
+      def jwk_matches_signing_algorithm?
+        case headers["alg"]
+        when /\A(?:RS|PS)/ then jwk.keypair.is_a?(OpenSSL::PKey::RSA)
+        when /\AES/        then jwk.keypair.is_a?(OpenSSL::PKey::EC)
+        else false
+        end
+      end
+
+      def jwk_key_size_sufficient?
+        return true unless jwk.keypair.is_a?(OpenSSL::PKey::RSA)
+
+        jwk.keypair.n.num_bits >= MINIMUM_RSA_KEY_BITS
       end
 
       def validate_jti
@@ -140,7 +155,7 @@ module Doorkeeper
 
       def validate_signature
         ::JWT.decode(dpop, jwk.keypair, true, algorithms: [headers["alg"]])
-      rescue ::JWT::DecodeError, ::JWT::JWKError
+      rescue ::JWT::DecodeError, OpenSSL::OpenSSLError
         false
       end
 

--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -34,6 +34,8 @@ module Doorkeeper
       delegate :name, :description, :state, to: :@error
 
       def initialize(attributes = {})
+        @access_token_method = attributes[:access_token_method]
+        @dpop = attributes[:dpop]
         @error = OAuth::Error.new(*attributes.values_at(:name, :state, :translate_options))
         @exception_class = attributes[:exception_class]
         @redirect_uri = attributes[:redirect_uri]
@@ -103,8 +105,24 @@ module Doorkeeper
 
       private
 
+      attr_reader :access_token_method, :dpop
+
       def authenticate_info
-        %(Bearer realm="#{realm}", error="#{sanitize_error_values(name)}", error_description="#{sanitize_error_values(description)}")
+        error_name = sanitize_error_values(name)
+        error_description = sanitize_error_values(description)
+
+        if dpop_required?
+          %(DPoP realm="#{realm}", error="#{error_name}", error_description="#{error_description}", algs="#{dpop_algs}")
+        elsif !dpop_supported?
+          %(Bearer realm="#{realm}", error="#{error_name}", error_description="#{error_description}")
+        elsif dpop_used_to_authenticate?
+          %(Bearer, DPoP realm="#{realm}", error="#{error_name}", error_description="#{error_description}", algs="#{dpop_algs}")
+        elsif access_token_method
+          %(Bearer realm="#{realm}", error="#{error_name}", error_description="#{error_description}", DPoP algs="#{dpop_algs}")
+        else
+          %(Bearer realm="#{realm}", error="#{error_name}", error_description="#{error_description}", ) +
+            %(DPoP realm="#{realm}", error="#{error_name}", error_description="#{error_description}", algs="#{dpop_algs}")
+        end
       end
 
       # This method removes any characters that are invalid in error
@@ -124,6 +142,22 @@ module Doorkeeper
             "_"
           end
         end.join("")
+      end
+
+      def dpop_algs
+        Doorkeeper.config.dpop_signature_algorithms.join(" ")
+      end
+
+      def dpop_required?
+        dpop == :required
+      end
+
+      def dpop_supported?
+        Doorkeeper.config.access_token_model.dpop_supported?
+      end
+
+      def dpop_used_to_authenticate?
+        access_token_method == :from_dpop_authorization
       end
     end
   end

--- a/lib/doorkeeper/oauth/invalid_dpop_proof_response.rb
+++ b/lib/doorkeeper/oauth/invalid_dpop_proof_response.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    class InvalidDPoPProofResponse < ErrorResponse
+      def initialize(attributes = {})
+        super(attributes.merge(name: :invalid_dpop_proof, state: :unauthorized))
+      end
+
+      def status
+        :unauthorized
+      end
+
+      def description
+        @description ||= I18n.translate(:invalid_dpop_proof, scope: %i[doorkeeper errors messages])
+      end
+
+      protected
+
+      def exception_class
+        Doorkeeper::Errors::InvalidDPoPProof
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/invalid_token_response.rb
+++ b/lib/doorkeeper/oauth/invalid_token_response.rb
@@ -10,6 +10,8 @@ module Doorkeeper
                    :revoked
                  elsif access_token&.expired?
                    :expired
+                 elsif access_token&.uses_dpop? && attributes[:access_token_method] == :from_dpop_authorization
+                   :invalid_dpop_key_binding
                  else
                    :unknown
                  end
@@ -46,6 +48,7 @@ module Doorkeeper
         {
           expired: Doorkeeper::Errors::TokenExpired,
           revoked: Doorkeeper::Errors::TokenRevoked,
+          invalid_dpop_key_binding: Doorkeeper::Errors::TokenInvalidDPoPKeyBinding,
           unknown: Doorkeeper::Errors::TokenUnknown,
         }
       end

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -10,6 +10,7 @@ module Doorkeeper
       validate :resource_owner, error: Errors::InvalidGrant
       validate :scopes, error: Errors::InvalidScope
       validate :resource_indicators, error: Errors::InvalidTarget
+      validate :dpop_proof, error: Errors::InvalidDPoPProof
 
       attr_reader :client, :credentials, :resource_owner, :parameters, :access_token
 

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -203,7 +203,10 @@ module Doorkeeper
           if client&.confidential
             dpop_proof.present? ? dpop_proof.valid? : true
           else
-            dpop_proof.valid? && refresh_token.dpop_binding_matches?(dpop_proof.jkt)
+            # Same reason as `BaseRequest#validate_dpop_proof`: a caller that
+            # builds this request itself never gets a proof injected, so nil
+            # must fail the validation rather than raise.
+            !!dpop_proof&.valid? && refresh_token.dpop_binding_matches?(dpop_proof.jkt)
           end
         else
           super

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -70,7 +70,7 @@ module Doorkeeper
       end
 
       def create_access_token
-        attributes = {}.merge(custom_token_attributes_with_data)
+        attributes = custom_token_attributes_with_data.merge(dpop_token_attributes)
 
         resource_owner =
           if Doorkeeper.config.polymorphic_resource_owner?
@@ -188,6 +188,26 @@ module Doorkeeper
           .with_indifferent_access
           .slice(*Doorkeeper.config.custom_access_token_attributes)
           .symbolize_keys
+      end
+
+      def dpop_token_attributes
+        if client&.confidential && refresh_token.uses_dpop?
+          { dpop_jkt: refresh_token.dpop_jkt }.merge(super)
+        else
+          super
+        end
+      end
+
+      def validate_dpop_proof
+        if refresh_token&.uses_dpop?
+          if client&.confidential
+            dpop_proof.present? ? dpop_proof.valid? : true
+          else
+            dpop_proof.valid? && refresh_token.dpop_binding_matches?(dpop_proof.jkt)
+          end
+        else
+          super
+        end
       end
     end
   end

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -11,6 +11,7 @@ module Doorkeeper
       validate :client_match, error: Errors::InvalidGrant
       validate :scope,        error: Errors::InvalidScope
       validate :resource_indicators, error: Errors::InvalidTarget
+      validate :dpop_proof, error: Errors::InvalidDPoPProof
 
       attr_reader :access_token, :client, :credentials, :refresh_token
       attr_reader :missing_param
@@ -192,7 +193,7 @@ module Doorkeeper
 
       def dpop_token_attributes
         if client&.confidential && refresh_token.uses_dpop?
-          { dpop_jkt: refresh_token.dpop_jkt }.merge(super)
+          super(fallback_dpop_jkt: refresh_token.dpop_jkt)
         else
           super
         end

--- a/lib/doorkeeper/oauth/token.rb
+++ b/lib/doorkeeper/oauth/token.rb
@@ -17,6 +17,8 @@ module Doorkeeper
         from_bearer_param: "bearer_token",
       }.freeze
 
+      Resolution = Struct.new(:access_token_method, :plaintext_token, :access_token)
+
       class << self
         # RFC 6750 §2: "Clients MUST NOT use more than one method to transmit
         # the token in each request", and §3.1 lists using more than one method
@@ -44,11 +46,7 @@ module Doorkeeper
         # exemption client authentication gives its legacy callable
         # extractors (Request#validate_client_authentication!).
         def from_request(request, *methods)
-          used = methods.sum do |method|
-            method.is_a?(Symbol) ? transmission_methods_used(request, method) : 0
-          end
-
-          raise Errors::MultipleAccessTokenMethods if used > 1
+          refuse_multiple_transmission_methods!(request, methods)
 
           methods.inject(nil) do |_, method|
             method = self.method(method) if method.is_a?(Symbol)
@@ -57,14 +55,27 @@ module Doorkeeper
           end
         end
 
-        def authenticate(request, *methods)
-          if (token = from_request(request, *methods))
+        # Resolves one method at a time, so the multi-method check has to run
+        # here across every configured method before any single one is read:
+        # inside from_request it would only ever see the one method it was
+        # handed and could never count two.
+        def resolve(request, *methods)
+          refuse_multiple_transmission_methods!(request, methods)
+
+          method, token = methods.lazy.map { |m| [m, from_request(request, m)] }.detect(&:last)
+
+          if token
             access_token = Doorkeeper.config.access_token_model.by_token(token)
             if access_token.present? && Doorkeeper.config.refresh_token_enabled?
               access_token.revoke_previous_refresh_token!
             end
-            access_token
           end
+
+          Resolution.new(method, token, access_token) if access_token
+        end
+
+        def authenticate(request, *methods)
+          resolve(request, *methods)&.access_token
         end
 
         def from_access_token_param(request)
@@ -94,6 +105,14 @@ module Doorkeeper
         end
 
         private
+
+        def refuse_multiple_transmission_methods!(request, methods)
+          used = methods.sum do |method|
+            method.is_a?(Symbol) ? transmission_methods_used(request, method) : 0
+          end
+
+          raise Errors::MultipleAccessTokenMethods if used > 1
+        end
 
         # How many transmission methods the given built-in extractor finds a
         # token in. Usually one, or none — but for the parameter extractors

--- a/lib/doorkeeper/oauth/token.rb
+++ b/lib/doorkeeper/oauth/token.rb
@@ -81,6 +81,12 @@ module Doorkeeper
           token_from_header(header, pattern) if match?(header, pattern)
         end
 
+        def from_dpop_authorization(request)
+          pattern = /^DPoP /i
+          header = request.authorization
+          token_from_header(header, pattern) if match?(header, pattern)
+        end
+
         def from_basic_authorization(request)
           pattern = /^Basic /i
           header = request.authorization

--- a/lib/doorkeeper/oauth/token.rb
+++ b/lib/doorkeeper/oauth/token.rb
@@ -63,12 +63,10 @@ module Doorkeeper
           refuse_multiple_transmission_methods!(request, methods)
 
           method, token = methods.lazy.map { |m| [m, from_request(request, m)] }.detect(&:last)
+          access_token = Doorkeeper.config.access_token_model.by_token(token) if token
 
-          if token
-            access_token = Doorkeeper.config.access_token_model.by_token(token)
-            if access_token.present? && Doorkeeper.config.refresh_token_enabled?
-              access_token.revoke_previous_refresh_token!
-            end
+          if access_token && Doorkeeper.config.refresh_token_enabled? && !access_token.uses_dpop?
+            access_token.revoke_previous_refresh_token!
           end
 
           Resolution.new(method, token, access_token) if access_token

--- a/lib/doorkeeper/oauth/token_introspection.rb
+++ b/lib/doorkeeper/oauth/token_introspection.rb
@@ -218,6 +218,7 @@ module Doorkeeper
 
       def valid_authorized_token?
         !authorized_token_matches_introspected? &&
+          !authorized_token.uses_dpop? &&
           authorized_token.accessible? &&
           token_introspection_allowed?(auth_token: authorized_token)
       end

--- a/lib/doorkeeper/oauth/token_introspection.rb
+++ b/lib/doorkeeper/oauth/token_introspection.rb
@@ -111,6 +111,8 @@ module Doorkeeper
           scope: @token.scopes_string,
           client_id: @token.try(:application).try(:uid),
           iat: @token.created_at.to_i,
+          # Section 6.2 of OAuth 2.0 Demonstrating Proof of Possession (DPoP) [RFC9449]
+          **(dpop_bound_token_presented? ? { cnf: { jkt: @token.dpop_jkt } } : {}),
         }
 
         # RFC 8707: include audience restriction when resource indicators are present
@@ -205,6 +207,13 @@ module Doorkeeper
 
       def refresh_token_presented?
         @token_type == :refresh_token
+      end
+
+      def dpop_bound_token_presented?
+        return false unless @token.uses_dpop?
+        return true unless refresh_token_presented?
+
+        !@token.try(:application)&.confidential?
       end
 
       def valid_authorized_token?

--- a/lib/doorkeeper/rails/helpers.rb
+++ b/lib/doorkeeper/rails/helpers.rb
@@ -93,12 +93,16 @@ module Doorkeeper
         return @doorkeeper_token if defined?(@doorkeeper_token)
 
         @doorkeeper_token = OAuth::Token.authenticate(
-          request,
+          __doorkeeper_request__,
           *Doorkeeper.config.access_token_methods,
         )
       rescue Errors::MultipleAccessTokenMethods => e
         @_doorkeeper_multiple_token_methods_error = e
         @doorkeeper_token = nil
+      end
+
+      def __doorkeeper_request__
+        request
       end
     end
   end

--- a/lib/doorkeeper/rails/helpers.rb
+++ b/lib/doorkeeper/rails/helpers.rb
@@ -3,8 +3,17 @@
 module Doorkeeper
   module Rails
     module Helpers
-      def doorkeeper_authorize!(*scopes)
+      def doorkeeper_authorize!(*scopes, dpop: nil)
+        unless dpop.nil? || dpop == :required
+          raise ArgumentError, "dpop must be `:required` or `nil`, got: `#{dpop.inspect}`"
+        end
+
         @_doorkeeper_scopes = scopes.presence || Doorkeeper.config.default_scopes
+        @_doorkeeper_dpop = if Doorkeeper.config.access_token_methods == %i[from_dpop_authorization]
+                              :required
+                            else
+                              dpop
+                            end
 
         doorkeeper_render_error unless valid_doorkeeper_token?
       end
@@ -16,7 +25,16 @@ module Doorkeeper
       def doorkeeper_bad_request_render_options(**); end
 
       def valid_doorkeeper_token?
-        doorkeeper_token&.acceptable?(@_doorkeeper_scopes)
+        doorkeeper_token&.acceptable?(@_doorkeeper_scopes) && doorkeeper_token_dpop_binding_satisfied?
+      end
+
+      def doorkeeper_token_dpop_binding_satisfied?
+        return false unless doorkeeper_token
+
+        dpop_used = doorkeeper_token_resolution&.access_token_method == :from_dpop_authorization
+        return true unless @_doorkeeper_dpop == :required || dpop_used || doorkeeper_token.uses_dpop?
+
+        dpop_used && doorkeeper_dpop_proof.valid? && doorkeeper_token.dpop_binding_matches?(doorkeeper_dpop_proof.jkt)
       end
 
       private
@@ -44,14 +62,24 @@ module Doorkeeper
       end
 
       def doorkeeper_error
+        error_attributes = {
+          access_token_method: doorkeeper_token_resolution&.access_token_method,
+          dpop: @_doorkeeper_dpop,
+        }
+
+        # The multi-method refusal is checked first: it leaves the resolution
+        # nil, so the DPoP predicate below cannot tell such a request apart
+        # from one that carried no token at all and would answer 401 for it.
         if @_doorkeeper_multiple_token_methods_error
           OAuth::InvalidRequestResponse.new(
             reason: @_doorkeeper_multiple_token_methods_error.reason,
           )
+        elsif doorkeeper_invalid_dpop_proof_response?
+          OAuth::InvalidDPoPProofResponse.new(error_attributes)
         elsif doorkeeper_invalid_token_response?
-          OAuth::InvalidTokenResponse.from_access_token(doorkeeper_token)
+          OAuth::InvalidTokenResponse.from_access_token(doorkeeper_token, error_attributes)
         else
-          OAuth::ForbiddenTokenResponse.from_scopes(@_doorkeeper_scopes)
+          OAuth::ForbiddenTokenResponse.from_scopes(@_doorkeeper_scopes, error_attributes)
         end
       end
 
@@ -81,24 +109,46 @@ module Doorkeeper
       end
 
       def doorkeeper_invalid_token_response?
-        !doorkeeper_token || !doorkeeper_token.accessible?
+        !doorkeeper_token || !doorkeeper_token.accessible? || !doorkeeper_token_dpop_binding_satisfied?
       end
 
-      # Answers nil (not a raise) when the request transmits an access token
-      # by more than one method, so host code that consults doorkeeper_token
-      # directly keeps its token-or-nil contract; doorkeeper_authorize! then
-      # renders the invalid_request (400) response RFC 6750 §3.1 prescribes
-      # instead of invalid_token, via doorkeeper_error above.
+      def doorkeeper_invalid_dpop_proof_response?
+        doorkeeper_token_resolution&.access_token_method == :from_dpop_authorization && !doorkeeper_dpop_proof.valid?
+      end
+
+      def doorkeeper_dpop_proof
+        @doorkeeper_dpop_proof ||=
+          OAuth::DPoPProof.new(__doorkeeper_request__, doorkeeper_token_resolution.plaintext_token)
+      end
+
       def doorkeeper_token
         return @doorkeeper_token if defined?(@doorkeeper_token)
 
-        @doorkeeper_token = OAuth::Token.authenticate(
-          __doorkeeper_request__,
-          *Doorkeeper.config.access_token_methods,
-        )
+        @doorkeeper_token = doorkeeper_token_resolution&.access_token
+
+        if @doorkeeper_token&.uses_dpop? &&
+           Doorkeeper.config.refresh_token_enabled? &&
+           doorkeeper_token_dpop_binding_satisfied?
+
+          @doorkeeper_token.revoke_previous_refresh_token!
+        end
+
+        @doorkeeper_token
+      end
+
+      # Answers nil (not a raise) when the request transmits an access token
+      # by more than one method, so doorkeeper_token keeps its token-or-nil
+      # contract for host code that consults it directly; doorkeeper_authorize!
+      # then renders the invalid_request (400) response RFC 6750 §3.1
+      # prescribes instead of invalid_token, via doorkeeper_error above.
+      def doorkeeper_token_resolution
+        return @doorkeeper_token_resolution if defined?(@doorkeeper_token_resolution)
+
+        @doorkeeper_token_resolution =
+          OAuth::Token.resolve(__doorkeeper_request__, *Doorkeeper.config.access_token_methods)
       rescue Errors::MultipleAccessTokenMethods => e
         @_doorkeeper_multiple_token_methods_error = e
-        @doorkeeper_token = nil
+        @doorkeeper_token_resolution = nil
       end
 
       def __doorkeeper_request__

--- a/lib/doorkeeper/request/authorization_code.rb
+++ b/lib/doorkeeper/request/authorization_code.rb
@@ -3,7 +3,7 @@
 module Doorkeeper
   module Request
     class AuthorizationCode < Strategy
-      delegate :client, :parameters, to: :server
+      delegate :client, :dpop_proof, :parameters, to: :server
 
       def request
         @request ||= OAuth::AuthorizationCodeRequest.new(
@@ -11,7 +11,7 @@ module Doorkeeper
           grant,
           client,
           parameters,
-        )
+        ).tap { |request| request.dpop_proof = dpop_proof }
       end
 
       private

--- a/lib/doorkeeper/request/client_credentials.rb
+++ b/lib/doorkeeper/request/client_credentials.rb
@@ -3,14 +3,14 @@
 module Doorkeeper
   module Request
     class ClientCredentials < Strategy
-      delegate :client, :parameters, to: :server
+      delegate :client, :dpop_proof, :parameters, to: :server
 
       def request
         @request ||= OAuth::ClientCredentialsRequest.new(
           Doorkeeper.config,
           client,
           parameters,
-        )
+        ).tap { |request| request.dpop_proof = dpop_proof }
       end
     end
   end

--- a/lib/doorkeeper/request/password.rb
+++ b/lib/doorkeeper/request/password.rb
@@ -3,7 +3,7 @@
 module Doorkeeper
   module Request
     class Password < Strategy
-      delegate :credentials, :resource_owner, :parameters, :client, to: :server
+      delegate :credentials, :resource_owner, :dpop_proof, :parameters, :client, to: :server
 
       def request
         @request ||= OAuth::PasswordAccessTokenRequest.new(
@@ -12,7 +12,7 @@ module Doorkeeper
           credentials,
           resource_owner,
           parameters,
-        )
+        ).tap { |request| request.dpop_proof = dpop_proof }
       end
     end
   end

--- a/lib/doorkeeper/request/refresh_token.rb
+++ b/lib/doorkeeper/request/refresh_token.rb
@@ -3,7 +3,7 @@
 module Doorkeeper
   module Request
     class RefreshToken < Strategy
-      delegate :credentials, :parameters, to: :server
+      delegate :credentials, :dpop_proof, :parameters, to: :server
 
       def refresh_token
         Doorkeeper.config.access_token_model.by_refresh_token(parameters[:refresh_token])
@@ -15,7 +15,7 @@ module Doorkeeper
           refresh_token,
           credentials,
           parameters,
-        )
+        ).tap { |request| request.dpop_proof = dpop_proof }
       end
     end
   end

--- a/lib/doorkeeper/server.rb
+++ b/lib/doorkeeper/server.rb
@@ -43,5 +43,11 @@ module Doorkeeper
     def credentials
       @credentials ||= client_authentication_method_for_request.authenticate(context.request)
     end
+
+    def dpop_proof
+      return unless Doorkeeper.config.access_token_model.dpop_supported? || Doorkeeper.config.force_dpop?
+
+      @dpop_proof ||= OAuth::DPoPProof.new(context.request)
+    end
   end
 end

--- a/lib/doorkeeper/validations.rb
+++ b/lib/doorkeeper/validations.rb
@@ -17,7 +17,7 @@ module Doorkeeper
 
     def valid?
       validate
-      @error.nil?
+      error.nil?
     end
 
     module ClassMethods

--- a/lib/generators/doorkeeper/dpop_generator.rb
+++ b/lib/generators/doorkeeper/dpop_generator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Doorkeeper
+  # Generates migration with DPOP required database column for
+  # Doorkeeper access token table.
+  #
+  class DpopGenerator < ::Rails::Generators::Base
+    include ::Rails::Generators::Migration
+    source_root File.expand_path("templates", __dir__)
+    desc "Provide support for DPoP."
+
+    def dpop
+      migration_template(
+        "enable_dpop_migration.rb.erb",
+        "db/migrate/enable_dpop.rb",
+        migration_version: migration_version,
+      )
+    end
+
+    def instructions
+      say %(Add `gem "jwt", ">= 2.7"` to your Gemfile before using DPoP.)
+    end
+
+    def self.next_migration_number(dirname)
+      ActiveRecord::Generators::Base.next_migration_number(dirname)
+    end
+
+    private
+
+    def migration_version
+      "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+    end
+  end
+end

--- a/lib/generators/doorkeeper/templates/enable_dpop_migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/enable_dpop_migration.rb.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class EnableDpop < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_column :oauth_access_tokens, :dpop_jkt, :string, null: true
+  end
+end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -753,7 +753,9 @@ Doorkeeper.configure do
   # dpop_iat_leeway 300
   #
   # Asymmetric JWS algorithms accepted for DPoP proof signatures.
-  # Defaults to %w[ES256 PS256].
+  # Defaults to %w[ES256 PS256]. Must be a subset of the algorithms supported by
+  # Doorkeeper: RS256/384/512, PS256/384/512, and ES256/384/512. Unsupported
+  # values are rejected and the default is used instead.
   #
   # dpop_signature_algorithms %w[ES256 PS256]
 end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -745,6 +745,11 @@ Doorkeeper.configure do
   # enforcement is configured separately via `access_token_methods` or
   # `doorkeeper_authorize!(dpop: :required)`.
   #
+  # This only covers tokens issued through `find_or_create_access_token` /
+  # `dpop_token_attributes` (every built-in grant, plus custom grants that use
+  # them). A custom grant that calls `AccessToken.create_for` directly bypasses
+  # the check and can still issue Bearer tokens.
+  #
   # force_dpop
   #
   # Clock skew, in seconds, tolerated when validating a proof's `iat` claim.

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -708,4 +708,52 @@ Doorkeeper.configure do
   #   allowed = %w[https://api.example.com/ https://calendar.example.com/]
   #   resource_indicators.all? { |r| allowed.include?(r) }
   # }
+
+  # OAuth 2.0 Demonstrating Proof of Possession (DPoP) (RFC 9449)
+  #
+  # DPoP is a sender-constraining mechanism that binds access tokens to a
+  # client's cryptographic key pair. Unlike a bearer token, possession of a
+  # DPoP-bound access token alone isn't enough to use it -- the client must also
+  # prove possession of the corresponding private key. Doorkeeper covers both
+  # halves: issuing DPoP-bound access tokens (authorization server) and
+  # enforcing the key binding when authenticating (resource server).
+  #
+  # This is a minimally spec-compliant implementation. It intentionally omits a
+  # few optional parts of the spec:
+  #   - no `jti` tracking to prevent DPoP proof replays (section 11.1)
+  #   - no server-provided nonces to prevent pre-generated proofs (section 8)
+  #   - no authorization code binding to a DPoP key (section 10)
+  #
+  # DPoP support is enabled by adding the `dpop_jkt` column to the access token
+  # model. Existing installations are unchanged unless you run
+  # `rails generate doorkeeper:dpop` and apply the generated migration. Once
+  # the column exists, Doorkeeper's built-in grant flows automatically honor
+  # valid DPoP proofs.; the options below only customize or require that behavior.
+  #
+  # DPoP proof validation requires the `jwt` gem. It is only required at runtime
+  # once DPoP is enabled.
+  #
+  # Resource-server enforcement works by prepending `:from_dpop_authorization`
+  # to `access_token_methods`. Doorkeeper does this automatically only when
+  # you rely on the default `access_token_methods`. If you set that option
+  # explicitly (see above), you must prepend `:from_dpop_authorization`
+  # yourself.
+  #
+  # Require every token request to include a valid DPoP proof, ensuring newly
+  # issued access tokens are DPoP-bound (disabled by default). This applies
+  # when Doorkeeper acts as an authorization server. Resource-server
+  # enforcement is configured separately via `access_token_methods` or
+  # `doorkeeper_authorize!(dpop: :required)`.
+  #
+  # force_dpop
+  #
+  # Clock skew, in seconds, tolerated when validating a proof's `iat` claim.
+  # Defaults to 300.
+  #
+  # dpop_iat_leeway 300
+  #
+  # Asymmetric JWS algorithms accepted for DPoP proof signatures.
+  # Defaults to %w[ES256 PS256].
+  #
+  # dpop_signature_algorithms %w[ES256 PS256]
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -53,4 +53,6 @@ RSpec.describe Doorkeeper::ApplicationController, type: :controller do
       expect(response.body).to include("owner-sentinel")
     end
   end
+
+  include_examples "enforcing proof of possession using dpop"
 end

--- a/spec/controllers/application_metal_controller_spec.rb
+++ b/spec/controllers/application_metal_controller_spec.rb
@@ -100,4 +100,6 @@ RSpec.describe Doorkeeper::ApplicationMetalController, type: :controller do
       end
     end
   end
+
+  include_examples "enforcing proof of possession using dpop"
 end

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -629,5 +629,65 @@ RSpec.describe "doorkeeper authorize filter" do
     end
   end
 
+  # RFC 6750 §2 applies to the DPoP scheme as it does to Bearer: a token in
+  # the DPoP Authorization header plus one in a request parameter is two
+  # transmission methods, and is refused with invalid_request (400) before
+  # the proof is ever examined. The helpers resolve the token through
+  # OAuth::Token.resolve, so this pins that the check runs on that path too.
+  context "when a dpop token is also transmitted by a second method", token: :dpop do
+    controller do
+      before_action :doorkeeper_authorize!
+      include ControllerActions
+    end
+
+    def valid_proof
+      build_dpop_proof(
+        ath: Base64.urlsafe_encode64(Digest::SHA256.digest(token_string), padding: false),
+        htm: "GET",
+        htu: "http://test.host/anonymous",
+        signing_key: signing_key,
+      )
+    end
+
+    it "accepts the dpop scheme with a valid proof on its own" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = valid_proof
+      get :index
+
+      expect(response).to be_successful
+    end
+
+    it "refuses the request with invalid_request when a parameter carries another token" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = valid_proof
+      get :index, params: { access_token: "another-token" }
+
+      expect(response.status).to eq 400
+      expect(response.header["WWW-Authenticate"]).to include('error="invalid_request"')
+    end
+
+    it "refuses the same token repeated in the dpop scheme and a parameter" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = valid_proof
+      get :index, params: { access_token: token_string }
+
+      expect(response.status).to eq 400
+      expect(response.header["WWW-Authenticate"]).to include('error="invalid_request"')
+    end
+
+    it "renders through the bad request hook rather than the unauthorized one" do
+      expect(controller).to receive(:doorkeeper_bad_request_render_options)
+        .with(error: an_instance_of(Doorkeeper::OAuth::InvalidRequestResponse))
+        .and_call_original
+      expect(controller).not_to receive(:doorkeeper_unauthorized_render_options)
+
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = valid_proof
+      get :index, params: { access_token: "another-token" }
+
+      expect(response.status).to eq 400
+    end
+  end
+
   include_examples "enforcing proof of possession using dpop"
 end

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "doorkeeper authorize filter" do
         Doorkeeper::AccessToken,
         acceptable?: true, previous_refresh_token: "",
         revoke_previous_refresh_token!: true,
+        uses_dpop?: false,
       )
     end
 
@@ -156,6 +157,7 @@ RSpec.describe "doorkeeper authorize filter" do
         accessible?: true, scopes: %w[write public],
         previous_refresh_token: "",
         revoke_previous_refresh_token!: true,
+        uses_dpop?: false,
       )
       expect(token).to receive(:acceptable?).with([:write]).and_return(true)
       expect(
@@ -172,6 +174,7 @@ RSpec.describe "doorkeeper authorize filter" do
         accessible?: true, scopes: ["public"], revoked?: false,
         expired?: false, previous_refresh_token: "",
         revoke_previous_refresh_token!: true,
+        uses_dpop?: false,
       )
       expect(
         Doorkeeper::AccessToken,
@@ -302,6 +305,7 @@ RSpec.describe "doorkeeper authorize filter" do
         accessible?: true, scopes: ["public"], revoked?: false,
         expired?: false, previous_refresh_token: "",
         revoke_previous_refresh_token!: true,
+        uses_dpop?: false,
       )
     end
 
@@ -508,10 +512,122 @@ RSpec.describe "doorkeeper authorize filter" do
       end
     end
 
+    context "when token has mismatched public keys" do
+      it "raises Doorkeeper::Errors::TokenInvalidDPoPKeyBinding exception", token: :dpop do
+        expect do
+          @request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+          @request.env["HTTP_DPOP"] =
+            build_dpop_proof(
+              ath: Base64.urlsafe_encode64(Digest::SHA256.digest(token_string), padding: false),
+              htm: "GET",
+              htu: "http://test.host/anonymous",
+              signing_key: OpenSSL::PKey::EC.generate("prime256v1"),
+            )
+          get :index
+        end.to raise_error(Doorkeeper::Errors::TokenInvalidDPoPKeyBinding)
+      end
+    end
+
+    context "when the dpop proof is invalid" do
+      it "raises Doorkeeper::Errors::InvalidDPoPProof exception", token: :dpop do
+        expect do
+          @request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+          @request.env["HTTP_DPOP"] =
+            build_dpop_proof(
+              ath: Base64.urlsafe_encode64(Digest::SHA256.digest(token_string), padding: false),
+              htm: "WRONG",
+              htu: "http://test.host/anonymous",
+              signing_key: signing_key,
+            )
+          get :index
+        end.to raise_error(Doorkeeper::Errors::InvalidDPoPProof)
+      end
+    end
+
     context "when token is valid" do
       it "allows into index action", token: :valid do
         expect(response).to be_successful
       end
     end
   end
+
+  context "when given an invalid dpop option" do
+    controller do
+      before_action { doorkeeper_authorize!(dpop: :invalid) }
+
+      include ControllerActions
+    end
+
+    it "raises an ArgumentError" do
+      expect { get :index }.to raise_error(
+        ArgumentError, "dpop must be `:required` or `nil`, got: `:invalid`",
+      )
+    end
+  end
+
+  context "when refresh tokens are revoked on use for a dpop token", token: :dpop do
+    before { config_is_set(:refresh_token_enabled, true) }
+
+    controller do
+      before_action :doorkeeper_authorize!
+      include ControllerActions
+    end
+
+    def valid_proof(htm: "GET")
+      build_dpop_proof(
+        ath: Base64.urlsafe_encode64(Digest::SHA256.digest(token_string), padding: false),
+        htm: htm,
+        htu: "http://test.host/anonymous",
+        signing_key: signing_key,
+      )
+    end
+
+    it "revokes the previous refresh token once a valid proof is presented" do
+      expect(token).to receive(:revoke_previous_refresh_token!)
+
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = valid_proof
+      get :index
+
+      expect(response).to be_successful
+    end
+
+    it "does not revoke when the dpop token is presented as a bearer token" do
+      expect(token).not_to receive(:revoke_previous_refresh_token!)
+
+      request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
+      get :index
+
+      expect(response).to be_unauthorized
+    end
+
+    it "does not revoke when the dpop proof is invalid" do
+      expect(token).not_to receive(:revoke_previous_refresh_token!)
+
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = valid_proof(htm: "X")
+      get :index
+
+      expect(response).to be_unauthorized
+    end
+
+    context "when the request fails the scope check" do
+      controller do
+        before_action { doorkeeper_authorize! :admin }
+        include ControllerActions
+      end
+
+      it "still revokes on a valid proof" do
+        expect(token).to receive(:revoke_previous_refresh_token!)
+
+        request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+        request.env["HTTP_DPOP"] = valid_proof
+        get :index
+
+        expect(response).to be_forbidden
+      end
+    end
+  end
+
+  include_examples "enforcing proof of possession using dpop"
 end

--- a/spec/controllers/token_info_controller_spec.rb
+++ b/spec/controllers/token_info_controller_spec.rb
@@ -73,4 +73,102 @@ RSpec.describe Doorkeeper::TokenInfoController, type: :controller do
       end
     end
   end
+
+  context "when using dpop", token: :dpop do
+    def build_dpop_proof(ath: Base64.urlsafe_encode64(Digest::SHA256.digest(token_string), padding: false),
+                         htm: "GET",
+                         htu: "http://test.host/oauth/token/info",
+                         signing_key: self.signing_key)
+      super
+    end
+
+    it "responds with token info for a valid dpop proof" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = build_dpop_proof
+      get :show
+
+      expect(response.status).to eq 200
+      expect(response.body).to eq(token.to_json)
+    end
+
+    it "rejects an invalid dpop proof with incorrect request details" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = build_dpop_proof(htu: "http://test.host/oauth/token")
+      get :show
+
+      expect(response.status).to eq 401
+      expect(response.body).to eq(Doorkeeper::OAuth::InvalidDPoPProofResponse.new.body.to_json)
+    end
+
+    it "rejects an invalid dpop proof with ath claim" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = build_dpop_proof(ath: "X")
+      get :show
+
+      expect(response.status).to eq 401
+      expect(response.body).to eq(Doorkeeper::OAuth::InvalidDPoPProofResponse.new.body.to_json)
+    end
+
+    it "rejects an invalid dpop proof with mismatched public keys" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = build_dpop_proof(signing_key: OpenSSL::PKey::EC.generate("prime256v1"))
+      get :show
+
+      expect(response.status).to eq 401
+      expect(response.body).to eq(
+        Doorkeeper::OAuth::InvalidTokenResponse.from_access_token(
+          token, access_token_method: :from_dpop_authorization,
+        ).body.to_json,
+      )
+    end
+
+    it "rejects a dpop token received as a bearer token" do
+      request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
+      get :show
+
+      expect(response.status).to eq 401
+      expect(response.body).to eq(Doorkeeper::OAuth::InvalidTokenResponse.new.body.to_json)
+    end
+
+    it "rejects a bearer token received as a dpop token", token: :valid do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      get :show
+
+      expect(response.status).to eq 401
+      expect(response.body).to eq(Doorkeeper::OAuth::InvalidDPoPProofResponse.new.body.to_json)
+    end
+
+    it "rejects an empty dpop proof" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      get :show
+
+      expect(response.status).to eq 401
+      expect(response.body).to eq(Doorkeeper::OAuth::InvalidDPoPProofResponse.new.body.to_json)
+    end
+
+    it "rejects an unknown token presented via dpop with a bad proof as invalid_token" do
+      allow(Doorkeeper::AccessToken).to receive(:by_token).with(token_string).and_return(nil)
+
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = build_dpop_proof(htm: "X")
+      get :show
+
+      expect(response.status).to eq 401
+      expect(response.body).to eq(Doorkeeper::OAuth::InvalidTokenResponse.new.body.to_json)
+    end
+
+    context "when dpop is not supported" do
+      before do
+        allow(Doorkeeper.config.access_token_model).to receive(:dpop_supported?).and_return(false)
+      end
+
+      it "responds with token info for a dpop-bound token presented as a bearer token" do
+        request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
+        get :show
+
+        expect(response.status).to eq 200
+        expect(response.body).to eq(token.to_json)
+      end
+    end
+  end
 end

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -204,6 +204,22 @@ RSpec.describe Doorkeeper::TokensController, type: :controller do
     end
   end
 
+  describe "POST #create when an exception is raised that has a response" do
+    it "renders the exception's response" do
+      custom_response = Doorkeeper::OAuth::InvalidTokenResponse.new(reason: "custom")
+
+      allow(Doorkeeper.config).to(
+        receive(:before_successful_strategy_response)
+          .and_return(->(_request) { raise Doorkeeper::Errors::InvalidToken, custom_response }),
+      )
+
+      post :create, params: { client_id: client.uid, client_secret: client.secret, grant_type: "password" }
+
+      expect(response.status).to eq(401)
+      expect(json).to eq(JSON.parse(custom_response.body.to_json))
+    end
+  end
+
   # https://datatracker.ietf.org/doc/html/rfc7009#section-2.2
   describe "POST #revoke" do
     let(:client) { FactoryBot.create(:application) }

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -861,5 +861,25 @@ RSpec.describe Doorkeeper::TokensController, type: :controller do
         )
       end
     end
+
+    context "when access token uses dpop" do
+      let(:token_for_introspection) { FactoryBot.create(:access_token, application: client, dpop_jkt: "secret") }
+
+      it "responds with full token introspection" do
+        request.headers["Authorization"] = basic_auth_header_for_client(client)
+
+        post :introspect, params: { token: token_for_introspection.token }
+
+        expect(json_response).to match(
+          "active" => true,
+          "client_id" => client.uid,
+          "token_type" => "DPoP",
+          "scope" => nil,
+          "exp" => an_instance_of(Integer),
+          "iat" => an_instance_of(Integer),
+          "cnf" => { "jkt" => "secret" },
+        )
+      end
+    end
   end
 end

--- a/spec/dummy/db/migrate/20260205014939_enable_dpop.rb
+++ b/spec/dummy/db/migrate/20260205014939_enable_dpop.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class EnableDpop < ActiveRecord::Migration[5.0]
+  def change
+    add_column :oauth_access_tokens, :dpop_jkt, :string, null: true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
@@ -26,8 +26,8 @@ ActiveRecord::Schema.define(version: 20260801000000) do
     t.string "tenant_name"
     t.bigint "access_token_id"
     unless ENV["WITHOUT_PKCE"]
-      t.string   "code_challenge"
-      t.string   "code_challenge_method"
+      t.string "code_challenge"
+      t.string "code_challenge_method"
     end
     t.index ["access_token_id"], name: "index_oauth_access_grants_on_access_token_id"
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20260801000000) do
     t.text "resource"
     t.string "previous_refresh_token", default: "", null: false
     t.string "tenant_name"
+    t.string "dpop_jkt"
     t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
     t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
@@ -74,5 +75,4 @@ ActiveRecord::Schema.define(version: 20260801000000) do
     t.datetime "updated_at"
     t.string "password"
   end
-
 end

--- a/spec/generators/dpop_generator_spec.rb
+++ b/spec/generators/dpop_generator_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "generators/doorkeeper/dpop_generator"
+
+RSpec.describe Doorkeeper::DpopGenerator do
+  include GeneratorSpec::TestCase
+
+  tests described_class
+  destination ::File.expand_path("tmp/dummy", __dir__)
+
+  describe "after running the generator" do
+    before do
+      prepare_destination
+    end
+
+    it "creates a migration with a version specifier" do
+      stub_const("ActiveRecord::VERSION::MAJOR", 5)
+      stub_const("ActiveRecord::VERSION::MINOR", 0)
+
+      run_generator
+
+      assert_migration "db/migrate/enable_dpop.rb" do |migration|
+        assert migration.include?("ActiveRecord::Migration[5.0]\n")
+      end
+    end
+  end
+end

--- a/spec/grape/grape_integration_spec.rb
+++ b/spec/grape/grape_integration_spec.rb
@@ -56,6 +56,30 @@ module GrapeApp
       end
     end
 
+    resource :protected_with_endpoint_dpop_required do
+      before do
+        doorkeeper_authorize!
+      end
+
+      desc "Protected resource, requires DPoP token (defined in endpoint)."
+
+      get :status, dpop: :required do
+        { response: "OK" }
+      end
+    end
+
+    resource :protected_with_helper_dpop_required do
+      before do
+        doorkeeper_authorize! dpop: :required
+      end
+
+      desc "Protected resource, requires DPoP token (defined in helper)."
+
+      get :status do
+        { response: "OK" }
+      end
+    end
+
     resource :public do
       desc "Public resource, no token required."
 
@@ -114,6 +138,58 @@ RSpec.describe "Grape integration" do
       expect(last_response).to be_successful
       expect(json_body).to have_key("response")
     end
+
+    it "fails request for protected resource that requires dpop (Grape endpoint)" do
+      get "api/v1/protected_with_endpoint_dpop_required/status.json?access_token=#{access_token.token}"
+
+      expect(last_response).not_to be_successful
+      expect(json_body).to have_key("error")
+    end
+
+    it "fails request for protected resource that requires dpop (Doorkeeper helper)" do
+      get "api/v1/protected_with_helper_dpop_required/status.json?access_token=#{access_token.token}"
+
+      expect(last_response).not_to be_successful
+      expect(json_body).to have_key("error")
+    end
+  end
+
+  context "with dpop Token", token: :dpop do
+    def build_dpop_proof(htu:,
+                         ath: Base64.urlsafe_encode64(Digest::SHA256.digest(token_string), padding: false),
+                         htm: "GET",
+                         signing_key: self.signing_key)
+      super
+    end
+
+    it "successfully requests protected resource" do
+      get "api/v1/protected/status.json",
+          {},
+          "HTTP_AUTHORIZATION" => "DPoP #{token_string}",
+          "HTTP_DPOP" => build_dpop_proof(htu: "http://example.org/api/v1/protected/status.json")
+
+      expect(last_response).to be_successful
+
+      expect(json_body["token"]).to eq(token.token)
+    end
+
+    it "successfully requests protected resource that requires dpop (Grape endpoint)" do
+      get "api/v1/protected_with_endpoint_dpop_required/status.json",
+          {},
+          "HTTP_AUTHORIZATION" => "DPoP #{token_string}",
+          "HTTP_DPOP" => build_dpop_proof(htu: "http://example.org/api/v1/protected_with_endpoint_dpop_required/status.json")
+
+      expect(last_response).to be_successful
+    end
+
+    it "successfully requests protected resource that requires dpop (Doorkeeper helper)" do
+      get "api/v1/protected_with_helper_dpop_required/status.json",
+          {},
+          "HTTP_AUTHORIZATION" => "DPoP #{token_string}",
+          "HTTP_DPOP" => build_dpop_proof(htu: "http://example.org/api/v1/protected_with_helper_dpop_required/status.json")
+
+      expect(last_response).to be_successful
+    end
   end
 
   context "with invalid Access Token" do
@@ -144,7 +220,7 @@ RSpec.describe "Grape integration" do
     # rendered; a nil outcome must be memoized like a token is, or every
     # consultation runs the whole authentication again.
     it "authenticates only once per request" do
-      expect(Doorkeeper::OAuth::Token).to receive(:authenticate).once.and_call_original
+      expect(Doorkeeper::OAuth::Token).to receive(:resolve).once.and_call_original
 
       get "api/v1/protected/status.json?access_token=unknown-token"
 

--- a/spec/grape/grape_integration_spec.rb
+++ b/spec/grape/grape_integration_spec.rb
@@ -303,4 +303,51 @@ RSpec.describe "Grape integration" do
       expect(json_body["token"]).to eq(access_token.token)
     end
   end
+
+  # Grape exposes request headers differently across its history, which causes
+  # the DPoP header to arrive under a different hash / key in each era:
+  #
+  # + ----------------------- + --------------------------------------------- + ---------------------------------------------------------------------------- +
+  # | era                     | behavior                                      | refs                                                                         |
+  # + ----------------------- + --------------------------------------------- + ---------------------------------------------------------------------------- +
+  # | < 2.0                   | stored in `Hash` under `Train-Case` keys      | https://github.com/ruby-grape/grape/blob/v1.8.0/lib/grape/request.rb#L38-L47 |
+  # |                         |                                               | https://github.com/ruby-grape/grape/blob/v1.8.0/lib/grape/request.rb#L49-L51 |
+  # + ----------------------- + --------------------------------------------- + ---------------------------------------------------------------------------- +
+  # | >= 2.0 < 2.1 (Rack < 3) | stored in `Hash` under `Train-Case` keys      | https://github.com/ruby-grape/grape/blob/v2.0.0/lib/grape/request.rb#L38-L47 |
+  # |                         |                                               | https://github.com/ruby-grape/grape/blob/v2.0.0/lib/grape/request.rb#L49-L57 |
+  # + ----------------------- + --------------------------------------------- + ---------------------------------------------------------------------------- +
+  # | >= 2.0 < 2.1 (Rack 3)   | stored in `Hash` under `kebab-case` keys      | (same as above)                                                              |
+  # + ----------------------- + --------------------------------------------- + ---------------------------------------------------------------------------- +
+  # | >= 2.1                  | stored in `Grape::Util::Header` (resolves to  | https://github.com/ruby-grape/grape/blob/v2.1.0/lib/grape/request.rb#L36-L45 |
+  # |                         | `Rack::Headers` or `Rack::Utils::HeaderHash`) | https://github.com/ruby-grape/grape/blob/v2.1.0/lib/grape/util/header.rb     |
+  # |                         | under case-insensitive keys                   |                                                                              |
+  # + ----------------------- + --------------------------------------------- + ---------------------------------------------------------------------------- +
+  #
+  # These specs mimic Grape's different header handling and ensure the `DPoPProof`
+  # resolves from the request.
+  describe "resolving the dpop proof across different grape header implementations" do
+    let(:proof) { build_dpop_proof(htm: "GET", htu: "http://example.org/resource") }
+
+    {
+      "stored in `Hash` under `Train-Case` keys" => ->(proof) { { "Dpop" => proof } },
+      "stored in `Hash` under `kebab-case` keys" => ->(proof) { { "dpop" => proof } },
+      "stored in `Grape::Util::Header` under case-insensitive keys" => ->(proof) { Grape::Util::Header.new.tap { |headers| headers["dpop"] = proof } },
+    }.each do |description, build_headers|
+      context "when #{description}" do
+        subject(:dpop_proof) do
+          Doorkeeper::OAuth::DPoPProof.new(Doorkeeper::Grape::AuthorizationDecorator.new(request))
+        end
+
+        let(:request) do
+          instance_double(Grape::Request, env: { "HTTP_DPOP" => proof },
+                                          headers: build_headers.call(proof),
+                                          request_method: "GET",
+                                          base_url: "http://example.org",
+                                          path: "/resource",)
+        end
+
+        it { expect(dpop_proof).not_to be_blank }
+      end
+    end
+  end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -1688,4 +1688,61 @@ RSpec.describe Doorkeeper::Config do
       end.not_to raise_error
     end
   end
+
+  describe "dpop_signature_algorithms" do
+    it "is ['ES256', 'PS256'] by default" do
+      expect(config.dpop_signature_algorithms).to eq(%w[ES256 PS256])
+    end
+
+    it "can be set to a valid subset of the supported algorithms" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        dpop_signature_algorithms ["ES256"]
+      end
+
+      expect(config.dpop_signature_algorithms).to eq(["ES256"])
+    end
+
+    it "normalizes symbols to strings" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        dpop_signature_algorithms [:ES256]
+      end
+
+      expect(config.dpop_signature_algorithms).to eq(["ES256"])
+    end
+
+    it "leaves the option undefined when it was not explicitly configured" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+      end
+
+      # Validation must not flip the "was it explicitly set?" signal that
+      # instance_variable_defined? carries for config options.
+      expect(config.instance_variable_defined?(:@dpop_signature_algorithms)).to be(false)
+      expect(config.dpop_signature_algorithms).to eq(%w[ES256 PS256])
+    end
+
+    it "resets to the default when an unsupported algorithm is configured" do
+      expect(Rails.logger).to receive(:warn).with(/dpop_signature_algorithms/)
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        dpop_signature_algorithms ["ES256", "none"]
+      end
+
+      expect(config.dpop_signature_algorithms).to eq(%w[ES256 PS256])
+    end
+
+    it "resets to the default when configured empty" do
+      expect(Rails.logger).to receive(:warn).with(/dpop_signature_algorithms/)
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        dpop_signature_algorithms []
+      end
+
+      expect(config.dpop_signature_algorithms).to eq(%w[ES256 PS256])
+    end
+  end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -714,7 +714,7 @@ RSpec.describe Doorkeeper::Config do
   describe "access_token_methods" do
     it "has defaults order" do
       expect(config.access_token_methods)
-        .to eq(%i[from_bearer_authorization from_access_token_param from_bearer_param])
+        .to eq(%i[from_dpop_authorization from_bearer_authorization from_access_token_param from_bearer_param])
     end
 
     it "can change the value" do
@@ -1640,6 +1640,52 @@ RSpec.describe Doorkeeper::Config do
         orm DOORKEEPER_ORM
         issuer "not a valid uri"
       end
+    end
+  end
+
+  describe "force_dpop" do
+    it "is disabled by default" do
+      expect(config.force_dpop?).to be(false)
+    end
+
+    it "can be enabled" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        force_dpop
+      end
+
+      expect(config.force_dpop?).to be(true)
+    end
+
+    it "warns when the access token model does not support dpop" do
+      allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false)
+      expect(Rails.logger).to receive(:warn).with(/force_dpop is enabled but .* has no/)
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        force_dpop
+      end
+    end
+
+    it "does not warn when force_dpop is disabled and dpop is unsupported" do
+      allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false)
+      expect(Rails.logger).not_to receive(:warn).with(/force_dpop/)
+
+      Doorkeeper.configure { orm DOORKEEPER_ORM }
+    end
+
+    it "skips the warning when the schema cannot be read yet" do
+      allow(Doorkeeper::AccessToken).to \
+        receive(:dpop_supported?).and_raise(ActiveRecord::StatementInvalid)
+
+      expect(Rails.logger).not_to receive(:warn).with(/force_dpop/)
+
+      expect do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          force_dpop
+        end
+      end.not_to raise_error
     end
   end
 end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
   subject(:request) do
-    described_class.new(server, grant, client, params)
+    described_class.new(server, grant, client, params).tap { |request| request.dpop_proof = dpop_proof }
   end
 
   let(:server) do
@@ -25,6 +25,7 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
   let(:client) { grant.application }
   let(:redirect_uri) { client.redirect_uri }
   let(:params) { { redirect_uri: redirect_uri } }
+  let(:dpop_proof) { nil }
 
   before do
     allow(server).to receive(:option_defined?).with(:custom_access_token_expires_in).and_return(true)
@@ -274,7 +275,7 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
       # denied before the single-use enforcement runs, so it cannot revoke
       # the token issued for the code without proving possession of it.
       replay = described_class.new(
-        server, grant.reload, client, redirect_uri: "https://other.example/callback",
+        server, grant.reload, client, { redirect_uri: "https://other.example/callback" },
       )
       replay.validate
 
@@ -481,4 +482,6 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
       expect { request.authorize }.to(change { previous_token.reload.revoked_at })
     end
   end
+
+  include_examples "sender-constraining access_token using dpop"
 end

--- a/spec/lib/oauth/base_request_dpop_spec.rb
+++ b/spec/lib/oauth/base_request_dpop_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::OAuth::BaseRequest do
+  describe "a third-party grant flow that subclasses BaseRequest" do
+    subject(:request) { Class.new(described_class).new }
+
+    context "when force_dpop is enabled and no proof was injected" do
+      before { config_is_set(:force_dpop, true) }
+
+      it "is invalid rather than raising" do
+        expect { request.valid? }.not_to raise_error
+        expect(request.valid?).to be false
+      end
+
+      it "reports invalid_dpop_proof" do
+        request.valid?
+
+        expect(request.error).to eq(Doorkeeper::Errors::InvalidDPoPProof)
+      end
+    end
+  end
+end

--- a/spec/lib/oauth/base_request_dpop_spec.rb
+++ b/spec/lib/oauth/base_request_dpop_spec.rb
@@ -9,15 +9,33 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
     context "when force_dpop is enabled and no proof was injected" do
       before { config_is_set(:force_dpop, true) }
 
-      it "is invalid rather than raising" do
+      it "neither raises nor invalidates the request on its own" do
         expect { request.valid? }.not_to raise_error
-        expect(request.valid?).to be false
+        expect(request.valid?).to be true
       end
 
-      it "reports invalid_dpop_proof" do
-        request.valid?
+      it "raises assembling dpop token attributes without a dpop binding" do
+        expect { request.send(:dpop_token_attributes) }
+          .to raise_error(Doorkeeper::Errors::InvalidDPoPProof) do |error|
+            expect(error.response.name).to eq(:invalid_dpop_proof)
+            expect(error.response.status).to eq(:bad_request)
+          end
+      end
+    end
 
-        expect(request.error).to eq(Doorkeeper::Errors::InvalidDPoPProof)
+    context "when force_dpop is enabled, the request had no dpop binding, but the grant has a dpop binding" do
+      subject(:request) do
+        Class.new(described_class) do
+          def dpop_token_attributes
+            super(fallback_dpop_jkt: "thumbprint")
+          end
+        end.new
+      end
+
+      before { config_is_set(:force_dpop, true) }
+
+      it "uses the existing binding" do
+        expect(request.send(:dpop_token_attributes)).to eq(dpop_jkt: "thumbprint")
       end
     end
   end

--- a/spec/lib/oauth/base_request_spec.rb
+++ b/spec/lib/oauth/base_request_spec.rb
@@ -147,6 +147,22 @@ RSpec.describe Doorkeeper::OAuth::BaseRequest do
       expect(result.expires_in).to be(500)
     end
 
+    context "when a custom_access_token_attribute collides with the dpop thumbprint" do
+      before { request.dpop_proof = dpop_proof_double }
+
+      it "does not let the custom_access_token_attribute override the dpop_jkt" do
+        result = request.find_or_create_access_token(
+          client,
+          resource_owner,
+          "public",
+          { dpop_jkt: "jkt_if_successful_override" },
+          server,
+        )
+
+        expect(result.dpop_jkt).to eq("jkt_123")
+      end
+    end
+
     it "respects use_refresh_token with a block" do
       server = double(
         :server,

--- a/spec/lib/oauth/client_credentials/creator_spec.rb
+++ b/spec/lib/oauth/client_credentials/creator_spec.rb
@@ -130,6 +130,47 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Creator do
         expect(result).to eq(existing_token)
       end
     end
+
+    context "when the request is DPoP-bound" do
+      it "returns a token bound to the same key" do
+        existing_token = creator.call(client, scopes, dpop_jkt: "jkt_abc")
+
+        result = creator.call(client, scopes, dpop_jkt: "jkt_abc")
+
+        expect(Doorkeeper::AccessToken.count).to eq(1)
+        expect(result).to eq(existing_token)
+      end
+
+      it "does not return a token bound to a different key" do
+        existing_token = creator.call(client, scopes, dpop_jkt: "jkt_abc")
+
+        result = creator.call(client, scopes, dpop_jkt: "jkt_xyz")
+
+        expect(Doorkeeper::AccessToken.count).to eq(2)
+        expect(result).not_to eq(existing_token)
+        expect(result.dpop_jkt).to eq("jkt_xyz")
+      end
+
+      it "does not return a bound token when the request presents no proof" do
+        existing_token = creator.call(client, scopes, dpop_jkt: "jkt_abc")
+
+        result = creator.call(client, scopes)
+
+        expect(Doorkeeper::AccessToken.count).to eq(2)
+        expect(result).not_to eq(existing_token)
+        expect(result.dpop_jkt).to be_nil
+      end
+
+      it "does not return an unbound token when the request presents a proof" do
+        existing_token = creator.call(client, scopes)
+
+        result = creator.call(client, scopes, dpop_jkt: "jkt_abc")
+
+        expect(Doorkeeper::AccessToken.count).to eq(2)
+        expect(result).not_to eq(existing_token)
+        expect(result.dpop_jkt).to eq("jkt_abc")
+      end
+    end
   end
 
   context "when reuse_access_token is false" do

--- a/spec/lib/oauth/client_credentials_request_spec.rb
+++ b/spec/lib/oauth/client_credentials_request_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentialsRequest do
 
   let(:application)   { FactoryBot.create(:application, scopes: "") }
   let(:client)        { double :client, application: application, scopes: "" }
-  let(:token_creator) { double :issuer, create: true, token: double }
+  let(:token_creator) { double :issuer, create: true, error: nil, token: double }
 
   before do
     allow(server).to receive(:option_defined?).with(:custom_access_token_expires_in).and_return(true)

--- a/spec/lib/oauth/client_credentials_request_spec.rb
+++ b/spec/lib/oauth/client_credentials_request_spec.rb
@@ -3,7 +3,9 @@
 require "spec_helper"
 
 RSpec.describe Doorkeeper::OAuth::ClientCredentialsRequest do
-  subject(:request) { described_class.new(server, client) }
+  subject(:request) do
+    described_class.new(server, client).tap { |request| request.dpop_proof = dpop_proof }
+  end
 
   let(:server) do
     double(
@@ -16,6 +18,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentialsRequest do
   let(:application)   { FactoryBot.create(:application, scopes: "") }
   let(:client)        { double :client, application: application, scopes: "" }
   let(:token_creator) { double :issuer, create: true, error: nil, token: double }
+  let(:dpop_proof)    { nil }
 
   before do
     allow(server).to receive(:option_defined?).with(:custom_access_token_expires_in).and_return(true)
@@ -66,7 +69,7 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentialsRequest do
     end
 
     it "issues an access token with requested scopes" do
-      request = described_class.new(server, client, scope: "email")
+      request = described_class.new(server, client, { scope: "email" })
       allow(request).to receive(:issuer).and_return(token_creator)
       expect(token_creator).to receive(:create).with(client, Doorkeeper::OAuth::Scopes.from_string("email"), {})
       request.authorize
@@ -81,9 +84,26 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentialsRequest do
     end
 
     it "issues an access token with the custom access token attributes" do
-      request = described_class.new(server, client, scope: "email", tenant_id: 9000)
+      request = described_class.new(server, client, { scope: "email", tenant_id: 9000 })
       allow(request).to receive(:issuer).and_return(token_creator)
       expect(token_creator).to receive(:create).with(client, Doorkeeper::OAuth::Scopes.from_string("email"), { tenant_id: 9000 })
+      request.authorize
+    end
+  end
+
+  context "when a custom_access_token_attribute collides with the dpop thumbprint" do
+    before do
+      Doorkeeper.configure do
+        custom_access_token_attributes [:dpop_jkt]
+      end
+    end
+
+    it "does not let the custom_access_token_attribute override the dpop_jkt" do
+      request = described_class.new(server, client, { dpop_jkt: "jkt_if_successful_override" })
+      request.dpop_proof = dpop_proof_double
+      allow(request).to receive(:issuer).and_return(token_creator)
+
+      expect(token_creator).to receive(:create).with(client, nil, { dpop_jkt: "jkt_123" })
       request.authorize
     end
   end
@@ -113,10 +133,16 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentialsRequest do
     end
 
     it "issues an access token with requested scopes" do
-      request = described_class.new(server, client, scope: "phone")
+      request = described_class.new(server, client, { scope: "phone" })
       request.authorize
       expect(request.response).to be_a(Doorkeeper::OAuth::TokenResponse)
       expect(request.response.token.scopes_string).to eq("phone")
     end
   end
+
+  include_examples(
+    "sender-constraining access_token using dpop",
+    when_bearer_token_expected: -> { expect(token_creator).to receive(:create).with(client, nil, {}) },
+    when_dpop_token_expected: -> { expect(token_creator).to receive(:create).with(client, nil, { dpop_jkt: "jkt_123" }) },
+  )
 end

--- a/spec/lib/oauth/code_response_spec.rb
+++ b/spec/lib/oauth/code_response_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Doorkeeper::OAuth::CodeResponse do
       state: "state",
       scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
       custom_access_token_attributes: {},
+      dpop_token_attributes: {},
     )
   end
 

--- a/spec/lib/oauth/dpop_proof_spec.rb
+++ b/spec/lib/oauth/dpop_proof_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
   subject(:dpop_proof) { described_class.new(request, access_token) }
 
   let(:request) do
-    instance_double(ActionDispatch::Request, base_url:, headers: request_headers, path:, request_method:)
+    instance_double(ActionDispatch::Request, base_url:, env:, path:, request_method:)
   end
   let(:base_url) { "https://protected.example.net" }
+  let(:env) { { "HTTP_DPOP" => dpop_header } }
   let(:path) { "/resource" }
-  let(:request_headers) { ActionDispatch::Http::Headers.from_hash("HTTP_DPOP" => dpop_header) }
   let(:request_method) { "GET" }
 
   let(:access_token) { nil }

--- a/spec/lib/oauth/dpop_proof_spec.rb
+++ b/spec/lib/oauth/dpop_proof_spec.rb
@@ -5,6 +5,8 @@ require "spec_helper"
 RSpec.describe Doorkeeper::OAuth::DPoPProof do
   subject(:dpop_proof) { described_class.new(request, access_token) }
 
+  let(:dpop_signature_algorithms) { ["ES256"] }
+
   let(:request) do
     instance_double(ActionDispatch::Request, base_url:, env:, path:, request_method:)
   end
@@ -30,7 +32,7 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
 
   before do
     allow(Doorkeeper).to receive(:config).and_return(
-      instance_double(Doorkeeper::Config, dpop_iat_leeway: 300, dpop_signature_algorithms: ["ES256"]),
+      instance_double(Doorkeeper::Config, dpop_iat_leeway: 300, dpop_signature_algorithms:),
     )
 
     Timecop.freeze(Time.current)
@@ -93,10 +95,20 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
     end
 
     describe "alg" do
-      let(:alg) { "RS256" }
-      let(:signing_key) { OpenSSL::PKey::RSA.generate(2048) }
+      context "when the proof alg is not among the configured algorithms" do
+        let(:alg) { "RS256" }
+        let(:signing_key) { OpenSSL::PKey::RSA.generate(2048) }
 
-      include_examples "invalid because", :invalid_signing_algorithm
+        include_examples "invalid because", :invalid_signing_algorithm
+      end
+
+      context "when the configuration allows a disallowed algorithm" do
+        let(:alg) { "none" }
+        let(:dpop_header) { JWT.encode(claims, nil, "none", jwt_headers) }
+        let(:dpop_signature_algorithms) { %w[none] }
+
+        include_examples "invalid because", :invalid_signing_algorithm
+      end
     end
 
     describe "jwk" do

--- a/spec/lib/oauth/dpop_proof_spec.rb
+++ b/spec/lib/oauth/dpop_proof_spec.rb
@@ -8,12 +8,11 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
   let(:dpop_signature_algorithms) { ["ES256"] }
 
   let(:request) do
-    instance_double(ActionDispatch::Request, base_url:, env:, path:, request_method:)
+    instance_double(ActionDispatch::Request, env:, request_method:, url:)
   end
-  let(:base_url) { "https://protected.example.net" }
   let(:env) { { "HTTP_DPOP" => dpop_header } }
-  let(:path) { "/resource" }
   let(:request_method) { "GET" }
+  let(:url) { "https://protected.example.net/resource" }
 
   let(:access_token) { nil }
 
@@ -21,7 +20,7 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
 
   let(:claims) { { "jti" => "jti_01", "iat" => iat, "htm" => htm, "htu" => htu } }
   let(:htm) { request_method }
-  let(:htu) { base_url + path }
+  let(:htu) { url }
   let(:iat) { Time.current.to_i }
 
   let(:jwt_headers) { { "typ" => typ, "alg" => alg, "jwk" => jwk } }
@@ -192,15 +191,59 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
 
     describe "htu" do
       context "when htu does not match request URI" do
-        let(:htu) { "#{base_url}/other" }
+        let(:htu) { "#{url}/other" }
 
         include_examples "invalid because", :invalid_htu
       end
 
-      context "when htu includes query string" do
-        let(:htu) { "#{base_url}#{path}?foo=bar" }
+      context "when htu matches the request URI but on a different port" do
+        let(:url) { "https://protected.example.net:8443/resource" }
+        let(:htu) { "https://protected.example.net:443/resource" }
 
         include_examples "invalid because", :invalid_htu
+      end
+
+      context "when htu is not a string" do
+        let(:claims) { super().merge("htu" => { "not" => "a string" }) }
+
+        include_examples "invalid because", :invalid_htu
+      end
+
+      context "when htu is not a parseable URI" do
+        let(:htu) { "http://[invalid" }
+
+        include_examples "invalid because", :invalid_htu
+      end
+
+      context "when htu includes a query string" do
+        let(:htu) { "#{url}?foo=bar" }
+
+        it "is valid" do
+          dpop_proof.validate
+          expect(dpop_proof).to be_valid
+          expect(dpop_proof.error).to be_nil
+        end
+      end
+
+      context "when htu includes a fragment" do
+        let(:htu) { "#{url}#section" }
+
+        it "is valid" do
+          dpop_proof.validate
+          expect(dpop_proof).to be_valid
+          expect(dpop_proof.error).to be_nil
+        end
+      end
+
+      context "when htu includes the default port" do
+        let(:url) { "https://protected.example.net/resource" }
+        let(:htu) { "https://protected.example.net:443/resource" }
+
+        it "is valid" do
+          dpop_proof.validate
+          expect(dpop_proof).to be_valid
+          expect(dpop_proof.error).to be_nil
+        end
       end
     end
 

--- a/spec/lib/oauth/dpop_proof_spec.rb
+++ b/spec/lib/oauth/dpop_proof_spec.rb
@@ -244,4 +244,27 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
       expect { dpop_proof.valid? }.to raise_error(LoadError, /requires the 'jwt' gem/)
     end
   end
+
+  # doorkeeper-jwt defines Doorkeeper::JWT, which shadows the jwt gem for any
+  # bare JWT reference made inside the Doorkeeper module — every gem reference
+  # in DPoPProof must be written ::JWT to survive that.
+  context "when doorkeeper-jwt's Doorkeeper::JWT module is defined" do
+    before do
+      stub_const("Doorkeeper::JWT", Module.new)
+    end
+
+    it "still validates a valid proof and computes its thumbprint" do
+      dpop_proof.validate
+
+      expect(dpop_proof).to be_valid
+      expected_jwk = JWT::JWK.import(jwt_headers.fetch("jwk"))
+      expect(dpop_proof.jkt).to eq(JWT::JWK::Thumbprint.new(expected_jwk).generate)
+    end
+
+    context "with a malformed proof value" do
+      let(:dpop_header) { "not-jwt" }
+
+      include_examples "invalid because", :invalid_type
+    end
+  end
 end

--- a/spec/lib/oauth/dpop_proof_spec.rb
+++ b/spec/lib/oauth/dpop_proof_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::OAuth::DPoPProof do
+  subject(:dpop_proof) { described_class.new(request, access_token) }
+
+  let(:request) do
+    instance_double(ActionDispatch::Request, base_url:, headers: request_headers, path:, request_method:)
+  end
+  let(:base_url) { "https://protected.example.net" }
+  let(:path) { "/resource" }
+  let(:request_headers) { ActionDispatch::Http::Headers.from_hash("HTTP_DPOP" => dpop_header) }
+  let(:request_method) { "GET" }
+
+  let(:access_token) { nil }
+
+  let(:dpop_header) { JWT.encode(claims, signing_key, alg, jwt_headers) }
+
+  let(:claims) { { "jti" => "jti_01", "iat" => iat, "htm" => htm, "htu" => htu } }
+  let(:htm) { request_method }
+  let(:htu) { base_url + path }
+  let(:iat) { Time.current.to_i }
+
+  let(:jwt_headers) { { "typ" => typ, "alg" => alg, "jwk" => jwk } }
+  let(:alg) { "ES256" }
+  let(:jwk) { JWT::JWK.new(signing_key).export }
+  let(:signing_key) { OpenSSL::PKey::EC.generate("prime256v1") }
+  let(:typ) { "dpop+jwt" }
+
+  before do
+    allow(Doorkeeper).to receive(:config).and_return(
+      instance_double(Doorkeeper::Config, dpop_iat_leeway: 300, dpop_signature_algorithms: ["ES256"]),
+    )
+
+    Timecop.freeze(Time.current)
+  end
+
+  after { Timecop.return }
+
+  shared_examples "invalid because" do |expected_error|
+    it "is invalid and has error #{expected_error}" do
+      dpop_proof.validate
+
+      expect(dpop_proof).not_to be_valid
+      expect(dpop_proof.error).to eq(expected_error)
+    end
+  end
+
+  describe "#validate" do
+    it "is valid and has no error" do
+      dpop_proof.validate
+      expect(dpop_proof).to be_valid
+      expect(dpop_proof.error).to be_nil
+    end
+
+    context "when dpop header is missing" do
+      let(:dpop_header) { nil }
+
+      include_examples "invalid because", :blank
+    end
+
+    context "when dpop header is blank" do
+      let(:dpop_header) { "" }
+
+      include_examples "invalid because", :blank
+    end
+
+    context "when dpop header is not a jwt" do
+      let(:dpop_header) { "not-jwt" }
+
+      include_examples "invalid because", :invalid_type
+    end
+
+    describe "single_proof" do
+      context "when multiple proofs separated by comma" do
+        let(:dpop_header) { "a.b.c,d.e.f" }
+
+        include_examples "invalid because", :multiple_dpop_proofs
+      end
+
+      context "when multiple proofs separated by semicolon" do
+        let(:dpop_header) { "a.b.c;d.e.f" }
+
+        include_examples "invalid because", :multiple_dpop_proofs
+      end
+    end
+
+    describe "type" do
+      let(:typ) { "not-dpop" }
+
+      include_examples "invalid because", :invalid_type
+    end
+
+    describe "alg" do
+      let(:alg) { "RS256" }
+      let(:signing_key) { OpenSSL::PKey::RSA.generate(2048) }
+
+      include_examples "invalid because", :invalid_signing_algorithm
+    end
+
+    describe "jwk" do
+      context "when jwk is missing" do
+        let(:jwt_headers) { super().except("jwk") }
+
+        include_examples "invalid because", :invalid_jwk
+      end
+
+      context "when jwk is not a hash" do
+        let(:jwk) { "not-a-jwk" }
+
+        include_examples "invalid because", :invalid_jwk
+      end
+
+      context "when jwk includes private material" do
+        let(:jwk) { JWT::JWK.new(signing_key).export(include_private: true) }
+
+        include_examples "invalid because", :invalid_jwk
+      end
+    end
+
+    describe "jti" do
+      let(:claims) { super().except("jti") }
+
+      include_examples "invalid because", :invalid_jti
+    end
+
+    describe "iat" do
+      context "when iat is missing" do
+        let(:claims) { super().except("iat") }
+
+        include_examples "invalid because", :invalid_iat
+      end
+
+      context "when iat outside leeway in the future" do
+        let(:claims) { super().merge("iat" => iat + Doorkeeper.config.dpop_iat_leeway + 1) }
+
+        include_examples "invalid because", :invalid_iat
+      end
+
+      context "when iat outside leeway in the past" do
+        let(:claims) { super().merge("iat" => iat - Doorkeeper.config.dpop_iat_leeway - 1) }
+
+        include_examples "invalid because", :invalid_iat
+      end
+    end
+
+    describe "ath" do
+      let(:access_token) { "access_token_01" }
+
+      context "when ath is missing" do
+        include_examples "invalid because", :invalid_ath
+      end
+
+      context "when ath mismatches access_token" do
+        let(:claims) { super().merge("ath" => "wrong") }
+
+        include_examples "invalid because", :invalid_ath
+      end
+
+      context "when ath matches access_token" do
+        let(:claims) do
+          digest = Digest::SHA256.digest(access_token)
+          super().merge("ath" => Base64.urlsafe_encode64(digest, padding: false))
+        end
+
+        it "is valid" do
+          dpop_proof.validate
+          expect(dpop_proof).to be_valid
+          expect(dpop_proof.error).to be_nil
+        end
+      end
+    end
+
+    describe "htm" do
+      let(:htm) { "POST" }
+
+      include_examples "invalid because", :invalid_htm
+    end
+
+    describe "htu" do
+      context "when htu does not match request URI" do
+        let(:htu) { "#{base_url}/other" }
+
+        include_examples "invalid because", :invalid_htu
+      end
+
+      context "when htu includes query string" do
+        let(:htu) { "#{base_url}#{path}?foo=bar" }
+
+        include_examples "invalid because", :invalid_htu
+      end
+    end
+
+    describe "signature" do
+      context "when jwt was signed with different private key pair to the jwk in the header" do
+        let(:dpop_header) do
+          JWT.encode(claims, OpenSSL::PKey::EC.generate("prime256v1"), alg, jwt_headers)
+        end
+
+        include_examples "invalid because", :invalid_signature
+      end
+    end
+  end
+
+  describe "#claims" do
+    # `claims` and `headers` both call `decode_without_verifying_signature`
+    # which memoizes both. validation always reads headers before claims, so
+    # this exercises `claims` directly for code coverage purposes.
+    it "decodes the proof and returns its claims" do
+      expect(dpop_proof.send(:claims)).to include("jti" => "jti_01")
+    end
+  end
+
+  describe "#jkt" do
+    context "when the proof is valid" do
+      it "returns the thumbprint for the public jwk in the header" do
+        expected_jwk = JWT::JWK.import(jwt_headers.fetch("jwk"))
+        expected_jkt = JWT::JWK::Thumbprint.new(expected_jwk).generate
+
+        expect(dpop_proof.jkt).to eq(expected_jkt)
+      end
+    end
+
+    context "when the proof is invalid" do
+      let(:dpop_header) { "not-jwt" }
+
+      it "returns nil" do
+        expect(dpop_proof.jkt).to be_nil
+      end
+    end
+  end
+
+  context "when the jwt gem cannot be loaded" do
+    before do
+      allow(dpop_proof).to receive(:require).with("jwt").and_raise(LoadError) # rubocop:disable RSpec/SubjectStub
+    end
+
+    it "surfaces a LoadError from #validate" do
+      expect { dpop_proof.validate }.to raise_error(LoadError, /requires the 'jwt' gem/)
+    end
+
+    it "surfaces a LoadError from #valid?" do
+      expect { dpop_proof.valid? }.to raise_error(LoadError, /requires the 'jwt' gem/)
+    end
+  end
+end

--- a/spec/lib/oauth/dpop_proof_spec.rb
+++ b/spec/lib/oauth/dpop_proof_spec.rb
@@ -128,6 +128,90 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
 
         include_examples "invalid because", :invalid_jwk
       end
+
+      context "when a jwk member is not valid urlsafe base64" do
+        let(:jwk) { super().merge(x: "invalid!") }
+
+        include_examples "invalid because", :invalid_jwk
+      end
+
+      context "when the jwk uses a point that is not on the curve" do
+        let(:jwk) do
+          off_curve = Base64.urlsafe_encode64("\x00" * 32, padding: false)
+          super().merge(x: off_curve, y: off_curve)
+        end
+
+        include_examples "invalid because", :invalid_jwk
+      end
+
+      context "when the jwk key type and the alg disagree" do
+        let(:dpop_header) do
+          # `JWT.encode` raises `JWT::EncodeError` when the jwk key type and alg disagree
+          encode = ->(part) { Base64.urlsafe_encode64(JSON.dump(part), padding: false) }
+          "#{encode.call(jwt_headers)}.#{encode.call(claims)}.#{encode.call("")}"
+        end
+
+        context "when an ES256 jwk is used with a PS256 alg" do
+          let(:dpop_signature_algorithms) { %w[ES256 PS256] }
+          let(:alg) { "PS256" }
+          let(:jwk) { JWT::JWK.new(OpenSSL::PKey::EC.generate("prime256v1")).export }
+
+          include_examples "invalid because", :invalid_jwk
+        end
+
+        context "when an ES256 jwk is used with a RS256 alg" do
+          let(:dpop_signature_algorithms) { %w[ES256 RS256] }
+          let(:alg) { "RS256" }
+          let(:jwk) { JWT::JWK.new(OpenSSL::PKey::EC.generate("prime256v1")).export }
+
+          include_examples "invalid because", :invalid_jwk
+        end
+
+        context "when an PS256 jwk is used with a ES256 alg" do
+          let(:dpop_signature_algorithms) { %w[PS256 ES256] }
+          let(:alg) { "ES256" }
+          let(:jwk) { JWT::JWK.new(OpenSSL::PKey::RSA.generate(2048)).export }
+
+          include_examples "invalid because", :invalid_jwk
+        end
+
+        context "when an RS256 jwk is used with a ES256 alg" do
+          let(:dpop_signature_algorithms) { %w[RS256 ES256] }
+          let(:alg) { "ES256" }
+          let(:jwk) { JWT::JWK.new(OpenSSL::PKey::RSA.generate(2048)).export }
+
+          include_examples "invalid because", :invalid_jwk
+        end
+      end
+
+      context "when the jwk uses an insufficient rsa key size" do
+        let(:alg) { "RS256" }
+        let(:dpop_header) do
+          # `JWT.encode` raises `JWT::EncodeError` when the jwk key size is less than 2048 bits
+          encode = ->(part) { Base64.urlsafe_encode64(part, padding: false) }
+          signing_input = "#{encode.call(JSON.dump(jwt_headers))}.#{encode.call(JSON.dump(claims))}"
+          "#{signing_input}.#{encode.call(signing_key.sign("SHA256", signing_input))}"
+        end
+        let(:dpop_signature_algorithms) { %w[RS256] }
+        let(:signing_key) { OpenSSL::PKey::RSA.generate(1024) }
+
+        include_examples "invalid because", :invalid_jwk
+      end
+
+      context "when the key only fails once its material is used" do
+        # jwt < 3 defers parsing a `kid`-bearing key until first use, so import
+        # succeeds and an off-curve point only raises when the keypair is
+        # materialised. stand in a key that mimics that behavior.
+        let(:deferred_jwk) do
+          instance_double(JWT::JWK::EC).tap do |key|
+            allow(key).to receive(:keypair).and_raise(OpenSSL::PKey::EC::Point::Error)
+          end
+        end
+
+        before { allow(JWT::JWK).to receive(:import).and_return(deferred_jwk) }
+
+        include_examples "invalid because", :invalid_jwk
+      end
     end
 
     describe "jti" do

--- a/spec/lib/oauth/dpop_proof_typeconfusion_spec.rb
+++ b/spec/lib/oauth/dpop_proof_typeconfusion_spec.rb
@@ -15,11 +15,14 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
   end
 
   # JWT.encode refuses to emit a non-Numeric `iat`, but nothing stops an
-  # attacker from assembling the compact serialization by hand.
+  # attacker from assembling the compact serialization by hand. Also, a JWT
+  # segment only has to be valid JSON, so `claims` and `headers` may be an
+  # Array or scalar rather than the expected Hash.
   def handcrafted_proof(claims:, headers: {})
-    merged = { "typ" => "dpop+jwt", "alg" => "ES256", "jwk" => jwk }.merge(headers)
+    base = { "typ" => "dpop+jwt", "alg" => "ES256", "jwk" => jwk }
+    header = headers.is_a?(Hash) ? base.merge(headers) : headers
     b64 = ->(h) { Base64.urlsafe_encode64(JSON.generate(h), padding: false) }
-    signing_input = "#{b64.call(merged)}.#{b64.call(claims)}"
+    signing_input = "#{b64.call(header)}.#{b64.call(claims)}"
     signature = JWT::JWA.resolve("ES256").sign(data: signing_input, signing_key: signing_key)
 
     "#{signing_input}.#{Base64.urlsafe_encode64(signature, padding: false)}"
@@ -80,6 +83,32 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
                         headers: { "jwk" => { "kty" => "bogus" } },)
 
       expect { validate!(token) }.not_to raise_error
+    end
+  end
+
+  describe "non-Hash jwt segments" do
+    it "returns false rather than raising for an Array payload" do
+      token = handcrafted_proof(claims: [1, 2, 3])
+
+      expect(validate!(token)).to be false
+    end
+
+    it "returns false rather than raising for a numeric payload" do
+      token = handcrafted_proof(claims: 42)
+
+      expect(validate!(token)).to be false
+    end
+
+    it "returns false rather than raising for an Array header" do
+      token = handcrafted_proof(claims: { "jti" => "x", "iat" => Time.now.to_i }, headers: [1, 2])
+
+      expect(validate!(token)).to be false
+    end
+
+    it "returns false rather than raising for a numeric header" do
+      token = handcrafted_proof(claims: { "jti" => "x", "iat" => Time.now.to_i }, headers: 42)
+
+      expect(validate!(token)).to be false
     end
   end
 

--- a/spec/lib/oauth/dpop_proof_typeconfusion_spec.rb
+++ b/spec/lib/oauth/dpop_proof_typeconfusion_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
   def request_double(token)
     instance_double(
       ActionDispatch::Request,
-      headers: { "DPoP" => token },
+      env: { "HTTP_DPOP" => token },
       request_method: "POST",
       base_url: "https://example.com",
       path: "/oauth/token",

--- a/spec/lib/oauth/dpop_proof_typeconfusion_spec.rb
+++ b/spec/lib/oauth/dpop_proof_typeconfusion_spec.rb
@@ -23,9 +23,20 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
     header = headers.is_a?(Hash) ? base.merge(headers) : headers
     b64 = ->(h) { Base64.urlsafe_encode64(JSON.generate(h), padding: false) }
     signing_input = "#{b64.call(header)}.#{b64.call(claims)}"
-    signature = JWT::JWA.resolve("ES256").sign(data: signing_input, signing_key: signing_key)
 
-    "#{signing_input}.#{Base64.urlsafe_encode64(signature, padding: false)}"
+    "#{signing_input}.#{Base64.urlsafe_encode64(es256_raw_signature(signing_input), padding: false)}"
+  end
+
+  # jwt 2.7 (the gemspec lower bound) has no public API to sign a hand-built
+  # signing input (JWT::JWA appeared in later releases), so produce the JWS
+  # ES256 signature directly with OpenSSL: an ECDSA DER signature unpacked
+  # into the raw 64-byte r || s form JWS requires (RFC 7518 3.4).
+  def es256_raw_signature(signing_input)
+    der = signing_key.sign(OpenSSL::Digest.new("SHA256"), signing_input)
+
+    OpenSSL::ASN1.decode(der).value.map do |int|
+      [int.value.to_i.to_s(16).rjust(64, "0")].pack("H*")
+    end.join
   end
 
   def request_double(token)

--- a/spec/lib/oauth/dpop_proof_typeconfusion_spec.rb
+++ b/spec/lib/oauth/dpop_proof_typeconfusion_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Probe: what happens when a DPoP proof carries well-formed JWT structure but
+# unexpected *types* in the header/claim values?
+RSpec.describe Doorkeeper::OAuth::DPoPProof do
+  let(:signing_key) { OpenSSL::PKey::EC.generate("prime256v1") }
+  let(:jwk) { JWT::JWK.new(signing_key).export }
+
+  def proof_for(claims:, headers: {})
+    base_headers = { "typ" => "dpop+jwt", "alg" => "ES256", "jwk" => jwk }
+    merged = base_headers.merge(headers)
+    JWT.encode(claims, signing_key, merged["alg"], merged)
+  end
+
+  # JWT.encode refuses to emit a non-Numeric `iat`, but nothing stops an
+  # attacker from assembling the compact serialization by hand.
+  def handcrafted_proof(claims:, headers: {})
+    merged = { "typ" => "dpop+jwt", "alg" => "ES256", "jwk" => jwk }.merge(headers)
+    b64 = ->(h) { Base64.urlsafe_encode64(JSON.generate(h), padding: false) }
+    signing_input = "#{b64.call(merged)}.#{b64.call(claims)}"
+    signature = JWT::JWA.resolve("ES256").sign(data: signing_input, signing_key: signing_key)
+
+    "#{signing_input}.#{Base64.urlsafe_encode64(signature, padding: false)}"
+  end
+
+  def request_double(token)
+    instance_double(
+      ActionDispatch::Request,
+      headers: { "DPoP" => token },
+      request_method: "POST",
+      base_url: "https://example.com",
+      path: "/oauth/token",
+    )
+  end
+
+  def validate!(token)
+    described_class.new(request_double(token)).valid?
+  end
+
+  describe "non-integer iat" do
+    it "returns false rather than raising for a String iat" do
+      token = handcrafted_proof(claims: { "jti" => "x", "iat" => "not-a-number" })
+
+      expect { validate!(token) }.not_to raise_error
+      expect(validate!(token)).to be false
+    end
+
+    it "returns false rather than raising for an Array iat" do
+      token = handcrafted_proof(claims: { "jti" => "x", "iat" => [1, 2] })
+
+      expect { validate!(token) }.not_to raise_error
+    end
+
+    it "returns false rather than raising for a Hash iat" do
+      token = handcrafted_proof(claims: { "jti" => "x", "iat" => { "a" => 1 } })
+
+      expect { validate!(token) }.not_to raise_error
+    end
+  end
+
+  describe "malformed jwk header" do
+    it "returns false rather than raising for a String jwk" do
+      token = proof_for(claims: { "jti" => "x", "iat" => Time.now.to_i },
+                        headers: { "jwk" => "i-am-not-a-jwk" },)
+
+      expect { validate!(token) }.not_to raise_error
+    end
+
+    it "returns false rather than raising for an Array jwk" do
+      token = proof_for(claims: { "jti" => "x", "iat" => Time.now.to_i },
+                        headers: { "jwk" => %w[a b] },)
+
+      expect { validate!(token) }.not_to raise_error
+    end
+
+    it "returns false rather than raising for a jwk with an unknown kty" do
+      token = proof_for(claims: { "jti" => "x", "iat" => Time.now.to_i },
+                        headers: { "jwk" => { "kty" => "bogus" } },)
+
+      expect { validate!(token) }.not_to raise_error
+    end
+  end
+
+  describe "baseline: a well-formed proof still validates" do
+    it "is valid" do
+      token = proof_for(claims: {
+                          "jti" => "x",
+                          "iat" => Time.now.to_i,
+                          "htm" => "POST",
+                          "htu" => "https://example.com/oauth/token",
+                        })
+
+      expect(validate!(token)).to be true
+    end
+  end
+end

--- a/spec/lib/oauth/dpop_proof_typeconfusion_spec.rb
+++ b/spec/lib/oauth/dpop_proof_typeconfusion_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe Doorkeeper::OAuth::DPoPProof do
       ActionDispatch::Request,
       env: { "HTTP_DPOP" => token },
       request_method: "POST",
-      base_url: "https://example.com",
-      path: "/oauth/token",
+      url: "https://example.com/oauth/token",
     )
   end
 

--- a/spec/lib/oauth/error_response_spec.rb
+++ b/spec/lib/oauth/error_response_spec.rb
@@ -151,6 +151,8 @@ RSpec.describe Doorkeeper::OAuth::ErrorResponse do
     describe "WWW-Authenticate header" do
       subject(:headers) { error_response.headers["WWW-Authenticate"] }
 
+      before { allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false) }
+
       it { expect(headers).to include("realm=\"#{error_response.send(:realm)}\"") }
       it { expect(headers).to include("error=\"#{error_response.name}\"") }
       it { expect(headers).to include("error_description=\"#{error_response.description}\"") }

--- a/spec/lib/oauth/invalid_token_response_spec.rb
+++ b/spec/lib/oauth/invalid_token_response_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Doorkeeper::OAuth::InvalidTokenResponse do
     end
 
     context "when unknown" do
-      let(:access_token) { double(revoked?: false, expired?: false) }
+      let(:access_token) { double(revoked?: false, expired?: false, uses_dpop?: false) }
 
       it "sets a description" do
         expect(response.description).to include("invalid")

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
   subject(:request) do
-    described_class.new(server, client, credentials, owner)
+    described_class.new(server, client, credentials, owner).tap { |request| request.dpop_proof = dpop_proof }
   end
 
   let(:server) do
@@ -22,6 +22,7 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
   let(:credentials) { Doorkeeper::ClientAuthentication::Credentials.new("uid", "secret") }
   let(:application) { client.application }
   let(:owner) { FactoryBot.build_stubbed(:resource_owner) }
+  let(:dpop_proof) { nil }
 
   before do
     allow(server).to receive(:option_defined?).with(:custom_access_token_expires_in).and_return(true)
@@ -131,7 +132,7 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
 
   describe "with scopes" do
     subject(:request) do
-      described_class.new(server, client, credentials, owner, scope: "public")
+      described_class.new(server, client, credentials, owner, { scope: "public" })
     end
 
     context "when scopes_by_grant_type is not configured for grant_type" do
@@ -188,7 +189,7 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
 
       context "with a valid resource indicator" do
         subject(:request) do
-          described_class.new(server, client, credentials, owner, resource: [resource_uri])
+          described_class.new(server, client, credentials, owner, { resource: [resource_uri] })
         end
 
         it "issues a token with the resource persisted" do
@@ -201,7 +202,7 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
 
       context "with multiple valid resource indicators" do
         subject(:request) do
-          described_class.new(server, client, credentials, owner, resource: [resource_uri, second_resource_uri])
+          described_class.new(server, client, credentials, owner, { resource: [resource_uri, second_resource_uri] })
         end
 
         let(:second_resource_uri) { "https://calendar.example.com/" }
@@ -230,7 +231,7 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
 
     context "when resource_indicator_validator rejects the resource" do
       subject(:request) do
-        described_class.new(server, client, credentials, owner, resource: [resource_uri])
+        described_class.new(server, client, credentials, owner, { resource: [resource_uri] })
       end
 
       before do
@@ -253,7 +254,7 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
 
     context "when resource_indicator_validator is not configured" do
       subject(:request) do
-        described_class.new(server, client, credentials, owner, resource: [resource_uri])
+        described_class.new(server, client, credentials, owner, { resource: [resource_uri] })
       end
 
       before do
@@ -293,7 +294,7 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
     end
 
     it "checks scopes" do
-      request = described_class.new(server, client, credentials, owner, scope: "public")
+      request = described_class.new(server, client, credentials, owner, { scope: "public" })
       allow(server).to receive(:scopes).and_return(Doorkeeper::OAuth::Scopes.from_string("public"))
 
       expect do
@@ -304,7 +305,7 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
     end
 
     it "falls back to the default otherwise" do
-      request = described_class.new(server, client, credentials, owner, scope: "private")
+      request = described_class.new(server, client, credentials, owner, { scope: "private" })
       allow(server).to receive(:scopes).and_return(Doorkeeper::OAuth::Scopes.from_string("private"))
 
       expect do
@@ -314,4 +315,6 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
       expect(Doorkeeper::AccessToken.last.expires_in).to eq(2.hours)
     end
   end
+
+  include_examples "sender-constraining access_token using dpop"
 end

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -317,5 +317,19 @@ RSpec.describe Doorkeeper::OAuth::RefreshTokenRequest do
     end
   end
 
+  context "when a public client refreshes a DPoP-bound token without a proof" do
+    let(:client) { FactoryBot.create(:application, confidential: false) }
+    let(:credentials) { Doorkeeper::ClientAuthentication::Credentials.new(client.uid, client.secret) }
+    let(:refresh_token) do
+      FactoryBot.create(:access_token, application: client, use_refresh_token: true, dpop_jkt: "secret")
+    end
+    let(:dpop_proof) { nil }
+
+    it "fails validation instead of raising" do
+      expect { request.validate }.not_to raise_error
+      expect(request.error).to eq(Doorkeeper::Errors::InvalidDPoPProof)
+    end
+  end
+
   include_examples "sender-constraining access_token using dpop"
 end

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -3,7 +3,9 @@
 require "spec_helper"
 
 RSpec.describe Doorkeeper::OAuth::RefreshTokenRequest do
-  subject(:request) { described_class.new(server, refresh_token, credentials) }
+  subject(:request) do
+    described_class.new(server, refresh_token, credentials).tap { |request| request.dpop_proof = dpop_proof }
+  end
 
   let(:server) do
     double :server, access_token_expires_in: 2.minutes
@@ -15,6 +17,7 @@ RSpec.describe Doorkeeper::OAuth::RefreshTokenRequest do
 
   let(:client) { refresh_token.application }
   let(:credentials) { Doorkeeper::ClientAuthentication::Credentials.new(client.uid, client.secret) }
+  let(:dpop_proof) { nil }
 
   before do
     allow(Doorkeeper::AccessToken).to receive(:refresh_token_revoked_on_use?).and_return(false)
@@ -291,4 +294,28 @@ RSpec.describe Doorkeeper::OAuth::RefreshTokenRequest do
       expect(Doorkeeper::AccessToken.last.scopes).to eq(%i[public])
     end
   end
+
+  context "when a custom_access_token_attribute collides with the dpop thumbprint" do
+    let(:client) { FactoryBot.create(:application, confidential: true) }
+    let(:credentials) { Doorkeeper::ClientAuthentication::Credentials.new(client.uid, client.secret) }
+    let(:refresh_token) do
+      FactoryBot.create(:access_token, application: client, use_refresh_token: true, dpop_jkt: "jkt_if_successful_override")
+    end
+    let(:dpop_proof) { dpop_proof_double }
+
+    before do
+      Doorkeeper.configure do
+        custom_access_token_attributes [:dpop_jkt]
+      end
+    end
+
+    it "does not let the custom_access_token_attribute override the dpop_jkt" do
+      refresh_token
+
+      expect { request.authorize }.to change { Doorkeeper::AccessToken.count }.by(1)
+      expect(Doorkeeper::AccessToken.last.dpop_jkt).to eq("jkt_123")
+    end
+  end
+
+  include_examples "sender-constraining access_token using dpop"
 end

--- a/spec/lib/oauth/resource_indicators_spec.rb
+++ b/spec/lib/oauth/resource_indicators_spec.rb
@@ -322,6 +322,12 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
         expect(response).to be_a(Doorkeeper::OAuth::ErrorResponse)
         expect(response.body[:error]).to eq(:invalid_target)
       end
+
+      # A rejected request must not reach the issuer: the error response is
+      # returned either way, so a token minted here would be an invisible leak.
+      it "does not mint a token for the rejected request" do
+        expect { request.authorize }.not_to(change { Doorkeeper::AccessToken.count })
+      end
     end
 
     context "without resource indicator" do

--- a/spec/lib/oauth/resource_indicators_spec.rb
+++ b/spec/lib/oauth/resource_indicators_spec.rb
@@ -125,9 +125,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
           Doorkeeper.config,
           access_grant,
           application,
-          redirect_uri: access_grant.redirect_uri,
-          code_verifier: nil,
-          resource: [resource_uri],
+          { redirect_uri: access_grant.redirect_uri, code_verifier: nil, resource: [resource_uri] },
         )
       end
 
@@ -144,9 +142,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
           Doorkeeper.config,
           access_grant,
           application,
-          redirect_uri: access_grant.redirect_uri,
-          code_verifier: nil,
-          resource: ["https://other.example.com/"],
+          { redirect_uri: access_grant.redirect_uri, code_verifier: nil, resource: ["https://other.example.com/"] },
         )
       end
 
@@ -163,8 +159,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
           Doorkeeper.config,
           access_grant,
           application,
-          redirect_uri: access_grant.redirect_uri,
-          code_verifier: nil,
+          { redirect_uri: access_grant.redirect_uri, code_verifier: nil },
         )
       end
 
@@ -189,8 +184,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
           Doorkeeper.config,
           access_grant,
           application,
-          redirect_uri: access_grant.redirect_uri,
-          code_verifier: nil,
+          { redirect_uri: access_grant.redirect_uri, code_verifier: nil },
         )
       end
 
@@ -221,9 +215,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
             Doorkeeper.config,
             access_grant,
             application,
-            redirect_uri: access_grant.redirect_uri,
-            code_verifier: nil,
-            resource: ["https://other.example.com/"],
+            { redirect_uri: access_grant.redirect_uri, code_verifier: nil, resource: ["https://other.example.com/"] },
           )
         end
 
@@ -240,9 +232,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
             Doorkeeper.config,
             access_grant,
             application,
-            redirect_uri: access_grant.redirect_uri,
-            code_verifier: nil,
-            resource: [resource_uri],
+            { redirect_uri: access_grant.redirect_uri, code_verifier: nil, resource: [resource_uri] },
           )
         end
 
@@ -259,8 +249,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
             Doorkeeper.config,
             access_grant,
             application,
-            redirect_uri: access_grant.redirect_uri,
-            code_verifier: nil,
+            { redirect_uri: access_grant.redirect_uri, code_verifier: nil },
           )
         end
 
@@ -289,7 +278,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
       parameters[:resource] = resource if resource
 
       request = Doorkeeper::OAuth::ClientCredentialsRequest.new(
-        Doorkeeper.config, client, **parameters,
+        Doorkeeper.config, client, parameters,
       )
       request.authorize
       request.access_token
@@ -300,8 +289,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
         Doorkeeper::OAuth::ClientCredentialsRequest.new(
           Doorkeeper.config,
           client,
-          scope: "public",
-          resource: [resource_uri],
+          { scope: "public", resource: [resource_uri] },
         )
       end
 
@@ -325,8 +313,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
         Doorkeeper::OAuth::ClientCredentialsRequest.new(
           Doorkeeper.config,
           client,
-          scope: "public",
-          resource: [resource_uri],
+          { scope: "public", resource: [resource_uri] },
         )
       end
 
@@ -342,7 +329,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
         Doorkeeper::OAuth::ClientCredentialsRequest.new(
           Doorkeeper.config,
           client,
-          scope: "public",
+          { scope: "public" },
         )
       end
 
@@ -470,8 +457,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
           Doorkeeper.config,
           access_token,
           credentials,
-          refresh_token: access_token.refresh_token,
-          resource: [resource_uri],
+          { refresh_token: access_token.refresh_token, resource: [resource_uri] },
         )
       end
 
@@ -489,8 +475,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
           Doorkeeper.config,
           access_token,
           credentials,
-          refresh_token: access_token.refresh_token,
-          resource: ["https://other.example.com/"],
+          { refresh_token: access_token.refresh_token, resource: ["https://other.example.com/"] },
         )
       end
 
@@ -507,7 +492,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
           Doorkeeper.config,
           access_token,
           credentials,
-          refresh_token: access_token.refresh_token,
+          { refresh_token: access_token.refresh_token },
         )
       end
 
@@ -533,8 +518,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
             Doorkeeper.config,
             access_token,
             credentials,
-            refresh_token: access_token.refresh_token,
-            resource: ["https://other.example.com/"],
+            { refresh_token: access_token.refresh_token, resource: ["https://other.example.com/"] },
           )
         end
 
@@ -551,8 +535,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
             Doorkeeper.config,
             access_token,
             credentials,
-            refresh_token: access_token.refresh_token,
-            resource: [resource_uri],
+            { refresh_token: access_token.refresh_token, resource: [resource_uri] },
           )
         end
 
@@ -570,7 +553,7 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
             Doorkeeper.config,
             access_token,
             credentials,
-            refresh_token: access_token.refresh_token,
+            { refresh_token: access_token.refresh_token },
           )
         end
 

--- a/spec/lib/oauth/token_introspection_spec.rb
+++ b/spec/lib/oauth/token_introspection_spec.rb
@@ -19,5 +19,16 @@ RSpec.describe Doorkeeper::OAuth::TokenIntrospection do
       expect(introspection.authorized?).to be(true)
       expect(introspection.error_response).to be_nil
     end
+
+    context "when the authorized token uses dpop" do
+      before { allow(authorized_token).to receive(:uses_dpop?).and_return(true) }
+
+      it "returns invalid_token error" do
+        introspection = described_class.new(server, introspected_token)
+
+        expect(introspection.authorized?).to be(false)
+        expect(introspection.error_response).to be_a(Doorkeeper::OAuth::InvalidTokenResponse)
+      end
+    end
   end
 end

--- a/spec/lib/oauth/token_spec.rb
+++ b/spec/lib/oauth/token_spec.rb
@@ -262,5 +262,66 @@ RSpec.describe Doorkeeper::OAuth::Token do
         described_class.authenticate double, token
       end
     end
+
+    context "when multiple methods are given" do
+      it "uses the first method that yields a token and ignores later ones" do
+        first  = ->(_r) { "first-token" }
+        second = double
+        expect(second).not_to receive(:call)
+
+        access_token = double("access token")
+        allow(Doorkeeper::AccessToken)
+          .to receive(:by_token).with("first-token").and_return(access_token)
+
+        expect(described_class.authenticate(double, first, second)).to eq(access_token)
+      end
+
+      it "skips methods that return a blank token" do
+        blank = ->(_r) { nil }
+        found = ->(_r) { "token" }
+
+        access_token = double("access token")
+        allow(Doorkeeper::AccessToken)
+          .to receive(:by_token).with("token").and_return(access_token)
+
+        expect(described_class.authenticate(double, blank, found)).to eq(access_token)
+      end
+
+      it "returns nil and does not query for a token when no method yields one" do
+        blank = ->(_r) { nil }
+        expect(Doorkeeper::AccessToken).not_to receive(:by_token)
+
+        expect(described_class.authenticate(double, blank)).to be_nil
+      end
+    end
+  end
+
+  describe ".resolve" do
+    it "returns a resolution instance when a token is found" do
+      found        = ->(_r) { "token" }
+      access_token = double("access token")
+
+      allow(Doorkeeper::AccessToken).to receive(:by_token).with("token").and_return(access_token)
+
+      expect(described_class.resolve(double, found)).to(
+        eq(Doorkeeper::OAuth::Token::Resolution.new(found, "token", access_token)),
+      )
+    end
+
+    it "returns nil when no method yields a token" do
+      blank = ->(_r) { nil }
+
+      expect(Doorkeeper::AccessToken).not_to receive(:by_token)
+
+      expect(described_class.resolve(double, blank)).to be_nil
+    end
+
+    it "returns nil when a token is found but no access token matches it" do
+      found = ->(_r) { "token" }
+
+      allow(Doorkeeper::AccessToken).to receive(:by_token).with("token").and_return(nil)
+
+      expect(described_class.resolve(double, found)).to be_nil
+    end
   end
 end

--- a/spec/lib/oauth/token_spec.rb
+++ b/spec/lib/oauth/token_spec.rb
@@ -247,19 +247,29 @@ RSpec.describe Doorkeeper::OAuth::Token do
         end
       end
 
-      it "revokes previous refresh_token if token was found" do
-        token = ->(_r) { "token" }
+      let(:method) { ->(_r) { "token" } }
+
+      it "revokes previous refresh_token for a bearer token" do
+        access_token = instance_double(Doorkeeper::AccessToken, uses_dpop?: false)
         expect(
           Doorkeeper::AccessToken,
-        ).to receive(:by_token).with("token").and_return(token)
-        expect(token).to receive(:revoke_previous_refresh_token!)
-        described_class.authenticate double, token
+        ).to receive(:by_token).with("token").and_return(access_token)
+        expect(access_token).to receive(:revoke_previous_refresh_token!)
+        described_class.authenticate double, method
+      end
+
+      it "does not revoke previous refresh_token for a dpop token" do
+        access_token = instance_double(Doorkeeper::AccessToken, uses_dpop?: true)
+        expect(
+          Doorkeeper::AccessToken,
+        ).to receive(:by_token).with("token").and_return(access_token)
+        expect(access_token).not_to receive(:revoke_previous_refresh_token!)
+        described_class.authenticate double, method
       end
 
       it "calls the finder if token was returned" do
-        token = ->(_r) { "token" }
         expect(Doorkeeper::AccessToken).to receive(:by_token).with("token")
-        described_class.authenticate double, token
+        described_class.authenticate double, method
       end
     end
 

--- a/spec/lib/oauth/token_spec.rb
+++ b/spec/lib/oauth/token_spec.rb
@@ -333,5 +333,40 @@ RSpec.describe Doorkeeper::OAuth::Token do
 
       expect(described_class.resolve(double, found)).to be_nil
     end
+
+    # RFC 6750 §2. resolve reads the configured methods one at a time, so the
+    # multi-method check cannot be left to from_request alone: handed a single
+    # method, from_request can never count two. The refusal has to happen
+    # here, across every method, before any token is looked up.
+    it "refuses a request where two built-in methods present tokens before looking any up" do
+      request = double.as_null_object
+      allow(described_class).to receive(:from_dpop_authorization).with(request).and_return("token-value")
+      allow(described_class).to receive(:from_access_token_param).with(request).and_return("another-token-value")
+
+      expect(Doorkeeper::AccessToken).not_to receive(:by_token)
+
+      expect { described_class.resolve(request, :from_dpop_authorization, :from_access_token_param) }
+        .to raise_error(Doorkeeper::Errors::MultipleAccessTokenMethods)
+    end
+
+    it "refuses the same token repeated across two built-in methods" do
+      request = double.as_null_object
+      allow(described_class).to receive(:from_dpop_authorization).with(request).and_return("token-value")
+      allow(described_class).to receive(:from_access_token_param).with(request).and_return("token-value")
+
+      expect { described_class.resolve(request, :from_dpop_authorization, :from_access_token_param) }
+        .to raise_error(Doorkeeper::Errors::MultipleAccessTokenMethods)
+    end
+
+    it "keeps first-wins selection for a custom callable extractor" do
+      request = double.as_null_object
+      allow(described_class).to receive(:from_dpop_authorization).with(request).and_return("token-value")
+      custom = ->(_r) { "another-token-value" }
+      access_token = double("access token")
+
+      allow(Doorkeeper::AccessToken).to receive(:by_token).with("token-value").and_return(access_token)
+
+      expect(described_class.resolve(request, :from_dpop_authorization, custom).access_token).to eq(access_token)
+    end
   end
 end

--- a/spec/lib/server_spec.rb
+++ b/spec/lib/server_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::Server do
+  subject(:server) { described_class.new(context) }
+
+  let(:context) { double("controller", request: request) }
+  let(:request) do
+    instance_double(ActionDispatch::Request, headers: ActionDispatch::Http::Headers.from_hash({}))
+  end
+
+  describe "#dpop_proof" do
+    context "when dpop is not supported" do
+      before do
+        allow(Doorkeeper.config.access_token_model).to receive(:dpop_supported?).and_return(false)
+      end
+
+      it "does not build a dpop proof, so the optional jwt gem is never required" do
+        expect(Doorkeeper::OAuth::DPoPProof).not_to receive(:new)
+
+        expect(server.dpop_proof).to be_nil
+      end
+    end
+
+    context "when dpop is supported" do
+      before do
+        allow(Doorkeeper.config.access_token_model).to receive(:dpop_supported?).and_return(true)
+      end
+
+      it "builds a dpop proof" do
+        expect(server.dpop_proof).to be_a(Doorkeeper::OAuth::DPoPProof)
+      end
+    end
+
+    context "when dpop is required" do
+      before { config_is_set(:force_dpop, true) }
+
+      it "builds a dpop proof" do
+        expect(server.dpop_proof).to be_a(Doorkeeper::OAuth::DPoPProof)
+      end
+    end
+  end
+end

--- a/spec/lib/server_spec.rb
+++ b/spec/lib/server_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Doorkeeper::Server do
 
   let(:context) { double("controller", request: request) }
   let(:request) do
-    instance_double(ActionDispatch::Request, headers: ActionDispatch::Http::Headers.from_hash({}))
+    instance_double(ActionDispatch::Request, env: {}, headers: ActionDispatch::Http::Headers.from_hash({}))
   end
 
   describe "#dpop_proof" do

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -920,6 +920,72 @@ RSpec.describe Doorkeeper::AccessToken do
         end.not_to(change { described_class.count })
       end
     end
+
+    context "when the request is DPoP-bound" do
+      it "reuses a matching token bound to the same key" do
+        existing = FactoryBot.create :access_token, default_attributes.merge(dpop_jkt: "jkt_abc")
+
+        expect do
+          token = described_class.find_or_create_for(
+            application: application,
+            resource_owner: resource_owner,
+            scopes: scopes,
+            dpop_jkt: "jkt_abc",
+          )
+          expect(token).to eq(existing)
+        end.not_to(change { described_class.count })
+      end
+
+      it "does not reuse a token bound to a different key" do
+        existing = FactoryBot.create :access_token, default_attributes.merge(dpop_jkt: "jkt_abc")
+
+        token = nil
+        expect do
+          token = described_class.find_or_create_for(
+            application: application,
+            resource_owner: resource_owner,
+            scopes: scopes,
+            dpop_jkt: "jkt_xyz",
+          )
+        end.to(change { described_class.count }.by(1))
+
+        expect(token).not_to eq(existing)
+        expect(token.dpop_jkt).to eq("jkt_xyz")
+      end
+
+      it "does not reuse a bound token when the request presents no proof" do
+        existing = FactoryBot.create :access_token, default_attributes.merge(dpop_jkt: "jkt_abc")
+
+        token = nil
+        expect do
+          token = described_class.find_or_create_for(
+            application: application,
+            resource_owner: resource_owner,
+            scopes: scopes,
+          )
+        end.to(change { described_class.count }.by(1))
+
+        expect(token).not_to eq(existing)
+        expect(token.dpop_jkt).to be_nil
+      end
+
+      it "does not reuse an unbound token when the request presents a proof" do
+        existing = FactoryBot.create :access_token, default_attributes
+
+        token = nil
+        expect do
+          token = described_class.find_or_create_for(
+            application: application,
+            resource_owner: resource_owner,
+            scopes: scopes,
+            dpop_jkt: "jkt_abc",
+          )
+        end.to(change { described_class.count }.by(1))
+
+        expect(token).not_to eq(existing)
+        expect(token.dpop_jkt).to eq("jkt_abc")
+      end
+    end
   end
 
   describe "#as_json" do

--- a/spec/models/doorkeeper/polymorphic_resource_owner_spec.rb
+++ b/spec/models/doorkeeper/polymorphic_resource_owner_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "polymorphic resource owner models" do
       )
 
       Doorkeeper::OAuth::AuthorizationCodeRequest.new(
-        server, grant, application, redirect_uri: grant.redirect_uri,
+        server, grant, application, { redirect_uri: grant.redirect_uri },
       ).authorize
 
       new_token = PolyAccessToken.order(:id).last

--- a/spec/requests/endpoints/introspection_spec.rb
+++ b/spec/requests/endpoints/introspection_spec.rb
@@ -31,6 +31,33 @@ RSpec.describe "Introspection endpoint" do
     expect(json_response).to include("active" => true)
   end
 
+  context "when authenticating the client with an access token" do
+    let(:authorized_token) { FactoryBot.create(:access_token, application: client) }
+
+    it "authorizes the request" do
+      post introspection_endpoint_url,
+           params: { token: access_token.token },
+           headers: { "HTTP_AUTHORIZATION" => "Bearer #{authorized_token.token}" }
+
+      expect(response).to be_successful
+      expect(json_response).to include("active" => true)
+    end
+
+    context "when the authorized token uses dpop" do
+      before { authorized_token.update!(dpop_jkt: "jkt_abc") }
+
+      it "rejects the request" do
+        post introspection_endpoint_url,
+             params: { token: access_token.token },
+             headers: { "HTTP_AUTHORIZATION" => "Bearer #{authorized_token.token}" }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(json_response).to include("error" => "invalid_token")
+        expect(json_response).not_to include("active")
+      end
+    end
+  end
+
   it "does not read client credentials from the query string (RFC 6749 §2.3.1)" do
     query = build_query(client_id: client.uid, client_secret: client.secret)
 

--- a/spec/requests/endpoints/introspection_spec.rb
+++ b/spec/requests/endpoints/introspection_spec.rb
@@ -75,6 +75,73 @@ RSpec.describe "Introspection endpoint" do
     end
   end
 
+  context "when introspecting a dpop token" do
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        use_refresh_token
+      end
+
+      access_token.update!(dpop_jkt: "jkt_abc")
+    end
+
+    let(:access_token) do
+      FactoryBot.create(:access_token, application: client, use_refresh_token: true)
+    end
+
+    it "reports `cnf` when the access token is presented" do
+      post introspection_endpoint_url,
+           params: { token: access_token.token },
+           headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(client) }
+
+      expect(response).to be_successful
+      expect(json_response).to include("cnf" => { "jkt" => "jkt_abc" })
+    end
+
+    context "with a public client" do
+      let(:client) { FactoryBot.create(:application, confidential: false) }
+
+      it "reports `cnf` when the refresh token is presented" do
+        post introspection_endpoint_url,
+             params: { token: access_token.refresh_token },
+             headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(client) }
+
+        expect(response).to be_successful
+        expect(json_response).to include("cnf" => { "jkt" => "jkt_abc" })
+      end
+    end
+
+    context "with a confidential client" do
+      let(:client) { FactoryBot.create(:application, confidential: true) }
+
+      it "omits `cnf` when the refresh token is presented" do
+        post introspection_endpoint_url,
+             params: { token: access_token.refresh_token },
+             headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(client) }
+
+        expect(response).to be_successful
+        expect(json_response).not_to include("cnf")
+      end
+    end
+
+    context "without a client" do
+      let(:auth_client) { FactoryBot.create(:application) }
+
+      let(:access_token) do
+        FactoryBot.create(:clientless_access_token, use_refresh_token: true)
+      end
+
+      it "reports `cnf` when the refresh token is presented" do
+        post introspection_endpoint_url,
+             params: { token: access_token.refresh_token },
+             headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(auth_client) }
+
+        expect(response).to be_successful
+        expect(json_response).to include("cnf" => { "jkt" => "jkt_abc" })
+      end
+    end
+  end
+
   # Regression specs for https://github.com/doorkeeper-gem/doorkeeper/issues/1759
   #
   # With refresh_token_revoked_on_use? the previous refresh token is revoked

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -748,4 +748,110 @@ feature "Authorization Code Flow" do
       expect(access_token.tenant_name).to eq("Tenant 1")
     end
   end
+
+  context "when using dpop" do
+    scenario "resource owner requests an access token with valid dpop proof" do
+      visit authorization_endpoint_url(client: @client)
+      click_on "Authorize"
+
+      authorization_code = Doorkeeper::AccessGrant.first.token
+      with_dpop_proof_header(htm: "POST", htu: "http://www.example.com/oauth/token")
+      create_access_token authorization_code, @client
+
+      access_token_should_exist_for(@client, @resource_owner)
+
+      expect(json_response).to match(
+        "access_token" => Doorkeeper::AccessToken.first.token,
+        "token_type" => "DPoP",
+        "expires_in" => 7200,
+        "scope" => "default",
+        "created_at" => an_instance_of(Integer),
+      )
+    end
+
+    scenario "resource owner requests an access token with an invalid dpop proof" do
+      visit authorization_endpoint_url(client: @client)
+      click_on "Authorize"
+
+      authorization_code = Doorkeeper::AccessGrant.first.token
+      with_dpop_proof_header(htm: "X", htu: "X")
+      create_access_token authorization_code, @client
+
+      access_token_should_not_exist
+
+      response_status_should_be(400)
+      expect(json_response).to match(
+        "error" => "invalid_dpop_proof",
+        "error_description" => translated_error_message(:invalid_dpop_proof),
+      )
+    end
+
+    context "when dpop is not supported" do
+      before { allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false) }
+
+      scenario "does not build a dpop proof, so the optional jwt gem is never required" do
+        expect(Doorkeeper::OAuth::DPoPProof).not_to receive(:new)
+
+        visit authorization_endpoint_url(client: @client)
+        click_on "Authorize"
+
+        authorization_code = Doorkeeper::AccessGrant.first.token
+        create_access_token authorization_code, @client
+
+        access_token_should_exist_for(@client, @resource_owner)
+      end
+
+      scenario "resource owner requests an access token with valid dpop proof" do
+        visit authorization_endpoint_url(client: @client)
+        click_on "Authorize"
+
+        authorization_code = Doorkeeper::AccessGrant.first.token
+        with_dpop_proof_header(htm: "POST", htu: "http://www.example.com/oauth/token")
+        create_access_token authorization_code, @client
+
+        access_token_should_exist_for(@client, @resource_owner)
+
+        expect(json_response).to match(
+          "access_token" => Doorkeeper::AccessToken.first.token,
+          "token_type" => "Bearer",
+          "expires_in" => 7200,
+          "scope" => "default",
+          "created_at" => an_instance_of(Integer),
+        )
+      end
+
+      scenario "resource owner requests an access token with an invalid dpop proof" do
+        visit authorization_endpoint_url(client: @client)
+        click_on "Authorize"
+
+        authorization_code = Doorkeeper::AccessGrant.first.token
+        with_dpop_proof_header(htm: "X", htu: "X")
+        create_access_token authorization_code, @client
+
+        access_token_should_exist_for(@client, @resource_owner)
+
+        response_status_should_be(200)
+      end
+    end
+
+    context "when dpop is required" do
+      before { config_is_set(:force_dpop, true) }
+
+      scenario "resource owner requests an access token without a dpop proof" do
+        visit authorization_endpoint_url(client: @client)
+        click_on "Authorize"
+
+        authorization_code = Doorkeeper::AccessGrant.first.token
+        create_access_token authorization_code, @client
+
+        access_token_should_not_exist
+
+        response_status_should_be(400)
+        expect(json_response).to match(
+          "error" => "invalid_dpop_proof",
+          "error_description" => translated_error_message(:invalid_dpop_proof),
+        )
+      end
+    end
+  end
 end

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -786,6 +786,21 @@ feature "Authorization Code Flow" do
       )
     end
 
+    scenario "reports invalid_client, not invalid_dpop_proof, when both the secret and dpop proof are invalid" do
+      visit authorization_endpoint_url(client: @client)
+      click_on "Authorize"
+
+      authorization_code = Doorkeeper::AccessGrant.first.token
+      with_dpop_proof_header(htm: "X", htu: "X")
+      page.driver.post token_endpoint_url,
+                       token_endpoint_params(code: authorization_code, client: @client, client_secret: "wrong-secret")
+
+      access_token_should_not_exist
+
+      response_status_should_be(401)
+      expect(json_response).to include("error" => "invalid_client")
+    end
+
     context "when dpop is not supported" do
       before { allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false) }
 

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -304,8 +304,106 @@ RSpec.describe "Client Credentials Request" do
     end
   end
 
+  context "when using dpop" do
+    it "authorizes the client and returns the dpop token response if the dpop proof is valid" do
+      headers =
+        authorization(client.uid, client.secret)
+          .merge(dpop(htm: "POST", htu: "http://www.example.com/oauth/token"))
+
+      params = { grant_type: "client_credentials" }
+
+      post "/oauth/token", params: params, headers: headers
+
+      expect(json_response).to match(
+        "access_token" => Doorkeeper::AccessToken.first.token,
+        "token_type" => "DPoP",
+        "expires_in" => Doorkeeper.configuration.access_token_expires_in,
+        "created_at" => an_instance_of(Integer),
+      )
+    end
+
+    it "does not authorize the client and returns the error if the dpop proof is invalid" do
+      headers = authorization(client.uid, client.secret).merge(dpop(htm: "X", htu: "X"))
+      params  = { grant_type: "client_credentials" }
+
+      post "/oauth/token", params: params, headers: headers
+
+      access_token_should_not_exist
+
+      response_status_should_be(400)
+      expect(json_response).to match(
+        "error" => "invalid_dpop_proof",
+        "error_description" => translated_error_message(:invalid_dpop_proof),
+      )
+    end
+
+    context "when dpop is not supported" do
+      before { allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false) }
+
+      it "does not build a dpop proof, so the optional jwt gem is never required" do
+        expect(Doorkeeper::OAuth::DPoPProof).not_to receive(:new)
+
+        headers = authorization(client.uid, client.secret)
+        params  = { grant_type: "client_credentials" }
+
+        post "/oauth/token", params: params, headers: headers
+
+        response_status_should_be(200)
+      end
+
+      it "authorizes the client and returns the bearer token response if the dpop proof is valid" do
+        headers =
+          authorization(client.uid, client.secret)
+            .merge(dpop(htm: "POST", htu: "http://www.example.com/oauth/token"))
+
+        params = { grant_type: "client_credentials" }
+
+        post "/oauth/token", params: params, headers: headers
+
+        expect(json_response).to match(
+          "access_token" => Doorkeeper::AccessToken.first.token,
+          "token_type" => "Bearer",
+          "expires_in" => Doorkeeper.configuration.access_token_expires_in,
+          "created_at" => an_instance_of(Integer),
+        )
+      end
+
+      it "authorizes the client validates the request without trying to validate the would be invalid dpop proof" do
+        headers = authorization(client.uid, client.secret).merge(dpop(htm: "X", htu: "X"))
+        params  = { grant_type: "client_credentials" }
+
+        post "/oauth/token", params: params, headers: headers
+
+        response_status_should_be(200)
+      end
+    end
+
+    context "when dpop is required" do
+      before { config_is_set(:force_dpop, true) }
+
+      it "does not authorize the client and returns the error if the dpop proof is missing" do
+        headers = authorization(client.uid, client.secret)
+        params  = { grant_type: "client_credentials" }
+
+        post "/oauth/token", params: params, headers: headers
+
+        access_token_should_not_exist
+
+        response_status_should_be(400)
+        expect(json_response).to match(
+          "error" => "invalid_dpop_proof",
+          "error_description" => translated_error_message(:invalid_dpop_proof),
+        )
+      end
+    end
+  end
+
   def authorization(username, password)
     credentials = ActionController::HttpAuthentication::Basic.encode_credentials username, password
     { "HTTP_AUTHORIZATION" => credentials }
+  end
+
+  def dpop(**kwargs)
+    { "HTTP_DPOP" => build_dpop_proof(**kwargs) }
   end
 end

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -337,6 +337,21 @@ RSpec.describe "Client Credentials Request" do
       )
     end
 
+    it "reports invalid_client, not invalid_dpop_proof, when both the secret and dpop proof are invalid" do
+      headers = authorization(client.uid, "wrong-secret").merge(dpop(htm: "X", htu: "X"))
+      params  = { grant_type: "client_credentials" }
+
+      post "/oauth/token", params: params, headers: headers
+
+      access_token_should_not_exist
+
+      response_status_should_be(401)
+      expect(json_response).to match(
+        "error" => "invalid_client",
+        "error_description" => translated_error_message(:invalid_client),
+      )
+    end
+
     context "when dpop is not supported" do
       before { allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false) }
 

--- a/spec/requests/flows/dpop_malformed_proof_spec.rb
+++ b/spec/requests/flows/dpop_malformed_proof_spec.rb
@@ -10,9 +10,10 @@ describe "DPoP proof with unexpected value types", type: :request do
   let(:jwk) { JWT::JWK.new(signing_key).export }
 
   def handcrafted_proof(claims:, headers: {})
-    merged = { "typ" => "dpop+jwt", "alg" => "ES256", "jwk" => jwk }.merge(headers)
+    base = { "typ" => "dpop+jwt", "alg" => "ES256", "jwk" => jwk }
+    header = headers.is_a?(Hash) ? base.merge(headers) : headers
     b64 = ->(h) { Base64.urlsafe_encode64(JSON.generate(h), padding: false) }
-    signing_input = "#{b64.call(merged)}.#{b64.call(claims)}"
+    signing_input = "#{b64.call(header)}.#{b64.call(claims)}"
     signature = JWT::JWA.resolve("ES256").sign(data: signing_input, signing_key: signing_key)
 
     "#{signing_input}.#{Base64.urlsafe_encode64(signature, padding: false)}"
@@ -54,6 +55,30 @@ describe "DPoP proof with unexpected value types", type: :request do
   it "rejects an Array jwk with 400, not 500" do
     post_token(handcrafted_proof(claims: { "jti" => "x", "iat" => Time.now.to_i },
                                  headers: { "jwk" => %w[a b] },))
+
+    expect(response.status).to eq(400)
+  end
+
+  it "rejects an Array payload segment with 400, not 500" do
+    post_token(handcrafted_proof(claims: [1, 2, 3]))
+
+    expect(response.status).to eq(400)
+  end
+
+  it "rejects a numeric payload segment with 400, not 500" do
+    post_token(handcrafted_proof(claims: 42))
+
+    expect(response.status).to eq(400)
+  end
+
+  it "rejects an Array header segment with 400, not 500" do
+    post_token(handcrafted_proof(claims: { "jti" => "x", "iat" => Time.now.to_i }, headers: [1, 2]))
+
+    expect(response.status).to eq(400)
+  end
+
+  it "rejects a numeric header segment with 400, not 500" do
+    post_token(handcrafted_proof(claims: { "jti" => "x", "iat" => Time.now.to_i }, headers: 42))
 
     expect(response.status).to eq(400)
   end

--- a/spec/requests/flows/dpop_malformed_proof_spec.rb
+++ b/spec/requests/flows/dpop_malformed_proof_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# End-to-end probe: does a malformed (but well-signed) DPoP proof surface as a
+# 400 invalid_dpop_proof, or does it escape as an unhandled 500?
+describe "DPoP proof with unexpected value types", type: :request do
+  let(:client) { FactoryBot.create :application }
+  let(:signing_key) { OpenSSL::PKey::EC.generate("prime256v1") }
+  let(:jwk) { JWT::JWK.new(signing_key).export }
+
+  def handcrafted_proof(claims:, headers: {})
+    merged = { "typ" => "dpop+jwt", "alg" => "ES256", "jwk" => jwk }.merge(headers)
+    b64 = ->(h) { Base64.urlsafe_encode64(JSON.generate(h), padding: false) }
+    signing_input = "#{b64.call(merged)}.#{b64.call(claims)}"
+    signature = JWT::JWA.resolve("ES256").sign(data: signing_input, signing_key: signing_key)
+
+    "#{signing_input}.#{Base64.urlsafe_encode64(signature, padding: false)}"
+  end
+
+  def authorization(username, password)
+    { "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password) }
+  end
+
+  def post_token(proof)
+    post "/oauth/token",
+         params: { grant_type: "client_credentials" },
+         headers: authorization(client.uid, client.secret).merge("DPoP" => proof)
+  end
+
+  it "rejects a String iat with 400, not 500" do
+    post_token(handcrafted_proof(claims: { "jti" => "x", "iat" => "not-a-number" }))
+
+    expect(response.status).to eq(400)
+    expect(json_response["error"]).to eq("invalid_dpop_proof")
+  end
+
+  it "rejects an Array iat with 400, not 500" do
+    post_token(handcrafted_proof(claims: { "jti" => "x", "iat" => [1, 2] }))
+
+    expect(response.status).to eq(400)
+  end
+
+  it "rejects an unknown jwk kty with 400, not 500" do
+    proof = handcrafted_proof(
+      claims: { "jti" => "x", "iat" => Time.now.to_i },
+      headers: { "jwk" => { "kty" => "bogus" } },
+    )
+    post_token(proof)
+
+    expect(response.status).to eq(400)
+  end
+
+  it "rejects an Array jwk with 400, not 500" do
+    post_token(handcrafted_proof(claims: { "jti" => "x", "iat" => Time.now.to_i },
+                                 headers: { "jwk" => %w[a b] },))
+
+    expect(response.status).to eq(400)
+  end
+end

--- a/spec/requests/flows/dpop_malformed_proof_spec.rb
+++ b/spec/requests/flows/dpop_malformed_proof_spec.rb
@@ -14,9 +14,20 @@ describe "DPoP proof with unexpected value types", type: :request do
     header = headers.is_a?(Hash) ? base.merge(headers) : headers
     b64 = ->(h) { Base64.urlsafe_encode64(JSON.generate(h), padding: false) }
     signing_input = "#{b64.call(header)}.#{b64.call(claims)}"
-    signature = JWT::JWA.resolve("ES256").sign(data: signing_input, signing_key: signing_key)
 
-    "#{signing_input}.#{Base64.urlsafe_encode64(signature, padding: false)}"
+    "#{signing_input}.#{Base64.urlsafe_encode64(es256_raw_signature(signing_input), padding: false)}"
+  end
+
+  # jwt 2.7 (the gemspec lower bound) has no public API to sign a hand-built
+  # signing input (JWT::JWA appeared in later releases), so produce the JWS
+  # ES256 signature directly with OpenSSL: an ECDSA DER signature unpacked
+  # into the raw 64-byte r || s form JWS requires (RFC 7518 3.4).
+  def es256_raw_signature(signing_input)
+    der = signing_key.sign(OpenSSL::Digest.new("SHA256"), signing_input)
+
+    OpenSSL::ASN1.decode(der).value.map do |int|
+      [int.value.to_i.to_s(16).rjust(64, "0")].pack("H*")
+    end.join
   end
 
   def authorization(username, password)

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -540,5 +540,99 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
         end
       end
     end
+
+    context "when using dpop" do
+      it "issues a new dpop token if the dpop proof is valid" do
+        expect do
+          post(
+            token_endpoint_url,
+            params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner),
+            headers: { "HTTP_DPOP" => build_dpop_proof(htm: "POST", htu: "http://www.example.com/oauth/token") },
+          )
+        end.to change(Doorkeeper::AccessToken, :count).by(1)
+
+        token = Doorkeeper::AccessToken.first
+
+        expect(token.application_id).to eq(@client.id)
+        expect(json_response).to include("access_token" => token.token, "token_type" => "DPoP")
+      end
+
+      it "doesn't issue new token if the dpop proof is invalid" do
+        expect do
+          post(
+            token_endpoint_url,
+            params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner),
+            headers: { "HTTP_DPOP" => build_dpop_proof(htm: "X", htu: "X") },
+          )
+        end.not_to change(Doorkeeper::AccessToken, :count)
+
+        expect(response.status).to eq(400)
+        expect(json_response).to include(
+          "error" => "invalid_dpop_proof",
+          "error_description" => an_instance_of(String),
+        )
+      end
+
+      context "when dpop is not supported" do
+        before { allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false) }
+
+        it "does not build a dpop proof, so the optional jwt gem is never required" do
+          expect(Doorkeeper::OAuth::DPoPProof).not_to receive(:new)
+
+          expect do
+            post(
+              token_endpoint_url,
+              params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner),
+            )
+          end.to change(Doorkeeper::AccessToken, :count).by(1)
+        end
+
+        it "issues a new bearer token if the dpop proof is valid" do
+          expect do
+            post(
+              token_endpoint_url,
+              params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner),
+              headers: { "HTTP_DPOP" => build_dpop_proof(htm: "POST", htu: "http://www.example.com/oauth/token") },
+            )
+          end.to change(Doorkeeper::AccessToken, :count).by(1)
+
+          token = Doorkeeper::AccessToken.first
+
+          expect(token.application_id).to eq(@client.id)
+          expect(json_response).to include("access_token" => token.token, "token_type" => "Bearer")
+        end
+
+        it "issues a new bearer token if the dpop proof is invalid" do
+          expect do
+            post(
+              token_endpoint_url,
+              params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner),
+              headers: { "HTTP_DPOP" => build_dpop_proof(htm: "X", htu: "X") },
+            )
+          end.to change(Doorkeeper::AccessToken, :count).by(1)
+
+          token = Doorkeeper::AccessToken.first
+
+          expect(token.application_id).to eq(@client.id)
+          expect(json_response).to include("access_token" => token.token, "token_type" => "Bearer")
+        end
+      end
+
+      context "when dpop is required" do
+        before { config_is_set(:force_dpop, true) }
+
+        it "doesn't issue new token if the dpop proof is missing" do
+          expect do
+            post(token_endpoint_url, params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner))
+          end.not_to change(Doorkeeper::AccessToken, :count)
+
+          expect(response.status).to eq(400)
+          expect(json_response).to include(
+            "error" => "invalid_dpop_proof",
+            "error_description" => an_instance_of(String),
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -573,6 +573,23 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
         )
       end
 
+      it "reports invalid_client, not invalid_dpop_proof, when both the secret and dpop proof are invalid" do
+        expect do
+          post(
+            token_endpoint_url,
+            params: password_token_endpoint_params(
+              client: @client,
+              resource_owner: @resource_owner,
+              client_secret: "wrong-secret",
+            ),
+            headers: { "HTTP_DPOP" => build_dpop_proof(htm: "X", htu: "X") },
+          )
+        end.not_to change(Doorkeeper::AccessToken, :count)
+
+        expect(response.status).to eq(401)
+        expect(json_response).to include("error" => "invalid_client")
+      end
+
       context "when dpop is not supported" do
         before { allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false) }
 

--- a/spec/requests/flows/refresh_token_spec.rb
+++ b/spec/requests/flows/refresh_token_spec.rb
@@ -388,4 +388,317 @@ RSpec.describe "Refresh Token Flow" do
       )
     end
   end
+
+  context "when using dpop" do
+    def build_dpop_proof(htm: "POST", htu: "http://www.example.com/oauth/token", signing_key: self.signing_key)
+      super
+    end
+
+    let(:invalid_dpop_proof) { build_dpop_proof(htm: "X") }
+    let(:mismatched_dpop_proof) { build_dpop_proof(signing_key: OpenSSL::PKey::EC.generate("prime256v1")) }
+    let(:valid_dpop_proof) { build_dpop_proof }
+
+    let(:jkt) { JWT::JWK::Thumbprint.new(JWT::JWK.new(signing_key)).generate }
+    let(:signing_key) { OpenSSL::PKey::EC.generate("prime256v1") }
+
+    let!(:token) do
+      FactoryBot.create(
+        :access_token,
+        application: client,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        use_refresh_token: true,
+      )
+    end
+
+    context "with a private client" do
+      def make_refresh_request(headers: {})
+        post refresh_token_endpoint_url,
+             params: refresh_token_endpoint_params(client:, refresh_token: token.refresh_token),
+             headers:
+      end
+
+      let(:client) { @client }
+
+      it "binds the new access token to the dpop proof's public key if it is valid" do
+        make_refresh_request(headers: { "HTTP_DPOP" => valid_dpop_proof })
+
+        new_token = Doorkeeper::AccessToken.last
+        expect(json_response).to include(
+          "access_token" => new_token.token,
+          "token_type" => "DPoP",
+          "refresh_token" => new_token.refresh_token,
+        )
+        expect(new_token).to be_uses_dpop
+        expect(new_token.dpop_jkt).to eq(jkt)
+      end
+
+      it "does not issue a new access token if dpop proof is invalid" do
+        expect do
+          make_refresh_request(headers: { "HTTP_DPOP" => invalid_dpop_proof })
+        end.not_to change(Doorkeeper::AccessToken, :count)
+
+        expect(json_response).to match(
+          "error" => "invalid_dpop_proof",
+          "error_description" => "Invalid DPoP proof",
+        )
+      end
+
+      context "when refreshing an access token that uses dpop" do
+        let!(:token) { super().tap { |it| it.update!(dpop_jkt: jkt) } }
+
+        it "issues a new access token without presenting a dpop proof since it already presents client credentials to refresh" do
+          make_refresh_request
+
+          new_token = Doorkeeper::AccessToken.last
+          expect(json_response).to include(
+            "access_token" => new_token.token,
+            "token_type" => "DPoP",
+            "refresh_token" => new_token.refresh_token,
+          )
+          expect(new_token).to be_uses_dpop
+          expect(new_token.dpop_jkt).to eq(token.dpop_jkt)
+        end
+
+        it "does not issue a new access token if dpop proof is invalid" do
+          expect do
+            make_refresh_request(headers: { "HTTP_DPOP" => invalid_dpop_proof })
+          end.not_to change(Doorkeeper::AccessToken, :count)
+
+          expect(json_response).to match(
+            "error" => "invalid_dpop_proof",
+            "error_description" => "Invalid DPoP proof",
+          )
+        end
+
+        it "binds the new access token to the dpop proof's new public key so long as it is valid" do
+          make_refresh_request(headers: { "HTTP_DPOP" => mismatched_dpop_proof })
+
+          new_token = Doorkeeper::AccessToken.last
+          expect(json_response).to include(
+            "access_token" => new_token.token,
+            "token_type" => "DPoP",
+            "refresh_token" => new_token.refresh_token,
+          )
+          expect(new_token).to be_uses_dpop
+          expect(new_token.dpop_jkt).not_to eq(token.dpop_jkt)
+
+          jkt_from_mismatched_dpop_proof =
+            JWT::JWK::Thumbprint.new(JWT::JWK.import(JWT.decode(mismatched_dpop_proof, nil, false)[1]["jwk"])).generate
+          expect(new_token.dpop_jkt).to eq(jkt_from_mismatched_dpop_proof)
+        end
+      end
+
+      context "when dpop is not supported" do
+        before { allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false) }
+
+        it "does not build a dpop proof, so the optional jwt gem is never required" do
+          expect(Doorkeeper::OAuth::DPoPProof).not_to receive(:new)
+
+          expect do
+            make_refresh_request
+          end.to change(Doorkeeper::AccessToken, :count).by(1)
+        end
+
+        it "issues a new unbound access token if the dpop proof is valid" do
+          make_refresh_request(headers: { "HTTP_DPOP" => valid_dpop_proof })
+
+          new_token = Doorkeeper::AccessToken.last
+          expect(json_response).to include(
+            "access_token" => new_token.token,
+            "token_type" => "Bearer",
+            "refresh_token" => new_token.refresh_token,
+          )
+          expect(new_token).not_to be_uses_dpop
+        end
+
+        it "issues a new unbound access token if the dpop proof is invalid" do
+          make_refresh_request(headers: { "HTTP_DPOP" => invalid_dpop_proof })
+
+          new_token = Doorkeeper::AccessToken.last
+          expect(json_response).to include(
+            "access_token" => new_token.token,
+            "token_type" => "Bearer",
+            "refresh_token" => new_token.refresh_token,
+          )
+          expect(new_token).not_to be_uses_dpop
+        end
+      end
+
+      context "when dpop is required" do
+        before { config_is_set(:force_dpop, true) }
+
+        it "does not issue a new access token if the dpop proof is missing" do
+          expect do
+            make_refresh_request
+          end.not_to change(Doorkeeper::AccessToken, :count)
+
+          expect(json_response).to match(
+            "error" => "invalid_dpop_proof",
+            "error_description" => "Invalid DPoP proof",
+          )
+        end
+
+        context "when refreshing an access token that uses dpop" do
+          let!(:token) { super().tap { |it| it.update!(dpop_jkt: jkt) } }
+
+          it "issues a new access token without presenting a dpop proof since it already presents client credentials to refresh" do
+            make_refresh_request
+
+            new_token = Doorkeeper::AccessToken.last
+            expect(json_response).to include(
+              "access_token" => new_token.token,
+              "token_type" => "DPoP",
+              "refresh_token" => new_token.refresh_token,
+            )
+            expect(new_token).to be_uses_dpop
+            expect(new_token.dpop_jkt).to eq(token.dpop_jkt)
+          end
+
+          it "binds the new access token to the dpop proof's new public key so long as it is valid" do
+            make_refresh_request(headers: { "HTTP_DPOP" => mismatched_dpop_proof })
+
+            new_token = Doorkeeper::AccessToken.last
+            expect(json_response).to include(
+              "access_token" => new_token.token,
+              "token_type" => "DPoP",
+              "refresh_token" => new_token.refresh_token,
+            )
+            expect(new_token).to be_uses_dpop
+            expect(new_token.dpop_jkt).not_to eq(token.dpop_jkt)
+
+            jkt_from_mismatched_dpop_proof =
+              JWT::JWK::Thumbprint.new(JWT::JWK.import(JWT.decode(mismatched_dpop_proof, nil, false)[1]["jwk"])).generate
+            expect(new_token.dpop_jkt).to eq(jkt_from_mismatched_dpop_proof)
+          end
+        end
+      end
+    end
+
+    context "with a public client" do
+      def make_refresh_request(headers: {})
+        post refresh_token_endpoint_url,
+             params: refresh_token_endpoint_params(client_id: client.uid, refresh_token: token.refresh_token),
+             headers:
+      end
+
+      let(:client) { FactoryBot.create(:application, confidential: false) }
+
+      it "binds the new access token to the dpop proof's public key if it is valid" do
+        make_refresh_request(headers: { "HTTP_DPOP" => valid_dpop_proof })
+
+        new_token = Doorkeeper::AccessToken.last
+        expect(json_response).to include(
+          "access_token" => new_token.token,
+          "token_type" => "DPoP",
+          "refresh_token" => new_token.refresh_token,
+        )
+        expect(new_token).to be_uses_dpop
+        expect(new_token.dpop_jkt).to eq(jkt)
+      end
+
+      it "does not issue a new access token if dpop proof is invalid" do
+        expect do
+          make_refresh_request(headers: { "HTTP_DPOP" => invalid_dpop_proof })
+        end.not_to change(Doorkeeper::AccessToken, :count)
+
+        expect(json_response).to match(
+          "error" => "invalid_dpop_proof",
+          "error_description" => "Invalid DPoP proof",
+        )
+      end
+
+      context "when refreshing an access token that uses dpop" do
+        let!(:token) { super().tap { |it| it.update!(dpop_jkt: jkt) } }
+
+        it "does not issue a new access token if dpop proof is missing" do
+          expect do
+            make_refresh_request
+          end.not_to change(Doorkeeper::AccessToken, :count)
+
+          expect(json_response).to match(
+            "error" => "invalid_dpop_proof",
+            "error_description" => "Invalid DPoP proof",
+          )
+        end
+
+        it "does not issue a new access token if the public keys are mismatched" do
+          expect do
+            make_refresh_request(headers: { "HTTP_DPOP" => mismatched_dpop_proof })
+          end.not_to change(Doorkeeper::AccessToken, :count)
+
+          expect(json_response).to match(
+            "error" => "invalid_dpop_proof",
+            "error_description" => "Invalid DPoP proof",
+          )
+        end
+      end
+
+      context "when dpop is not supported" do
+        before { allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false) }
+
+        it "does not build a dpop proof, so the optional jwt gem is never required" do
+          expect(Doorkeeper::OAuth::DPoPProof).not_to receive(:new)
+
+          expect do
+            make_refresh_request
+          end.to change(Doorkeeper::AccessToken, :count).by(1)
+        end
+
+        it "issues a new unbound access token if the dpop proof is valid" do
+          make_refresh_request(headers: { "HTTP_DPOP" => valid_dpop_proof })
+
+          new_token = Doorkeeper::AccessToken.last
+          expect(json_response).to include(
+            "access_token" => new_token.token,
+            "token_type" => "Bearer",
+            "refresh_token" => new_token.refresh_token,
+          )
+          expect(new_token).not_to be_uses_dpop
+        end
+
+        it "issues a new unbound access token if the dpop proof is invalid" do
+          make_refresh_request(headers: { "HTTP_DPOP" => invalid_dpop_proof })
+
+          new_token = Doorkeeper::AccessToken.last
+          expect(json_response).to include(
+            "access_token" => new_token.token,
+            "token_type" => "Bearer",
+            "refresh_token" => new_token.refresh_token,
+          )
+          expect(new_token).not_to be_uses_dpop
+        end
+      end
+
+      context "when dpop is required" do
+        before { config_is_set(:force_dpop, true) }
+
+        it "does not issue a new access token if the dpop proof is missing" do
+          expect do
+            make_refresh_request
+          end.not_to change(Doorkeeper::AccessToken, :count)
+
+          expect(json_response).to match(
+            "error" => "invalid_dpop_proof",
+            "error_description" => "Invalid DPoP proof",
+          )
+        end
+
+        context "when refreshing an access token that uses dpop" do
+          let!(:token) { super().tap { |it| it.update!(dpop_jkt: jkt) } }
+
+          it "does not issue a new access token if the dpop proof is missing" do
+            expect do
+              make_refresh_request
+            end.not_to change(Doorkeeper::AccessToken, :count)
+
+            expect(json_response).to match(
+              "error" => "invalid_dpop_proof",
+              "error_description" => "Invalid DPoP proof",
+            )
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/flows/refresh_token_spec.rb
+++ b/spec/requests/flows/refresh_token_spec.rb
@@ -444,6 +444,17 @@ RSpec.describe "Refresh Token Flow" do
         )
       end
 
+      it "reports invalid_client, not invalid_dpop_proof, when both the secret and dpop proof are invalid" do
+        expect do
+          post refresh_token_endpoint_url,
+               params: refresh_token_endpoint_params(client:, client_secret: "wrong-secret", refresh_token: token.refresh_token),
+               headers: { "HTTP_DPOP" => invalid_dpop_proof }
+        end.not_to change(Doorkeeper::AccessToken, :count)
+
+        expect(response.status).to eq(401)
+        expect(json_response).to include("error" => "invalid_client")
+      end
+
       context "when refreshing an access token that uses dpop" do
         let!(:token) { super().tap { |it| it.update!(dpop_jkt: jkt) } }
 

--- a/spec/support/helpers/dpop_helper.rb
+++ b/spec/support/helpers/dpop_helper.rb
@@ -3,8 +3,8 @@
 require "jwt"
 
 module DPoPHelper
-  def build_dpop_proof(htm:, htu:, signing_key: OpenSSL::PKey::EC.generate("prime256v1"))
-    claims = { "jti" => "jti_01", "iat" => Time.current.to_i, "htm" => htm, "htu" => htu }
+  def build_dpop_proof(htm:, htu:, ath: nil, signing_key: OpenSSL::PKey::EC.generate("prime256v1"))
+    claims = { "jti" => "jti_01", "iat" => Time.current.to_i, "ath" => ath, "htm" => htm, "htu" => htu }.compact
 
     headers = { "typ" => "dpop+jwt", "alg" => "ES256", "jwk" => JWT::JWK.new(signing_key).export }
 

--- a/spec/support/helpers/dpop_helper.rb
+++ b/spec/support/helpers/dpop_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "jwt"
+
+module DPoPHelper
+  def build_dpop_proof(htm:, htu:, signing_key: OpenSSL::PKey::EC.generate("prime256v1"))
+    claims = { "jti" => "jti_01", "iat" => Time.current.to_i, "htm" => htm, "htu" => htu }
+
+    headers = { "typ" => "dpop+jwt", "alg" => "ES256", "jwk" => JWT::JWK.new(signing_key).export }
+
+    JWT.encode(claims, signing_key, headers["alg"], headers)
+  end
+
+  def dpop_proof_double(messages = {})
+    blank = messages.fetch(:blank?, false)
+    valid = messages.fetch(:valid?, !blank)
+
+    raise ArgumentError, "can't be blank? && valid?" if blank && valid
+
+    instance_double(Doorkeeper::OAuth::DPoPProof, blank?: blank)
+      .tap { |it| allow(it).to receive(:valid?) { it.present? && valid } }
+      .tap { |it| allow(it).to receive(:jkt) { !it.valid? ? nil : "jkt_123" } }
+  end
+end
+
+RSpec.configuration.send :include, DPoPHelper

--- a/spec/support/helpers/request_spec_helper.rb
+++ b/spec/support/helpers/request_spec_helper.rb
@@ -49,6 +49,10 @@ module RequestSpecHelper
     with_header "Authorization", "Bearer #{token}"
   end
 
+  def with_dpop_proof_header(**kwargs)
+    with_header "DPoP", build_dpop_proof(**kwargs)
+  end
+
   def with_header(header, value)
     page.driver.header(header, value)
   end

--- a/spec/support/shared/controllers_shared_context.rb
+++ b/spec/support/shared/controllers_shared_context.rb
@@ -6,8 +6,10 @@ shared_context "valid token", token: :valid do
   let :token do
     double(
       Doorkeeper::AccessToken,
-      accessible?: true, includes_scope?: true, acceptable?: true,
+      accessible?: true, revoked?: false, expired?: false,
+      includes_scope?: true, acceptable?: true,
       previous_refresh_token: "", revoke_previous_refresh_token!: true,
+      uses_dpop?: false,
     )
   end
 
@@ -27,6 +29,7 @@ shared_context "invalid token", token: :invalid do
       accessible?: false, revoked?: false, expired?: false,
       includes_scope?: false, acceptable?: false,
       previous_refresh_token: "", revoke_previous_refresh_token!: true,
+      uses_dpop?: false,
     )
   end
 
@@ -48,6 +51,7 @@ shared_context "expired token", token: :expired do
       accessible?: false, revoked?: false, expired?: true,
       includes_scope?: false, acceptable?: false,
       previous_refresh_token: "", revoke_previous_refresh_token!: true,
+      uses_dpop?: false,
     )
   end
 
@@ -69,6 +73,7 @@ shared_context "revoked token", token: :revoked do
       accessible?: false, revoked?: true, expired?: false,
       includes_scope?: false, acceptable?: false,
       previous_refresh_token: "", revoke_previous_refresh_token!: true,
+      uses_dpop?: false,
     )
   end
 
@@ -89,6 +94,7 @@ shared_context "forbidden token", token: :forbidden do
       Doorkeeper::AccessToken,
       accessible?: true, includes_scope?: true, acceptable?: false,
       previous_refresh_token: "", revoke_previous_refresh_token!: true,
+      uses_dpop?: false,
     )
   end
 
@@ -96,5 +102,17 @@ shared_context "forbidden token", token: :forbidden do
     allow(
       Doorkeeper::AccessToken,
     ).to receive(:by_token).with(token_string).and_return(token)
+  end
+end
+
+shared_context "dpop token", token: :dpop do
+  let(:jkt) { JWT::JWK::Thumbprint.new(JWT::JWK.new(signing_key)).generate }
+  let(:signing_key) { OpenSSL::PKey::EC.generate("prime256v1") }
+
+  let(:token_string) { "1A2B3C4D" }
+  let(:token) { FactoryBot.create(:access_token, token: token_string, dpop_jkt: jkt) }
+
+  before do
+    allow(Doorkeeper::AccessToken).to receive(:by_token).with(token_string).and_return(token)
   end
 end

--- a/spec/support/shared/controllers_shared_examples.rb
+++ b/spec/support/shared/controllers_shared_examples.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+shared_examples "enforcing proof of possession using dpop" do
+  context "when using dpop", token: :dpop do
+    def self.controller(&block)
+      super(described_class || ::ApplicationController) do
+        def index # rubocop:disable Lint/NestedMethodDefinition
+          render plain: "index"
+        end
+
+        def doorkeeper_unauthorized_render_options(error: nil) # rubocop:disable Lint/NestedMethodDefinition
+          { json: ActiveSupport::JSON.encode(error: error.name, error_description: error.description) }
+        end
+
+        instance_eval(&block)
+      end
+    end
+
+    def build_dpop_proof(ath: Base64.urlsafe_encode64(Digest::SHA256.digest(token_string), padding: false),
+                         htm: "GET",
+                         htu: "http://test.host/#{controller.controller_path}",
+                         signing_key: self.signing_key)
+      super
+    end
+
+    controller do
+      before_action :doorkeeper_authorize!
+    end
+
+    it "accepts a valid dpop proof" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = build_dpop_proof
+      get :index
+
+      expect(response).to be_successful
+    end
+
+    it "rejects an invalid dpop proof with incorrect request details" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = build_dpop_proof(htm: "X")
+      get :index
+
+      expect(response).to be_unauthorized
+      expect(response.header["WWW-Authenticate"]).to match(/^Bearer, DPoP/)
+
+      expect(json_response["error"]).to match("invalid_dpop_proof")
+      expect(json_response["error_description"]).to match("Invalid DPoP proof")
+    end
+
+    it "rejects an invalid dpop proof with ath claim" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = build_dpop_proof(ath: "X")
+      get :index
+
+      expect(response).to be_unauthorized
+      expect(response.header["WWW-Authenticate"]).to match(/^Bearer, DPoP/)
+
+      expect(json_response["error"]).to match("invalid_dpop_proof")
+      expect(json_response["error_description"]).to match("Invalid DPoP proof")
+    end
+
+    it "rejects an invalid dpop proof with mismatched public keys" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = build_dpop_proof(signing_key: OpenSSL::PKey::EC.generate("prime256v1"))
+      get :index
+
+      expect(response).to be_unauthorized
+      expect(response.header["WWW-Authenticate"]).to match(/^Bearer, DPoP/)
+
+      expect(json_response["error"]).to match("invalid_token")
+      expect(json_response["error_description"]).to match("Invalid DPoP key binding")
+    end
+
+    it "rejects a dpop token received as a bearer token" do
+      request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
+      get :index
+
+      expect(response).to be_unauthorized
+      expect(response.header["WWW-Authenticate"]).to match(/^Bearer.*DPoP algs="ES256 PS256"$/)
+
+      expect(json_response["error"]).to match("invalid_token")
+      expect(json_response["error_description"]).to match("The access token is invalid")
+    end
+
+    it "rejects a bearer token received as a dpop token", token: :valid do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      get :index
+
+      expect(response).to be_unauthorized
+      expect(response.header["WWW-Authenticate"]).to match(/^Bearer, DPoP/)
+
+      expect(json_response["error"]).to match("invalid_dpop_proof")
+      expect(json_response["error_description"]).to match("Invalid DPoP proof")
+    end
+
+    it "rejects an empty dpop proof" do
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      get :index
+
+      expect(response).to be_unauthorized
+      expect(response.header["WWW-Authenticate"]).to match(/^Bearer, DPoP/)
+
+      expect(json_response["error"]).to match("invalid_dpop_proof")
+      expect(json_response["error_description"]).to match("Invalid DPoP proof")
+    end
+
+    it "rejects an unknown token presented via dpop with a bad proof as invalid_token" do
+      allow(Doorkeeper::AccessToken).to receive(:by_token).with(token_string).and_return(nil)
+
+      request.env["HTTP_AUTHORIZATION"] = "DPoP #{token_string}"
+      request.env["HTTP_DPOP"] = build_dpop_proof(htm: "X")
+      get :index
+
+      expect(response).to be_unauthorized
+      expect(response.header["WWW-Authenticate"]).to include("Bearer")
+      expect(response.header["WWW-Authenticate"]).to include("DPoP")
+
+      expect(json_response["error"]).to match("invalid_token")
+    end
+
+    it "rejects a request without an authorization token" do
+      request.env["HTTP_DPOP"] = build_dpop_proof
+      get :index
+
+      expect(response).to be_unauthorized
+      expect(response.header["WWW-Authenticate"]).to include("Bearer")
+      expect(response.header["WWW-Authenticate"]).to include("DPoP")
+      expect(response.header["WWW-Authenticate"]).to include("error=").twice
+
+      expect(json_response["error"]).to match("invalid_token")
+      expect(json_response["error_description"]).to match("The access token is invalid")
+    end
+
+    context "when dpop is not supported" do
+      before do
+        allow(Doorkeeper.config.access_token_model).to receive(:dpop_supported?).and_return(false)
+      end
+
+      it "accepts a dpop-bound token presented as a bearer token" do
+        request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
+        get :index
+
+        expect(response).to be_successful
+      end
+
+      it "rejects an invalid token and challenges with only bearer", token: :invalid do
+        request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
+        get :index
+
+        expect(response).to be_unauthorized
+        expect(response.header["WWW-Authenticate"]).to match(/^Bearer/)
+        expect(response.header["WWW-Authenticate"]).not_to include("DPoP")
+
+        expect(json_response["error"]).to match("invalid_token")
+        expect(json_response["error_description"]).to match("The access token is invalid")
+      end
+    end
+
+    context "when dpop required" do
+      controller do
+        before_action { doorkeeper_authorize!(dpop: :required) }
+      end
+
+      it "rejects a valid bearer token", token: :valid do
+        request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
+        get :index
+
+        expect(response).to be_unauthorized
+        expect(response.header["WWW-Authenticate"]).to match(/^DPoP/)
+        expect(response.header["WWW-Authenticate"]).not_to include("Bearer")
+
+        expect(json_response["error"]).to match("invalid_token")
+        expect(json_response["error_description"]).to match("The access token is invalid")
+      end
+
+      context "when doorkeeper_token is accessed before require is set" do
+        controller do
+          before_action { doorkeeper_token }
+          before_action { doorkeeper_authorize!(dpop: :required) }
+        end
+
+        it "rejects a valid bearer token", token: :valid do
+          request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
+          get :index
+
+          expect(response).to be_unauthorized
+          expect(response.header["WWW-Authenticate"]).to match(/^DPoP/)
+          expect(response.header["WWW-Authenticate"]).not_to include("Bearer")
+
+          expect(json_response["error"]).to match("invalid_token")
+          expect(json_response["error_description"]).to match("The access token is invalid")
+        end
+      end
+    end
+
+    context "when dpop required because from_dpop_authorization is the only configured access_token_method" do
+      before do
+        config_is_set(:access_token_methods, %i[from_dpop_authorization])
+      end
+
+      it "rejects a valid bearer token", token: :valid do
+        request.env["HTTP_AUTHORIZATION"] = "Bearer #{token_string}"
+        get :index
+
+        expect(response).to be_unauthorized
+        expect(response.header["WWW-Authenticate"]).to match(/^DPoP/)
+        expect(response.header["WWW-Authenticate"]).not_to include("Bearer")
+
+        expect(json_response["error"]).to match("invalid_token")
+        expect(json_response["error_description"]).to match("The access token is invalid")
+      end
+    end
+  end
+end

--- a/spec/support/shared/requests_shared_examples.rb
+++ b/spec/support/shared/requests_shared_examples.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+shared_examples "sender-constraining access_token using dpop" do |when_bearer_token_expected: nil, when_dpop_token_expected: nil|
+  context "when using dpop" do
+    context "when the dpop proof is valid" do
+      let(:dpop_proof) { dpop_proof_double }
+
+      it "issues a dpop token" do
+        instance_exec(&when_dpop_token_expected) if when_dpop_token_expected
+        request.authorize
+
+        next if when_dpop_token_expected
+
+        issued_token = Doorkeeper::AccessToken.last
+        expect(issued_token).to be_uses_dpop
+        expect(issued_token.token_type).to eq("DPoP")
+        expect(issued_token.dpop_jkt).to eq("jkt_123")
+      end
+    end
+
+    context "when the dpop proof is invalid" do
+      let(:dpop_proof) { dpop_proof_double(valid?: false) }
+
+      it "invalidates the request" do
+        request.validate
+        expect(request.error).to eq(Doorkeeper::Errors::InvalidDPoPProof)
+      end
+    end
+
+    context "when dpop is not supported" do
+      before { allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false) }
+
+      context "when the dpop proof is valid" do
+        let(:dpop_proof) { dpop_proof_double }
+
+        it "issues a Bearer token" do
+          instance_exec(&when_bearer_token_expected) if when_bearer_token_expected
+          request.authorize
+
+          next if when_bearer_token_expected
+
+          issued_token = Doorkeeper::AccessToken.last
+          expect(issued_token).not_to be_uses_dpop
+          expect(issued_token.token_type).to eq("Bearer")
+        end
+      end
+
+      context "when the dpop proof is invalid" do
+        let(:dpop_proof) { dpop_proof_double(valid?: false) }
+
+        it "validates the request without trying to validate the would be invalid dpop proof" do
+          request.validate
+          expect(request.error).to be_nil
+        end
+      end
+    end
+
+    context "when dpop is required" do
+      before { config_is_set(:force_dpop, true) }
+
+      context "when the dpop proof is blank" do
+        let(:dpop_proof) { dpop_proof_double(blank?: true) }
+
+        it "invalidates the request" do
+          request.validate
+          expect(request.error).to eq(Doorkeeper::Errors::InvalidDPoPProof)
+        end
+      end
+
+      context "when dpop is not supported" do
+        before { allow(Doorkeeper::AccessToken).to receive(:dpop_supported?).and_return(false) }
+
+        it "invalidates the request rather than issuing an unbound bearer token" do
+          request.validate
+          expect(request.error).to eq(Doorkeeper::Errors::InvalidDPoPProof)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### summary

adds a minimally spec-compliant implementation of [oauth 2.0 demonstrating proof of possession (dpop)](https://datatracker.ietf.org/doc/html/rfc9449).

closes https://github.com/doorkeeper-gem/doorkeeper/issues/1655

### overview

dpop is a sender-constraining mechanism that binds access tokens to a client's cryptographic key pair. unlike bearer tokens, a dpop-bound token can't be used by an attacker who intercepts it -- they'd also need the private key that corresponds to the public key presented when the token was issued.

this covers both halves of doorkeeper: issuing dpop-bound access tokens (authorization server) and enforcing the key binding when authenticating (resource server).

the feature is fully opt-in. nothing changes for existing installations unless you run `rails generate doorkeeper:dpop` and migrate.

### how it works

on the authorization server side, when a token request includes a `DPoP` header or `force_dpop?` is configured, the proof is validated and the resulting access token is bound to the public key via its jwk sha-256 thumbprint. 

on the resource server side, when a dpop-bound token is presented or required (by either configuration or the endpoint), the accompanying proof must be valid and its key must match the one the token was originally bound to. 

### refresh token flow

the refresh token flow follows the spec's distinction between confidential and public clients. 

a confidential client that refreshes a dpop-bound token can optionally include a new dpop proof:
- if it does, the new token is bound to that proof's key
- if it doesn't, the binding carries forward from the original token

a public client must always include a valid dpop proof whose key matches the original binding.

### `force_dpop` vs `access_token_methods == %i[from_dpop_authorization]`

when doorkeeper is acting as an authorization server, `force_dpop` requires every token request to include a valid dpop proof and ensures the minted access token is bound to that proof's public key. 

when acting as a resource server, dpop is considered required if `from_dpop_authorization` is the only configured access token method, or if the endpoint has explicitly required it via `doorkeeper_authorize!(dpop: :required)`.

### `www-authenticate` headers

the error response `www-authenticate` headers are context-sensitive. when dpop is required, only the dpop scheme is advertised. when both bearer and dpop are supported, the header includes both schemes along with the supported algorithms. when a specific access token method was used to authenticate, the header reflects that method. this follows the guidance in the spec around telling clients what the server actually accepts.

### other information

#### optional specifications this skips

this intentionally omits a few optional parts of the spec:

- there's no `jti` tracking to prevent dpop proof replays ([section 11.1](https://datatracker.ietf.org/doc/html/rfc9449#name-dpop-proof-replay))
- no server-provided nonces to prevent pre-generated proofs ([section 8](https://datatracker.ietf.org/doc/html/rfc9449#name-authorization-server-provid)), and 
- no authorization code binding to a dpop key ([section 10](https://datatracker.ietf.org/doc/html/rfc9449#name-authorization-code-binding-))
 
all of these would be reasonable follow-ups but aren't required for a baseline implementation, and the first two each introduce storage / coordination concerns that deserve their own consideration.

#### stores `dpop_jkt` on the `oauth_access_tokens` table

the spec describes storing the bound public key in the token itself when the format allows for it (i.e., it's a jwt). however, doorkeeper doesn't natively issue structured tokens, and storing the thumbprint in the database is in keeping with the surrounding gem's approach.

the spec allows for other association methods in [section 6](https://datatracker.ietf.org/doc/html/rfc9449#name-public-key-confirmation), but doesn't describe any beyond the jwt-based approach. that said, at some point it may make sense to allow the dpop binding to be stored directly in the token if `doorkeeper-jwt` is being used.

#### `jwt` dependency

this adds the `jwt` gem as a runtime dependency (not in the gemspec, required when the dpop proof class loads) to validate and decode dpop proofs.