### PR TITLE
Update GitHub Workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,4 +12,24 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: dangoslen/changelog-enforcer@v3
+      - uses: actions/checkout@v4
+      - name: Check changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            gem_changes:
+              - 'lib/**'
+              - 'app/**'
+              - 'config/**'
+              - '*.gemspec'
+              - 'Gemfile'
+              - 'Gemfile.lock'
+              - 'ext/**'
+
+      - name: Enforce changelog
+        if: |
+          steps.changes.outputs.gem_changes == 'true'
+        uses: dangoslen/changelog-enforcer@v3
+        with:
+            changeLogPath: CHANGELOG.md

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,17 @@
 name: rubocop
 on:
   pull_request:
+    paths:
+      - 'lib/**/*.rb'
+      - 'app/**/*'
+      - 'spec/**/*.rb'
+      - 'bin/*'
+      - '.rubocop.yml'
+      - '.rubocop_todo.yml'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - 'Rakefile'
+      - '*.gemspec'
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
We can skip CHANGELOG update if it doesn't touch library itself

No need to run rubocop if code didn't change
