### PR TITLE
fix: detailed error 'insufficient_scope' in protected resources 403s

### DIFF
--- a/lib/doorkeeper/oauth/error_response.rb
+++ b/lib/doorkeeper/oauth/error_response.rb
@@ -94,7 +94,26 @@ module Doorkeeper
       private
 
       def authenticate_info
-        %(Bearer realm="#{realm}", error="#{name}", error_description="#{description}")
+        %(Bearer realm="#{realm}", error="#{sanitize_error_values(name)}", error_description="#{sanitize_error_values(description)}")
+      end
+
+      # This method removes any characters that are invalid in error
+      # details per RFC6750.
+      #
+      # > Values for the "error" and "error_description" attributes
+      # > (specified in Appendixes A.7 and A.8 of [RFC6749]) MUST NOT
+      # > include characters outside the set %x20-21 (" " or "!") / %x23-5B /
+      # > %x5D-7E (ascii "#" to "~" without "\").
+      def sanitize_error_values(string)
+        string.to_s.each_char.map do |char|
+          if char.in?("\x20".encode("utf-8").."\x21".encode("utf-8")) ||
+            char.in?("\x23".encode("utf-8").."\x5B".encode("utf-8")) ||
+             char.in?("\x5D".encode("utf-8").."\x7E".encode("utf-8"))
+            char
+          else
+            "_"
+          end
+        end.join("")
       end
     end
   end

--- a/lib/doorkeeper/oauth/forbidden_token_response.rb
+++ b/lib/doorkeeper/oauth/forbidden_token_response.rb
@@ -8,18 +8,12 @@ module Doorkeeper
       end
 
       def initialize(attributes = {})
-        super(attributes.merge(name: :invalid_scope, state: :forbidden))
+        super(attributes.merge(name: :insufficient_scope, state: :forbidden))
         @scopes = attributes[:scopes]
       end
 
       def status
         :forbidden
-      end
-
-      def headers
-        headers = super
-        headers.delete "WWW-Authenticate"
-        headers
       end
 
       def description

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "doorkeeper authorize filter" do
 
       get :index, params: { access_token: token_string }
       expect(response.status).to eq 403
-      expect(response.header).not_to include("WWW-Authenticate")
+      expect(response.header["WWW-Authenticate"]).to include('error="insufficient_scope"')
     end
   end
 
@@ -255,7 +255,7 @@ RSpec.describe "doorkeeper authorize filter" do
 
       it "renders a custom JSON response" do
         get :index, params: { access_token: token_string }
-        expect(response.header).not_to include("WWW-Authenticate")
+        expect(response.header["WWW-Authenticate"]).to include('error="insufficient_scope"')
         expect(response.content_type).to include("application/json")
         expect(response.status).to eq 403
 
@@ -294,7 +294,7 @@ RSpec.describe "doorkeeper authorize filter" do
 
       it "renders a custom status code and text response" do
         get :index, params: { access_token: token_string }
-        expect(response.header).not_to include("WWW-Authenticate")
+        expect(response.header["WWW-Authenticate"]).to include('error="insufficient_scope"')
         expect(response.status).to eq 403
         expect(response.body).to eq("Forbidden")
       end

--- a/spec/lib/oauth/error_response_spec.rb
+++ b/spec/lib/oauth/error_response_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe Doorkeeper::OAuth::ErrorResponse do
       it { expect(headers).to include("realm=\"#{error_response.send(:realm)}\"") }
       it { expect(headers).to include("error=\"#{error_response.name}\"") }
       it { expect(headers).to include("error_description=\"#{error_response.description}\"") }
+
+      context "with error description containing forbidden characters (\\ or \")" do
+        it "sanitize the value per RFC 6750 Section 3.1" do
+          error = double(:error, name: "backslash\\", description:"\"quotes\"")
+          allow(Doorkeeper::OAuth::Error).to receive(:new).and_return(error)
+          expect(headers).to include("error=\"backslash_\"")
+          expect(headers).to include("error_description=\"_quotes_\"")
+        end
+      end
     end
   end
 

--- a/spec/lib/oauth/forbidden_token_response_spec.rb
+++ b/spec/lib/oauth/forbidden_token_response_spec.rb
@@ -6,11 +6,21 @@ RSpec.describe Doorkeeper::OAuth::ForbiddenTokenResponse do
   subject(:response) { described_class.new }
 
   describe "#name" do
-    it { expect(response.name).to eq(:invalid_scope) }
+    it { expect(response.name).to eq(:insufficient_scope) }
   end
 
   describe "#status" do
     it { expect(response.status).to eq(:forbidden) }
+  end
+
+  describe "#headers" do
+    subject(:response) { described_class.from_scopes(["public"]) }
+
+    it "includes a WWW-Authenticate header per RFC 6750 Section 3.1" do
+      www_authenticate = response.headers["WWW-Authenticate"]
+      expect(www_authenticate).to include('error="insufficient_scope"')
+      expect(www_authenticate).to include('Access to this resource requires scope "public".')
+    end
   end
 
   describe ".from_scopes" do

--- a/spec/lib/oauth/forbidden_token_response_spec.rb
+++ b/spec/lib/oauth/forbidden_token_response_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Doorkeeper::OAuth::ForbiddenTokenResponse do
     it "includes a WWW-Authenticate header per RFC 6750 Section 3.1" do
       www_authenticate = response.headers["WWW-Authenticate"]
       expect(www_authenticate).to include('error="insufficient_scope"')
-      expect(www_authenticate).to include('Access to this resource requires scope "public".')
+      expect(www_authenticate).to include('error_description="Access to this resource requires scope _public_."')
     end
   end
 


### PR DESCRIPTION
### Summary

This PR changes the `ForbiddenTokenResponse` class which seems to be
used only for protected resources responses. Those responses seems to
be specified by the rfc6750 which states “the resource server MUST
include the HTTP "WWW-Authenticate" response header field” (see
https://datatracker.ietf.org/doc/html/rfc6750#section-3).

Oddly enough the header was explicitly removed when this error class
was introduced (by #418) but I'm not sure why? 

The PR description of #1202 seems to have analyzed the 403
`insufficient_scope` error was not implemented in doorkeeper, but I
think it was just an incorrect naming.

So I've renamed the error to follow the RFC to
`insufficient_scope` (instead of `invalid_scope`) and put the
`WWW-authenticate` header back.

Am I missing something? Or is this patch a valid fix?

Thanks for you help!