### PR TITLE
Fix token revocation bypass for public clients (RFC 7009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#1806] Fix token revocation bypass for public clients (RFC 7009)
 - [#1703] Use `ActiveSupport.on_load(:active_record)` in ORM hooks to prevent loading ActiveRecord models too early
 - [#1781] Honor `handle_auth_errors :raise` in `AuthorizationsController#authorize_response`
 - [#1797] Fix `doorkeeper:db:cleanup` rake task failure on PostgreSQL

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -87,22 +87,20 @@ module Doorkeeper
     # credentials, in the case of a confidential client. The token being
     # revoked must also belong to the requesting client.
     #
-    # Once a confidential client is authenticated, it must be authorized to
+    # Once a client is authenticated, it must be authorized to
     # revoke the provided access or refresh token. This ensures one client
     # cannot revoke another's tokens.
     #
-    # Doorkeeper determines the client type implicitly via the presence of the
-    # OAuth client associated with a given access or refresh token. Since public
-    # clients authenticate the resource owner via "password" or "implicit" grant
-    # types, they set the application_id as null (since the claim cannot be
-    # verified).
+    # Doorkeeper checks token ownership for any token that has an
+    # application_id set. Tokens issued without a client (application_id
+    # is null) can be revoked without client authorization.
     #
     # https://datatracker.ietf.org/doc/html/rfc6749#section-2.1
     # https://datatracker.ietf.org/doc/html/rfc7009
     def authorized?
       # Token belongs to specific client, so we need to check if
       # authenticated client could access it.
-      if token.application_id? && token.application.confidential?
+      if token.application_id?
         # We authorize client by checking token's application
         server.client && server.client.application == token.application
       else

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -101,8 +101,8 @@ module Doorkeeper
       # Token belongs to specific client, so we need to check if
       # authenticated client could access it.
       if token.application_id?
-        # We authorize client by checking token's application
-        server.client && server.client.application == token.application
+        # We authorize client by comparing client and token application IDs
+        server.client && server.client.id == token.application_id
       else
         # Token was issued without client, authorization unnecessary
         true

--- a/spec/requests/flows/revoke_token_spec.rb
+++ b/spec/requests/flows/revoke_token_spec.rb
@@ -173,6 +173,56 @@ RSpec.describe "Revoke Token Flow" do
     end
   end
 
+  context "with a token issued to a public client" do
+    let(:access_token) do
+      FactoryBot.create(
+        :access_token,
+        application: public_client_application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        use_refresh_token: true,
+      )
+    end
+
+    it "revokes the token when the requesting client matches" do
+      post revocation_token_endpoint_url,
+           params: { client_id: public_client_application.uid, token: access_token.token }
+
+      expect(response).to be_successful
+      expect(access_token.reload).to be_revoked
+    end
+
+    it "revokes the refresh token when the requesting client matches" do
+      post revocation_token_endpoint_url,
+           params: { client_id: public_client_application.uid, token: access_token.refresh_token, token_type_hint: "refresh_token" }
+
+      expect(response).to be_successful
+      expect(access_token.reload).to be_revoked
+    end
+
+    it "does not revoke the token when the requesting client is a different public client" do
+      other_public_client = FactoryBot.create(:application, confidential: false)
+
+      post revocation_token_endpoint_url,
+           params: { client_id: other_public_client.uid, token: access_token.token }
+
+      expect(response).to be_forbidden
+      expect(response.body).to include("unauthorized_client")
+      expect(access_token.reload).not_to be_revoked
+    end
+
+    it "does not revoke the refresh token when the requesting client is a different public client" do
+      other_public_client = FactoryBot.create(:application, confidential: false)
+
+      post revocation_token_endpoint_url,
+           params: { client_id: other_public_client.uid, token: access_token.refresh_token, token_type_hint: "refresh_token" }
+
+      expect(response).to be_forbidden
+      expect(response.body).to include("unauthorized_client")
+      expect(access_token.reload).not_to be_revoked
+    end
+  end
+
   context "without client authentication, when skip_client_authentication_for_password_grant is false (the default)" do
     before do
       Doorkeeper.configure do


### PR DESCRIPTION
## Summary

Fixes #1806. The `authorized?` method in `TokensController` only validated token ownership for confidential clients, allowing any valid `client_id` to revoke tokens belonging to other public clients — violating [RFC 7009 Section 5](https://datatracker.ietf.org/doc/html/rfc7009#section-5).

## Changes

- Remove `token.application.confidential?` from the ownership check so that **all** tokens with an `application_id` require the requesting client to match
- Add request spec tests for public client token revocation scenarios (access token & refresh token)

## Root Cause

The condition `token.application_id? && token.application.confidential?` caused tokens issued to public clients to fall through to the `else` branch, which unconditionally returned `true`. This meant any authenticated client could revoke any public client's tokens.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Confidential client revokes own token | ✅ Allowed | ✅ Allowed |
| Confidential client revokes other's token | ❌ Blocked | ❌ Blocked |
| Public client revokes own token | ✅ Allowed | ✅ Allowed |
| Public client revokes other's token | ⚠️ **Allowed (bug)** | ❌ **Blocked (fixed)** |
| No-client token revocation | ✅ Allowed | ✅ Allowed |

## Test Plan

- `bundle exec rspec spec/requests/flows/revoke_token_spec.rb` passes
- Full CI green

## Acknowledgments

- Issue report and reproduction test: #1805 / #1806 by @mainameiz
- Fix commit [`ea13996`](https://github.com/doorkeeper-gem/doorkeeper/commit/ea13996475c2de04fc169c6e5368d797be3d234d) by @nikolai-markov-workato (unable to open PR due to repository permissions)