### PR TITLE
Use Rubocop as GitHub Actions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,23 @@
+name: rubocop
+on:
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  rubocop:
+    name: runner / rubocop
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: rubocop
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1.227.0
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - uses: reviewdog/action-rubocop@fcb74ba274da10b18d038d0bcddaae3518739634 # v2.21.2
+        with:
+          reporter: github-pr-review # Default is github-pr-check
+          skip_install: true
+          use_bundler: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,7 @@ Run the tests with: `docker run -it --rm doorkeeper:test`
 [commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [pr]: https://github.com/doorkeeper-gem/doorkeeper/compare/
 
-* If [Hound] catches style violations, fix them. If our bot suggested changes — please add them.
-
-[hound]: https://houndci.com
+* If [Rubocop] catches style violations, fix them. If our bot suggested changes — please add them.
 
 * Wait for us. We try to at least comment on pull requests within one business day.
 * We may suggest changes.

--- a/Gemfile
+++ b/Gemfile
@@ -15,14 +15,15 @@ gem "rspec-mocks"
 gem "rspec-rails", "~> 8.0"
 gem "rspec-support"
 
-gem "rubocop", "~> 1.72"
-gem "rubocop-capybara", "~> 2.22", require: false
-gem "rubocop-factory_bot", "~> 2.27", require: false
-gem "rubocop-performance", "~> 1.24", require: false
-gem "rubocop-rails", "~> 2.30", require: false
-gem "rubocop-rspec", "~> 3.5", require: false
-gem "rubocop-rspec_rails", "~> 2.31", require: false
-
+group :development, :rubocop do
+  gem "rubocop", "~> 1.72"
+  gem "rubocop-capybara", "~> 2.22", require: false
+  gem "rubocop-factory_bot", "~> 2.27", require: false
+  gem "rubocop-performance", "~> 1.24", require: false
+  gem "rubocop-rails", "~> 2.30", require: false
+  gem "rubocop-rspec", "~> 3.5", require: false
+  gem "rubocop-rspec_rails", "~> 2.31", require: false
+end
 gem "bcrypt", "~> 3.1", require: false
 
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![CI](https://github.com/doorkeeper-gem/doorkeeper/actions/workflows/ci.yml/badge.svg)](https://github.com/doorkeeper-gem/doorkeeper/actions/workflows/ci.yml)
 [![Maintainability](https://qlty.sh/gh/doorkeeper-gem/projects/doorkeeper/maintainability.svg)](https://qlty.sh/gh/doorkeeper-gem/projects/doorkeeper)
 [![Coverage Status](https://coveralls.io/repos/github/doorkeeper-gem/doorkeeper/badge.svg?branch=main)](https://coveralls.io/github/doorkeeper-gem/doorkeeper?branch=main)
-[![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 [![GuardRails badge](https://api.guardrails.io/v2/badges/21183?token=66768ce8f6995814df81f65a2cff40f739f688492704f973e62809e15599bb62)](https://dashboard.guardrails.io/gh/doorkeeper-gem/repos/21183)
 [![Dependabot](https://img.shields.io/badge/dependabot-enabled-success.svg)](https://dependabot.com)
 


### PR DESCRIPTION
Add Rubocop as a GitHub Action instead of outdated Hound