### PR TITLE
Expose current_resource_owner as a view helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ User-visible changes worth mentioning.
 - [#1802] Fix `filter_parameters` not applied when `Doorkeeper.configure` is called inside to_prepare.
 - [#1804] Use `ActiveSupport.on_load(:active_record)` in ORM hooks to prevent loading ActiveRecord models too early
 - [#1806] Fix token revocation bypass for public clients (RFC 7009)
+- [#1815] Expose `current_resource_owner` as a view helper in `Doorkeeper::ApplicationController`.
 
 ## 5.9.0
 

--- a/lib/doorkeeper/helpers/controller.rb
+++ b/lib/doorkeeper/helpers/controller.rb
@@ -7,6 +7,10 @@ module Doorkeeper
     # Rails controller helpers.
     #
     module Controller
+      def self.included(base)
+        base.helper_method :current_resource_owner if base.respond_to?(:helper_method)
+      end
+
       private
 
       # :doc:

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper_integration"
+
+RSpec.describe Doorkeeper::ApplicationController, type: :controller do
+  describe "current_resource_owner view helper" do
+    controller(described_class) do
+      def index
+        render inline: "<%= current_resource_owner %>"
+      end
+    end
+
+    it "is registered as a helper method" do
+      expect(described_class._helper_methods).to include(:current_resource_owner)
+    end
+
+    it "is callable from views" do
+      allow(controller).to receive(:current_resource_owner).and_return("owner-sentinel")
+
+      get :index
+      expect(response.body).to include("owner-sentinel")
+    end
+  end
+end

--- a/spec/controllers/application_metal_controller_spec.rb
+++ b/spec/controllers/application_metal_controller_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Doorkeeper::ApplicationMetalController, type: :controller do
     end
   end
 
+  it "lacks `helper_method` so the included hook becomes a no-op" do
+    expect(described_class).not_to respond_to(:helper_method)
+  end
+
   it "lazy run hooks" do
     i = 0
     ActiveSupport.on_load(:doorkeeper_metal_controller) { i += 1 }


### PR DESCRIPTION
## Summary

Exposes `current_resource_owner` as a view helper, following the pattern used by Devise for `current_user`.

Previously, custom views needing access to the resource owner had to rely on the undocumented `@current_resource_owner` memoized instance variable. This PR makes the helper officially available in views.

Closes #1674.

## Changes

- Register `current_resource_owner` via `helper_method` in `Doorkeeper::Helpers::Controller`'s `included` hook, guarded by `respond_to?(:helper_method)` so `ApplicationMetalController` is unaffected
- Add specs covering helper registration and end-to-end view rendering
- Add a regression test ensuring the metal controller stays view-helper-free
- Update CHANGELOG

## Notes

Picking this up since the original reporter hasn't had a chance to open a PR.

cc @nbulaj — following your suggestion in the issue thread 🙌