### PR TITLE
Stop stubbing a private generator method to silence Thor command noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ User-visible changes worth mentioning.
 - [#1822] Update Rubocop config, auto-corrections.
 - [#1823] Update Rubocop config, part 2.
 - [#1825]Update Rubocop config, part 3.
+- [#1821] Fix noisy `Could not find command "no_previous_refresh_token_column?"` Thor output during the
+  `PreviousRefreshTokenGenerator` spec by stubbing the underlying DB column check instead of the generator's
+  private method (test-only change).
 
 ## 5.9.0
 

--- a/spec/generators/previous_refresh_token_generator_spec.rb
+++ b/spec/generators/previous_refresh_token_generator_spec.rb
@@ -9,16 +9,33 @@ RSpec.describe Doorkeeper::PreviousRefreshTokenGenerator do
   tests described_class
   destination ::File.expand_path("tmp/dummy", __dir__)
 
+  # Stub the database column check that backs
+  # PreviousRefreshTokenGenerator#no_previous_refresh_token_column? rather
+  # than stubbing that private method directly.
+  #
+  # Stubbing a *private* method on a Thor generator through
+  # `allow_any_instance_of` transiently (re)defines it on the class, which
+  # triggers Thor's `method_added` hook and registers it as a runnable
+  # command. Thor then prints `Could not find command "..."` noise while
+  # `run_generator` iterates over all commands. Stubbing the underlying
+  # `column_exists?` call keeps the test's intent without redefining any
+  # method on the generator class.
+  def stub_previous_refresh_token_column(exists:)
+    allow(ActiveRecord::Base.connection).to receive(:column_exists?).and_call_original
+    allow(ActiveRecord::Base.connection)
+      .to(receive(:column_exists?)
+      .with(:oauth_access_tokens, :previous_refresh_token)
+      .and_return(exists))
+  end
+
   describe "after running the generator" do
     before do
       prepare_destination
-
-      allow_any_instance_of(described_class).to(
-        receive(:no_previous_refresh_token_column?).and_return(true),
-      )
     end
 
     it "creates a migration with a version specifier" do
+      stub_previous_refresh_token_column(exists: false)
+
       stub_const("ActiveRecord::VERSION::MAJOR", 5)
       stub_const("ActiveRecord::VERSION::MINOR", 0)
 
@@ -29,11 +46,9 @@ RSpec.describe Doorkeeper::PreviousRefreshTokenGenerator do
       end
     end
 
-    context "when file already exist" do
+    context "when the column already exists" do
       it "does not create a migration" do
-        allow_any_instance_of(described_class).to(
-          receive(:no_previous_refresh_token_column?).and_call_original,
-        )
+        stub_previous_refresh_token_column(exists: true)
 
         run_generator
 


### PR DESCRIPTION
## Summary

Running the test suite prints this line twice:

```
Could not find command "no_previous_refresh_token_column?".
```

It comes from `spec/generators/previous_refresh_token_generator_spec.rb`, which stubs the **private** method `PreviousRefreshTokenGenerator#no_previous_refresh_token_column?` via `allow_any_instance_of(...).to receive(:no_previous_refresh_token_column?)`.

## Root cause

It is not a bug in Doorkeeper's generator code, and it never happens when a real user runs `rails generate doorkeeper:previous_refresh_token`. It is an interaction between RSpec and Thor that only occurs in the spec:

1. `allow_any_instance_of(...).to receive(:no_previous_refresh_token_column?)` (re)defines that method on the generator class.
2. Defining a method on a Thor class fires `Thor::Base.method_added`, which registers the (transiently public) method as a runnable **command**.
3. `run_generator` → `Thor::Group#invoke_all` iterates over *every* registered command and calls `Thor::Command#run`.
4. By then the stub has the original (private) visibility, so `Thor::Command#run` hits the `private_method?(instance)` branch and calls `handle_no_command_error`, which prints `Could not find command "no_previous_refresh_token_column?".`

So the trigger is "stub a *private* method on a Thor generator via `allow_any_instance_of`". Neither Thor nor RSpec is strictly misbehaving; the test just shouldn't stub the method under test on a Thor class.

## Fix

Stub the underlying database dependency that `no_previous_refresh_token_column?` wraps (`ActiveRecord::Base.connection.column_exists?`) instead of the private method itself. No method is (re)defined on the generator class, so Thor never registers a spurious command and the noise disappears.

Bonus: the "column already exists" example now stubs `column_exists? => true` explicitly instead of relying on `and_call_original` against the test schema, making it deterministic.

## Behavior change

None for the generator. Test-only change; the same scenarios are covered:

- column missing → migration generated (with the expected version specifier)
- column already present → no migration generated

## Testing

- `bundle exec rspec spec/generators/previous_refresh_token_generator_spec.rb`
  → 2 examples, 0 failures.
- Full suite: `bundle exec rspec` → 1295 examples, 0 failures, and the `Could not find command "..."` line no longer appears anywhere in the output.
- `bundle exec rubocop spec/generators/previous_refresh_token_generator_spec.rb`
  → no offenses.