### PR TITLE
Remove dead wildcard presence check in dynamic scope matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ User-visible changes worth mentioning.
   Colons are no longer hardcoded in the views — they are now part of the translation strings.
   Update the [doorkeeper-i18n](https://github.com/doorkeeper-gem/doorkeeper-i18n) gem to get the
   updated translations for all locales.
+- [#1820] Remove dead wildcard presence check in `Scopes#dynamic_scope_match?` (internal cleanup, no behavior change).
 
 ## 5.9.0
 

--- a/lib/doorkeeper/oauth/scopes.rb
+++ b/lib/doorkeeper/oauth/scopes.rb
@@ -115,7 +115,8 @@ module Doorkeeper
         return false if allowed_pattern[0] != request_pattern[0]
         return false if allowed_pattern[1].blank?
         return false if request_pattern[1].blank?
-        return true  if allowed_pattern[1] == DYNAMIC_SCOPE_WILDCARD && allowed_pattern[1].present?
+
+        return true if allowed_pattern[1] == DYNAMIC_SCOPE_WILDCARD
 
         allowed_pattern[1] == request_pattern[1]
       end


### PR DESCRIPTION
Small internal cleanup in `Doorkeeper::OAuth::Scopes#dynamic_scope_match?`.

The wildcard branch contained a redundant `present?` check that can never evaluate to `false`:

```ruby
return false if allowed_pattern[1].blank?
return false if request_pattern[1].blank?
return true  if allowed_pattern[1] == DYNAMIC_SCOPE_WILDCARD && allowed_pattern[1].present?
```

By the time the third line runs, `allowed_pattern[1].blank?` has already returned `false` on the previous line, so `allowed_pattern[1].present?` is always `true`. The `&& allowed_pattern[1].present?` term is dead code and has no effect on the result.

This PR drops the redundant term.

```ruby
return false if allowed_pattern[1].blank?
return false if request_pattern[1].blank?

return true if allowed_pattern[1] == DYNAMIC_SCOPE_WILDCARD
```

## Why

- Removes confusing dead code that suggests a guard which is never exercised.
- Makes the intent of the wildcard match explicit.

## Behavior change

None. This is a pure refactor — the result of `dynamic_scope_match?` is identical for every input.

## Testing

- `bundle exec rspec spec/lib/oauth/scopes_spec.rb spec/lib/models/scopes_spec.rb`
  → 53 examples, 0 failures (unchanged).
- Full suite unaffected.
- `bundle exec rubocop lib/doorkeeper/oauth/scopes.rb` introduces no new offenses (the 2 pre-existing offenses are unrelated and already present on `main`).