### PR TITLE
Remove hardcoded colons from views, move punctuation to i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#1784] Remove hardcoded colon from authorization view template, move punctuation to translation files
 - [#1781] Honor `handle_auth_errors :raise` in `AuthorizationsController#authorize_response`
 - [#1795] Fix: detailed error 'insufficient_scope' in protected resources 403s
 - [#1797] Fix `doorkeeper:db:cleanup` rake task failure on PostgreSQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ User-visible changes worth mentioning.
 
 ## main
 
-- [#1784] Remove hardcoded colon from authorization view template, move punctuation to translation files
 - [#1781] Honor `handle_auth_errors :raise` in `AuthorizationsController#authorize_response`
 - [#1795] Fix: detailed error 'insufficient_scope' in protected resources 403s
 - [#1797] Fix `doorkeeper:db:cleanup` rake task failure on PostgreSQL
@@ -18,6 +17,13 @@ User-visible changes worth mentioning.
 - [#1806] Fix token revocation bypass for public clients (RFC 7009)
 - [#1815] Expose `current_resource_owner` as a view helper in `Doorkeeper::ApplicationController`.
 - [#1818] Fix token introspection returning `exp: 0` for non-expiring tokens.
+- [#1784] Remove hardcoded colons from view templates, move punctuation to i18n translation strings.
+
+  **[IMPORTANT]**: if you have customized Doorkeeper views (`authorizations/new`, `authorizations/show`,
+  `applications/show`) or overridden the default `en.yml` translations, you may need to update them.
+  Colons are no longer hardcoded in the views — they are now part of the translation strings.
+  Update the [doorkeeper-i18n](https://github.com/doorkeeper-gem/doorkeeper-i18n) gem to get the
+  updated translations for all locales.
 
 ## 5.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#1784] Remove hardcoded colon from authorization view template, move punctuation to translation files
 - [#1781] Honor `handle_auth_errors :raise` in `AuthorizationsController#authorize_response`
 - [#1797] Fix `doorkeeper:db:cleanup` rake task failure on PostgreSQL
 - [#1800] Set `@grant_type` in `ClientCredentialsRequest` and `RefreshTokenRequest` constructors so `request.grant_type` returns

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -4,10 +4,10 @@
 
 <div class="row">
   <div class="col-md-8">
-    <h4><%= t('.application_id') %>:</h4>
+    <h4><%= t('.application_id') %></h4>
     <p><code class="bg-light" id="application_id"><%= @application.uid %></code></p>
 
-    <h4><%= t('.secret') %>:</h4>
+    <h4><%= t('.secret') %></h4>
     <p>
       <code class="bg-light" id="secret">
         <% secret = flash[:application_secret].presence || @application.plaintext_secret %>
@@ -19,7 +19,7 @@
       </code>
     </p>
 
-    <h4><%= t('.scopes') %>:</h4>
+    <h4><%= t('.scopes') %></h4>
     <p>
       <code class="bg-light" id="scopes">
         <% if @application.scopes.present? %>
@@ -30,10 +30,10 @@
       </code>
     </p>
 
-    <h4><%= t('.confidential') %>:</h4>
+    <h4><%= t('.confidential') %></h4>
     <p><code class="bg-light" id="confidential"><%= @application.confidential? %></code></p>
 
-    <h4><%= t('.callback_urls') %>:</h4>
+    <h4><%= t('.callback_urls') %></h4>
 
     <% if @application.redirect_uri.present? %>
       <table>

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -4,10 +4,10 @@
 
 <div class="row">
   <div class="col-md-8">
-    <h4><%= t('.application_id') %></h4>
+    <h4><%= t('.application_id') %>:</h4>
     <p><code class="bg-light" id="application_id"><%= @application.uid %></code></p>
 
-    <h4><%= t('.secret') %></h4>
+    <h4><%= t('.secret') %>:</h4>
     <p>
       <code class="bg-light" id="secret">
         <% secret = flash[:application_secret].presence || @application.plaintext_secret %>
@@ -19,7 +19,7 @@
       </code>
     </p>
 
-    <h4><%= t('.scopes') %></h4>
+    <h4><%= t('.scopes') %>:</h4>
     <p>
       <code class="bg-light" id="scopes">
         <% if @application.scopes.present? %>
@@ -30,10 +30,10 @@
       </code>
     </p>
 
-    <h4><%= t('.confidential') %></h4>
+    <h4><%= t('.confidential') %>:</h4>
     <p><code class="bg-light" id="confidential"><%= @application.confidential? %></code></p>
 
-    <h4><%= t('.callback_urls') %></h4>
+    <h4><%= t('.callback_urls') %>:</h4>
 
     <% if @application.redirect_uri.present? %>
       <table>

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -9,7 +9,7 @@
 
   <% if @pre_auth.scopes.count > 0 %>
     <div id="oauth-permissions">
-      <p><%= t('.able_to') %>:</p>
+      <p><%= t('.able_to') %></p>
 
       <ul class="text-info">
         <% @pre_auth.scopes.each do |scope| %>

--- a/app/views/doorkeeper/authorizations/show.html.erb
+++ b/app/views/doorkeeper/authorizations/show.html.erb
@@ -1,5 +1,5 @@
 <header class="page-header">
-  <h1><%= t('.title') %></h1>
+  <h1><%= t('.title') %>:</h1>
 </header>
 
 <main role="main">

--- a/app/views/doorkeeper/authorizations/show.html.erb
+++ b/app/views/doorkeeper/authorizations/show.html.erb
@@ -1,5 +1,5 @@
 <header class="page-header">
-  <h1><%= t('.title') %>:</h1>
+  <h1><%= t('.title') %></h1>
 </header>
 
 <main role="main">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,12 +51,12 @@ en:
         title: 'New Application'
       show:
         title: 'Application: %{name}'
-        application_id: 'UID'
-        secret: 'Secret'
+        application_id: 'UID:'
+        secret: 'Secret:'
         secret_hashed: 'Secret hashed'
-        scopes: 'Scopes'
-        confidential: 'Confidential'
-        callback_urls: 'Callback urls'
+        scopes: 'Scopes:'
+        confidential: 'Confidential:'
+        callback_urls: 'Callback urls:'
         actions: 'Actions'
         not_defined: 'Not defined'
 
@@ -71,7 +71,7 @@ en:
         prompt: 'Authorize %{client_name} to use your account?'
         able_to: 'This application will be able to:'
       show:
-        title: 'Authorization code'
+        title: 'Authorization code:'
       form_post:
         title: 'Submit this form'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,7 +71,7 @@ en:
         prompt: 'Authorize %{client_name} to use your account?'
         able_to: 'This application will be able to:'
       show:
-        title: 'Authorization code'
+        title: 'Authorization code:'
       form_post:
         title: 'Submit this form'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,12 +51,12 @@ en:
         title: 'New Application'
       show:
         title: 'Application: %{name}'
-        application_id: 'UID:'
-        secret: 'Secret:'
+        application_id: 'UID'
+        secret: 'Secret'
         secret_hashed: 'Secret hashed'
-        scopes: 'Scopes:'
-        confidential: 'Confidential:'
-        callback_urls: 'Callback urls:'
+        scopes: 'Scopes'
+        confidential: 'Confidential'
+        callback_urls: 'Callback urls'
         actions: 'Actions'
         not_defined: 'Not defined'
 
@@ -71,7 +71,7 @@ en:
         prompt: 'Authorize %{client_name} to use your account?'
         able_to: 'This application will be able to:'
       show:
-        title: 'Authorization code:'
+        title: 'Authorization code'
       form_post:
         title: 'Submit this form'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,12 +51,12 @@ en:
         title: 'New Application'
       show:
         title: 'Application: %{name}'
-        application_id: 'UID'
-        secret: 'Secret'
+        application_id: 'UID:'
+        secret: 'Secret:'
         secret_hashed: 'Secret hashed'
-        scopes: 'Scopes'
-        confidential: 'Confidential'
-        callback_urls: 'Callback URLs'
+        scopes: 'Scopes:'
+        confidential: 'Confidential:'
+        callback_urls: 'Callback URLs:'
         actions: 'Actions'
         not_defined: 'Not defined'
 
@@ -71,7 +71,7 @@ en:
         prompt: 'Authorize %{client_name} to use your account?'
         able_to: 'This application will be able to:'
       show:
-        title: 'Authorization code'
+        title: 'Authorization code:'
       form_post:
         title: 'Submit this form'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,7 +69,7 @@ en:
       new:
         title: 'Authorization required'
         prompt: 'Authorize %{client_name} to use your account?'
-        able_to: 'This application will be able to'
+        able_to: 'This application will be able to:'
       show:
         title: 'Authorization code'
       form_post:


### PR DESCRIPTION
### Summary

Remove all hardcoded `:` from view templates and move punctuation into translation strings, as discussed in #1784.

### Problem

The view templates had hardcoded colons after `t()` calls, while some translations (`de`, `ko`, `ru`) already included a colon in their strings. This resulted in a double colon (`::`) being displayed for those locales. Hardcoded colons also prevent languages with different punctuation rules (e.g. French ` :`) from following their own conventions.

### Changes

- `authorizations/new.html.erb` — remove hardcoded `:` after `t(.able_to)`
- `applications/show.html.erb` — remove hardcoded `:` after `application_id`, `secret`, `scopes`, `confidential`, `callback_urls`
- `authorizations/show.html.erb` — remove hardcoded `:` after `title`
- Add colons to the default `en.yml` translations so English output remains unchanged
- Add `[IMPORTANT]` upgrade note to `CHANGELOG.md`

### Companion PR

- **doorkeeper-i18n**: doorkeeper-gem/doorkeeper-i18n#73 — adds colons to all affected keys across all 25 locales

Fixes #1784