### PR TITLE
Fix re-entrant `on_load(:active_record)` NameError on `rails db:seed` (preserves #1703 fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
-- Add here
+- [#1829] Fix `NameError: uninitialized constant ApplicationRecord` on `rails db:seed` and other non-eager-loading flows caused by `on_load(:active_record)` firing re-entrantly during `ApplicationRecord` autoload.
 
 ## 5.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
-- [#1829] Fix `NameError: uninitialized constant ApplicationRecord` on `rails db:seed` and other non-eager-loading flows caused by `on_load(:active_record)` firing re-entrantly during `ApplicationRecord` autoload.
+- [#1829] Fix `NameError: uninitialized constant ApplicationRecord` on `rails db:seed` (and other non-eager-loading flows) caused by `on_load(:active_record)` firing re-entrantly during `ApplicationRecord` autoload, without re-introducing the early-AR-load regression that #1804 fixed.
 
 ## 5.9.1
 

--- a/lib/doorkeeper/engine.rb
+++ b/lib/doorkeeper/engine.rb
@@ -22,6 +22,23 @@ module Doorkeeper
       Doorkeeper.run_orm_hooks
     end
 
+    # Drain any queued `on_load(:active_record)` callbacks (including the one
+    # `run_orm_hooks` registers above) from `config.after_initialize`.
+    #
+    # `to_prepare` runs *before* `after_initialize` in Rails finishers, so by
+    # the time this block fires AR's own `:set_configs` after_initialize has
+    # already applied framework defaults from `new_framework_defaults_*.rb`
+    # (#1703). Touching `::ActiveRecord::Base` here loads AR in that
+    # known-clean context, firing the queued callbacks before any host-app
+    # code (e.g. `rails db:seed`) can autoload models and trigger the
+    # callbacks re-entrantly from inside `class ApplicationRecord <
+    # ActiveRecord::Base` (#1828).
+    initializer "doorkeeper.orm.flush_active_record_hooks", after: "active_record.set_configs" do
+      config.after_initialize do
+        ::ActiveRecord::Base if defined?(::ActiveRecord)
+      end
+    end
+
     if defined?(Sprockets) && Sprockets::VERSION.chr.to_i >= 4
       initializer "doorkeeper.assets.precompile" do |app|
         # Force users to use:

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -30,6 +30,19 @@ module Doorkeeper
 
       def self.run_hooks
         initialize_configured_associations
+        # Force ActiveRecord::Base to load now so any pending
+        # on_load(:active_record) callbacks (including the one just registered
+        # above) fire in this safe context — typically `config.to_prepare`,
+        # well after `:load_config_initializers`.
+        #
+        # Without this, a queued callback can fire re-entrantly during a host
+        # app autoload chain (e.g. `rails db:seed` evaluating
+        # `class ApplicationRecord < ActiveRecord::Base`) and then constantize
+        # a user-configured Doorkeeper model that inherits from
+        # `ApplicationRecord` while `ApplicationRecord` itself is still
+        # mid-definition — raising `NameError: uninitialized constant
+        # ApplicationRecord` (issue #1828).
+        ::ActiveRecord::Base
       end
 
       def self.initialize_configured_associations

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -30,19 +30,6 @@ module Doorkeeper
 
       def self.run_hooks
         initialize_configured_associations
-        # Force ActiveRecord::Base to load now so any pending
-        # on_load(:active_record) callbacks (including the one just registered
-        # above) fire in this safe context — typically `config.to_prepare`,
-        # well after `:load_config_initializers`.
-        #
-        # Without this, a queued callback can fire re-entrantly during a host
-        # app autoload chain (e.g. `rails db:seed` evaluating
-        # `class ApplicationRecord < ActiveRecord::Base`) and then constantize
-        # a user-configured Doorkeeper model that inherits from
-        # `ApplicationRecord` while `ApplicationRecord` itself is still
-        # mid-definition — raising `NameError: uninitialized constant
-        # ApplicationRecord` (issue #1828).
-        ::ActiveRecord::Base
       end
 
       def self.initialize_configured_associations

--- a/spec/lib/doorkeeper/orm/active_record_spec.rb
+++ b/spec/lib/doorkeeper/orm/active_record_spec.rb
@@ -232,6 +232,13 @@ if DOORKEEPER_ORM == :active_record
             # Simulate the `config.to_prepare` block in the engine.
             Doorkeeper::Orm::ActiveRecord.run_hooks
 
+            # Simulate the `config.after_initialize` flush in engine.rb that
+            # force-loads ::ActiveRecord::Base in a clean (non-re-entrant)
+            # context. This drains any queued `on_load(:active_record)`
+            # callbacks before host-app code (db:seed, controllers, ...) can
+            # trigger AR autoload from inside a user-model class body.
+            ::ActiveRecord::Base
+
             # Simulate seed-style host-app code referencing a model after boot.
             User
 

--- a/spec/lib/doorkeeper/orm/active_record_spec.rb
+++ b/spec/lib/doorkeeper/orm/active_record_spec.rb
@@ -144,5 +144,113 @@ if DOORKEEPER_ORM == :active_record
         end
       end
     end
+
+    # Regression test for https://github.com/doorkeeper-gem/doorkeeper/issues/1828
+    #
+    # `rails db:seed` (and any flow that runs without eager_load) can autoload
+    # ActiveRecord::Base lazily from inside `class ApplicationRecord < ActiveRecord::Base`.
+    # When AR::Base finishes loading, `run_load_hooks(:active_record)` fires —
+    # while ApplicationRecord is still mid-evaluation, so its constant is not
+    # yet defined. Without the fix, the on_load callback registered by
+    # `initialize_configured_associations` (post-#1804) calls `constantize` on
+    # a user-configured class that inherits from ApplicationRecord, which
+    # raises `NameError: uninitialized constant ApplicationRecord`.
+    #
+    # This can't be reproduced inside the dummy app because AR::Base loads at
+    # spec-helper time, so we drive a fresh subprocess that replays the
+    # autoload chain end-to-end.
+    describe "issue #1828 — re-entrant on_load(:active_record) during ApplicationRecord autoload" do
+      it "does not raise NameError on uninitialized constant ApplicationRecord" do
+        require "tmpdir"
+        require "English"
+        require "bundler"
+
+        doorkeeper_lib  = File.expand_path("../../../../lib", __dir__)
+        # Use the same Gemfile the parent is running under so this passes across
+        # the Appraisal matrix (rails_7_0.gemfile pins rspec-rails ~> 5.0 etc.).
+        gemfile         = Bundler.default_gemfile.to_s
+
+        Dir.mktmpdir("doorkeeper-1828-") do |dir|
+          File.write(File.join(dir, "application_record.rb"), <<~RUBY)
+            class ApplicationRecord < ActiveRecord::Base
+              self.abstract_class = true if respond_to?(:abstract_class=)
+            end
+          RUBY
+
+          File.write(File.join(dir, "user.rb"),       "class User < ApplicationRecord; end\n")
+          File.write(File.join(dir, "foo_token.rb"),  "class FooToken < ApplicationRecord; end\n")
+          File.write(File.join(dir, "foo_grant.rb"),  "class FooGrant < ApplicationRecord; end\n")
+
+          File.write(File.join(dir, "active_record_base_stub.rb"), <<~RUBY)
+            module ActiveRecord
+              class Base
+                def self.abstract_class=(_); end
+              end
+            end
+            ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
+          RUBY
+
+          File.write(File.join(dir, "run.rb"), <<~RUBY)
+            $LOAD_PATH.unshift #{doorkeeper_lib.inspect}
+
+            require "active_support"
+            require "active_support/core_ext/string/inflections"
+
+            module ActiveRecord
+              autoload :Base, #{File.join(dir, "active_record_base_stub.rb").inspect}
+            end
+
+            Object.autoload :User,              #{File.join(dir, "user.rb").inspect}
+            Object.autoload :ApplicationRecord, #{File.join(dir, "application_record.rb").inspect}
+            Object.autoload :FooToken,          #{File.join(dir, "foo_token.rb").inspect}
+            Object.autoload :FooGrant,          #{File.join(dir, "foo_grant.rb").inspect}
+
+            # Minimal Doorkeeper namespace so we can load `doorkeeper/orm/active_record.rb`
+            # without pulling Rails (and therefore without pre-loading AR::Base).
+            module Doorkeeper
+              module Models
+                module Ownership; end
+                module PolymorphicResourceOwner
+                  module ForAccessGrant; end
+                  module ForAccessToken; end
+                end
+              end
+
+              def self.config
+                @config ||= Config.new
+              end
+
+              class Config
+                def enable_application_owner?; false; end
+                def access_grant_model; FooGrant; end
+                def access_token_model; FooToken; end
+              end
+            end
+
+            require "doorkeeper/orm/active_record"
+
+            # Simulate the `config.to_prepare` block in the engine.
+            Doorkeeper::Orm::ActiveRecord.run_hooks
+
+            # Simulate seed-style host-app code referencing a model after boot.
+            User
+
+            puts "OK"
+          RUBY
+
+          env = { "BUNDLE_GEMFILE" => gemfile }
+          cmd = ["bundle", "exec", "ruby", File.join(dir, "run.rb")]
+          output = IO.popen(env, cmd, err: [:child, :out], &:read)
+          status = $CHILD_STATUS.exitstatus
+
+          expect(status).to(
+            eq(0),
+            "Subprocess exited #{status} — issue #1828 fix not in place.\n" \
+            "Output:\n#{output}",
+          )
+          expect(output).to include("OK")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #1828.

## Summary

`Doorkeeper::Orm::ActiveRecord.run_hooks` (introduced in #1804) registers an `ActiveSupport.on_load(:active_record)` callback that calls `constantize` on the configured Doorkeeper model classes. If `ActiveRecord::Base` has not yet been loaded — typical for `rails db:seed` and any flow with `config.eager_load = false` — that callback queues, and then fires later when something *else* triggers the `AR::Base` autoload.

The "something else" is normally the host app referencing its own model:

```
seeds.rb: User.create!(...)
  ↳ autoload User
  ↳ class User < ApplicationRecord
    ↳ autoload ApplicationRecord
    ↳ class ApplicationRecord < ActiveRecord::Base   # ← Ruby resolves superclass FIRST
      ↳ autoload ActiveRecord::Base
      ↳ require "active_record/base"
      ↳ ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)   # ← Doorkeeper's queued hook fires HERE
      ↳ Doorkeeper.config.access_grant_model        # constantize "FooGrant"
        ↳ autoload FooGrant
        ↳ class FooGrant < ApplicationRecord        # ApplicationRecord not yet defined (mid-load)
        ↳ NameError: uninitialized constant ApplicationRecord
```

Ruby evaluates the superclass expression before assigning the class constant, so `ApplicationRecord` is still undefined when the AR load hooks fire from inside its own definition.

## Why the obvious fix (force-load AR in `to_prepare`) doesn't work

The first attempt on this branch — touching `::ActiveRecord::Base` at the end of `run_hooks` to flush the queued callback — passes the standalone re-entrancy spec but **re-introduces #1703**.

Confirmed empirically against ngan's reproduction app (https://github.com/ngan/doorkeeper-activerecord-load-issue):

| Variant | #1703 (`configs` in AR `after_initialize`) | #1828 (re-entry) |
| --- | --- | --- |
| pre-#1804 | ❌ `Hash` (regression) | ✓ no bug |
| #1804 alone | ✓ `OrderedOptions` | ❌ re-entry introduced |
| `to_prepare` + AR force-load | ❌ `Hash` (regresses #1804) | ✓ fixed |
| **This PR** | **✓ `OrderedOptions`** | **✓ fixed** |

Root cause: in Rails 7 the finisher order is `:run_prepare_callbacks` → `:finisher_hook`, so `config.to_prepare` runs **before** `config.after_initialize`. Loading `::ActiveRecord::Base` inside `to_prepare` fires AR's own `:set_configs` `on_load(:active_record)` block (which reassigns its local `configs` to a `Hash`) before its `after_initialize` block has applied framework defaults — silently dropping `config.active_record.*` settings from `new_framework_defaults_*.rb`. The two requirements are genuinely opposed at this phase.

## Fix

Keep #1804's `on_load(:active_record)` wrapper inside `run_hooks` unchanged, and add a new engine initializer that drains the queue from `config.after_initialize`, ordered after `active_record.set_configs`:

```ruby
initializer "doorkeeper.orm.flush_active_record_hooks", after: "active_record.set_configs" do
  config.after_initialize do
    ::ActiveRecord::Base if defined?(::ActiveRecord)
  end
end
```

By the time this block fires:

- AR's own `:set_configs` `after_initialize` has already applied framework defaults to AR (#1703 preserved).
- AR's `:set_configs` `on_load` callback has not yet been triggered, because nothing has loaded `AR::Base` yet.
- Touching `::ActiveRecord::Base` autoloads AR in this clean context, running the queued `on_load` callbacks — including Doorkeeper's — before any host-app code (db:seed, controllers, ...) can autoload models and trigger them re-entrantly (#1828 fixed).

The `if defined?(::ActiveRecord)` guard keeps the initializer harmless for Mongoid / Sequel users; the `after:` constraint is silently ignored if `active_record.set_configs` is not registered.

## Tests

- Subprocess regression spec for #1828 in `spec/lib/doorkeeper/orm/active_record_spec.rb` (added in df5291fa), updated to simulate the engine `after_initialize` flush in addition to `run_hooks`. The dummy app pre-loads `ActiveRecord::Base`, so this scenario can only be reproduced in a fresh Ruby subprocess that replays the exact autoload chain (User → ApplicationRecord → ActiveRecord::Base → Doorkeeper hook → FooToken/FooGrant) end-to-end.
- ngan's #1703 reproduction app verified manually: with this PR, `configs` stays `OrderedOptions` in AR's `after_initialize`, matching the no-doorkeeper baseline.
- Full suite: `bundle exec rspec` → 1296 examples, 0 failures.

## Compatibility

- No public API change.
- #1703 fix from #1804 preserved (verified against the original repro).
- All existing STI / `on_load` tests in `spec/lib/doorkeeper/orm/active_record_spec.rb` continue to pass.
- New engine initializer is a no-op for non-AR ORMs.
