### PR TITLE
Add reproduction tests for on_load deferral (issue #1703)

### DIFF
--- a/spec/lib/doorkeeper/orm/active_record_spec.rb
+++ b/spec/lib/doorkeeper/orm/active_record_spec.rb
@@ -11,6 +11,49 @@ if DOORKEEPER_ORM == :active_record
       end
     end
 
+    # Reproduction test for https://github.com/doorkeeper-gem/doorkeeper/issues/1703
+    #
+    # Without the on_load wrapper, calling initialize_configured_associations
+    # eagerly triggers constantize on model class names (via access_token_model,
+    # access_grant_model, etc.), which forces ActiveRecord to load before
+    # config.active_record.* settings have been applied. This test verifies
+    # that the on_load block does NOT execute eagerly at registration time.
+    #
+    # See also: https://github.com/ngan/doorkeeper-activerecord-load-issue
+    describe "deferral of model loading (issue #1703)" do
+      it "does not call config model accessors at registration time" do
+        # Stub on_load to capture the block WITHOUT executing it,
+        # simulating the state before ActiveRecord is fully initialized.
+        allow(ActiveSupport).to receive(:on_load).with(:active_record)
+
+        expect(Doorkeeper.config).not_to receive(:application_model)
+        expect(Doorkeeper.config).not_to receive(:access_token_model)
+        expect(Doorkeeper.config).not_to receive(:access_grant_model)
+
+        described_class.initialize_configured_associations
+      end
+
+      it "calls config model accessors only when the on_load hook fires" do
+        deferred_block = nil
+
+        allow(ActiveSupport).to receive(:on_load).with(:active_record) do |*, &block|
+          deferred_block = block
+        end
+
+        described_class.initialize_configured_associations
+
+        # Block was captured but not yet executed
+        expect(deferred_block).not_to be_nil
+
+        # Now simulate ActiveRecord finishing initialization by executing the block
+        expect(Doorkeeper.config).to receive(:enable_application_owner?).and_return(false)
+        expect(Doorkeeper.config).to receive(:access_grant_model).and_return(Doorkeeper::AccessGrant)
+        expect(Doorkeeper.config).to receive(:access_token_model).and_return(Doorkeeper::AccessToken)
+
+        deferred_block.call
+      end
+    end
+
     describe "STI (Single Table Inheritance) support" do
       # Ensure STI subclasses work correctly with the ActiveSupport.on_load hook.
       # See: https://github.com/doorkeeper-gem/doorkeeper/issues/1703


### PR DESCRIPTION
## Summary

Follow-up to #1804. Adds regression tests that explicitly verify the deferral behavior introduced in 511a7806.

- **`does not call config model accessors at registration time`** -- Ensures `application_model` / `access_token_model` / `access_grant_model` are NOT called when `initialize_configured_associations` is invoked (i.e., `constantize` does not trigger early AR loading).
- **`calls config model accessors only when the on_load hook fires`** -- Captures the deferred block and verifies model accessors are called only when the block executes (simulating AR finishing initialization).

## Background: History of `on_load` in Doorkeeper

| Date | Commit | Author | What happened |
|---|---|---|---|
| 2018-02 | `9170e5b4` | Nikita Bulaj | **Introduced** `on_load(:active_record)` to defer model `require` calls (Fix #913) |
| 2021-03 | `6db479cb` | Nikita Bulaj | **Removed** `on_load` entirely, replaced with Ruby `autoload` |
| 2023-01 | `53d70a89` | Nikita Bulaj | Added `initialize_configured_associations` with eager `constantize` -- **reintroduced early loading problem** |
| 2026-03 | `511a7806` | Kenta Ishizaki | **Re-introduced** `on_load`, but only for module `include` calls (not model definitions) |

The key difference from the 2018 approach: model classes remain immediately available via `autoload`. Only the `include` of `Ownership` and `PolymorphicResourceOwner` modules is deferred. This avoids the past issues (#1319, #1281, #1117, #1583, #1043) while fixing the early AR loading reported in #1703.

Reproduction app by @ngan: https://github.com/ngan/doorkeeper-activerecord-load-issue

## Test plan

- [x] `bundle exec rspec spec/lib/doorkeeper/orm/active_record_spec.rb` passes (7 examples, 0 failures)
- [x] Confirm tests fail if the `on_load` wrapper is removed from `initialize_configured_associations`
- [x] Full CI green