### PR TITLE
Fix token introspection returning `exp: 0` for non-expiring tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ User-visible changes worth mentioning.
 - [#1804] Use `ActiveSupport.on_load(:active_record)` in ORM hooks to prevent loading ActiveRecord models too early
 - [#1806] Fix token revocation bypass for public clients (RFC 7009)
 - [#1815] Expose `current_resource_owner` as a view helper in `Doorkeeper::ApplicationController`.
+- [#1818] Fix token introspection returning `exp: 0` for non-expiring tokens.
 
 ## 5.9.0
 

--- a/lib/doorkeeper/oauth/token_introspection.rb
+++ b/lib/doorkeeper/oauth/token_introspection.rb
@@ -102,14 +102,18 @@ module Doorkeeper
 
       # 2.2. Introspection Response
       def success_response
-        customize_response(
+        response = {
           active: true,
           scope: @token.scopes_string,
           client_id: @token.try(:application).try(:uid),
           token_type: @token.token_type,
-          exp: @token.expires_at.to_i,
           iat: @token.created_at.to_i,
-        )
+        }
+        # `exp` is OPTIONAL per RFC 7662 §2.2; omit it for non-expiring tokens
+        # so clients don't interpret `0` as "expired at 1970-01-01".
+        response[:exp] = @token.expires_at.to_i if @token.expires_at
+
+        customize_response(response)
       end
 
       # If the introspection call is properly authorized but the token is not

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -451,6 +451,25 @@ RSpec.describe Doorkeeper::TokensController, type: :controller do
       end
     end
 
+    context "when token never expires (expires_in is nil)" do
+      let(:token_for_introspection) { FactoryBot.create(:access_token, application: client, expires_in: nil) }
+
+      it "omits the exp field per RFC 7662" do
+        request.headers["Authorization"] = basic_auth_header_for_client(client)
+
+        post :introspect, params: { token: token_for_introspection.token }
+
+        expect(json_response).to match(
+          "active" => true,
+          "client_id" => client.uid,
+          "token_type" => "Bearer",
+          "scope" => nil,
+          "iat" => an_instance_of(Integer),
+        )
+        expect(json_response).not_to have_key("exp")
+      end
+    end
+
     context "when token was issued to a different client than is making this request" do
       let(:different_client) { FactoryBot.create(:application) }
 


### PR DESCRIPTION
## Summary

When introspecting a token with `expires_in: nil` (non-expiring), the response includes `"exp": 0`, which represents the Unix epoch (1970-01-01 UTC). Clients interpreting this value will consider the token expired over 50 years ago.

Per [RFC 7662 §2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2), the `exp` field is OPTIONAL. For non-expiring tokens, it should be omitted entirely.

## Changes

- **`lib/doorkeeper/oauth/token_introspection.rb`**: Conditionally include `exp` only when `@token.expires_at` is present.
- **`spec/controllers/tokens_controller_spec.rb`**: Add test for introspecting a non-expiring token — verifies `exp` is absent and `iat` is present.

## Before

```json
{
  "active": true,
  "scope": "public",
  "client_id": "abc123",
  "token_type": "Bearer",
  "exp": 0,
  "iat": 1713800000
}
```

## After

```json
{
  "active": true,
  "scope": "public",
  "client_id": "abc123",
  "token_type": "Bearer",
  "iat": 1713800000
}
```

Closes #1817
