### PR TITLE
Wire model concerns from Mixin `included` blocks, drop `on_load(:active_record)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ User-visible changes worth mentioning.
 
 ## main
 
-- Add here
+- [#1830] Fix `NameError: uninitialized constant ApplicationRecord` on `rails db:seed` (and other non-eager-loading flows) caused by `on_load(:active_record)` firing re-entrantly during `ApplicationRecord` autoload. The orm hooks no longer depend on `ActiveSupport.on_load(:active_record)`; model concerns (`Ownership`, `PolymorphicResourceOwner::ForAccessGrant`, `PolymorphicResourceOwner::ForAccessToken`) are now wired up from each `Mixins::*` `included` block, which fires at parent-class autoload time — after `Doorkeeper.configure` has applied user settings and without re-entering the AR load chain.
+  - **Upgrade note**: fully custom model classes that don't include `Doorkeeper::Orm::ActiveRecord::Mixins::{Application,AccessToken,AccessGrant}` will no longer auto-receive `Ownership` / `PolymorphicResourceOwner` concerns (previously injected by `run_orm_hooks` via the configured class name). Either inherit from the Doorkeeper default model, include the corresponding `Mixins::*` module, or `include` the concerns directly.
 
 ## 5.9.1
 

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -28,22 +28,14 @@ module Doorkeeper
         autoload :Application, "doorkeeper/orm/active_record/mixins/application"
       end
 
-      def self.run_hooks
-        initialize_configured_associations
-      end
-
-      def self.initialize_configured_associations
-        # NOTE: on_load block is instance_exec'd on ActiveRecord::Base,
-        #       so use fully qualified references (e.g. Doorkeeper.config).
-        ActiveSupport.on_load(:active_record) do
-          if Doorkeeper.config.enable_application_owner?
-            Doorkeeper.config.application_model.include ::Doorkeeper::Models::Ownership
-          end
-
-          Doorkeeper.config.access_grant_model.include ::Doorkeeper::Models::PolymorphicResourceOwner::ForAccessGrant
-          Doorkeeper.config.access_token_model.include ::Doorkeeper::Models::PolymorphicResourceOwner::ForAccessToken
-        end
-      end
+      # Kept as a no-op so `Doorkeeper.run_orm_hooks` (and any plugin that
+      # checks `respond_to?(:run_hooks)`) stays quiet. The model concerns
+      # that used to be wired up here are now included from each Mixin's
+      # `included` block, which runs at parent-class autoload time — well
+      # after `Doorkeeper.configure` has applied user settings, and without
+      # touching `ActiveSupport.on_load(:active_record)` (whose re-entrant
+      # firing during `ApplicationRecord` autoload caused #1828).
+      def self.run_hooks; end
     end
   end
 end

--- a/lib/doorkeeper/orm/active_record/mixins/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/access_grant.rb
@@ -9,6 +9,7 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
       self.strict_loading_by_default = false if respond_to?(:strict_loading_by_default)
 
       include ::Doorkeeper::AccessGrantMixin
+      include ::Doorkeeper::Models::PolymorphicResourceOwner::ForAccessGrant
 
       belongs_to :application, class_name: Doorkeeper.config.application_class.to_s,
                                optional: true,

--- a/lib/doorkeeper/orm/active_record/mixins/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/access_token.rb
@@ -9,6 +9,7 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
       self.strict_loading_by_default = false if respond_to?(:strict_loading_by_default)
 
       include ::Doorkeeper::AccessTokenMixin
+      include ::Doorkeeper::Models::PolymorphicResourceOwner::ForAccessToken
 
       belongs_to :application, class_name: Doorkeeper.config.application_class.to_s,
                                inverse_of: :access_tokens,

--- a/lib/doorkeeper/orm/active_record/mixins/application.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/application.rb
@@ -9,6 +9,13 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
       self.strict_loading_by_default = false if respond_to?(:strict_loading_by_default)
 
       include ::Doorkeeper::ApplicationMixin
+      # Included unconditionally: this block runs once at parent-class
+      # autoload time, so gating on `enable_application_owner?` would
+      # freeze behavior at first-load time. The actual owner validation
+      # is still gated dynamically via `validate_owner?` →
+      # `confirm_application_owner?`, and `belongs_to :owner` is lazy on
+      # schemas that lack the columns.
+      include ::Doorkeeper::Models::Ownership
 
       has_many :access_grants,
                foreign_key: :application_id,

--- a/spec/lib/doorkeeper/orm/active_record_spec.rb
+++ b/spec/lib/doorkeeper/orm/active_record_spec.rb
@@ -4,60 +4,58 @@ require "spec_helper"
 
 if DOORKEEPER_ORM == :active_record
   RSpec.describe Doorkeeper::Orm::ActiveRecord do
-    describe ".initialize_configured_associations" do
-      it "uses ActiveSupport.on_load(:active_record) to defer model loading" do
-        expect(ActiveSupport).to receive(:on_load).with(:active_record)
-        described_class.initialize_configured_associations
+    describe ".run_hooks" do
+      # The orm hook used to register an `ActiveSupport.on_load(:active_record)`
+      # block that constantized the configured model classes (#1804). That
+      # callback could fire re-entrantly during `class ApplicationRecord <
+      # ActiveRecord::Base` autoload and raise `NameError: uninitialized
+      # constant ApplicationRecord` (#1828). The callback is gone now — the
+      # model concerns it used to include are wired up from each Mixin's
+      # `included` block instead — so `run_hooks` is a no-op and must not
+      # touch ActiveRecord at all.
+      it "does not register any on_load(:active_record) callback" do
+        expect(ActiveSupport).not_to receive(:on_load).with(:active_record)
+        described_class.run_hooks
+      end
+
+      it "does not constantize any configured model class" do
+        expect(Doorkeeper.config).not_to receive(:application_model)
+        expect(Doorkeeper.config).not_to receive(:access_grant_model)
+        expect(Doorkeeper.config).not_to receive(:access_token_model)
+        described_class.run_hooks
       end
     end
 
-    # Reproduction test for https://github.com/doorkeeper-gem/doorkeeper/issues/1703
-    #
-    # Without the on_load wrapper, calling initialize_configured_associations
-    # eagerly triggers constantize on model class names (via access_token_model,
-    # access_grant_model, etc.), which forces ActiveRecord to load before
-    # config.active_record.* settings have been applied. This test verifies
-    # that the on_load block does NOT execute eagerly at registration time.
-    #
-    # See also: https://github.com/ngan/doorkeeper-activerecord-load-issue
-    describe "deferral of model loading (issue #1703)" do
-      it "does not call config model accessors at registration time" do
-        # Stub on_load to capture the block WITHOUT executing it,
-        # simulating the state before ActiveRecord is fully initialized.
-        allow(ActiveSupport).to receive(:on_load).with(:active_record)
+    describe "automatic mixin concerns" do
+      # The model concerns used to be included by `run_hooks` via an
+      # `on_load(:active_record)` callback. They are now included by each
+      # Mixin's `included` block at parent-class autoload time, which both
+      # avoids the early-AR-load regression #1804 fixed (#1703) and removes
+      # the re-entrant on_load surface that #1828 stumbled into.
 
-        expect(Doorkeeper.config).not_to receive(:application_model)
-        expect(Doorkeeper.config).not_to receive(:access_token_model)
-        expect(Doorkeeper.config).not_to receive(:access_grant_model)
-
-        described_class.initialize_configured_associations
+      it "includes PolymorphicResourceOwner::ForAccessGrant in Doorkeeper::AccessGrant" do
+        expect(Doorkeeper::AccessGrant.ancestors).to include(
+          Doorkeeper::Models::PolymorphicResourceOwner::ForAccessGrant,
+        )
       end
 
-      it "calls config model accessors only when the on_load hook fires" do
-        deferred_block = nil
+      it "includes PolymorphicResourceOwner::ForAccessToken in Doorkeeper::AccessToken" do
+        expect(Doorkeeper::AccessToken.ancestors).to include(
+          Doorkeeper::Models::PolymorphicResourceOwner::ForAccessToken,
+        )
+      end
 
-        allow(ActiveSupport).to receive(:on_load).with(:active_record) do |*, &block|
-          deferred_block = block
-        end
-
-        described_class.initialize_configured_associations
-
-        # Block was captured but not yet executed
-        expect(deferred_block).not_to be_nil
-
-        # Now simulate ActiveRecord finishing initialization by executing the block
-        expect(Doorkeeper.config).to receive(:enable_application_owner?).and_return(false)
-        expect(Doorkeeper.config).to receive(:access_grant_model).and_return(Doorkeeper::AccessGrant)
-        expect(Doorkeeper.config).to receive(:access_token_model).and_return(Doorkeeper::AccessToken)
-
-        deferred_block.call
+      it "includes Ownership in Doorkeeper::Application" do
+        expect(Doorkeeper::Application.ancestors).to include(Doorkeeper::Models::Ownership)
       end
     end
 
     describe "STI (Single Table Inheritance) support" do
-      # Ensure STI subclasses work correctly with the ActiveSupport.on_load hook.
-      # See: https://github.com/doorkeeper-gem/doorkeeper/issues/1703
-      #      https://github.com/doorkeeper-gem/doorkeeper/issues/1513
+      # Ensure STI subclasses inherit the model concerns through the standard
+      # Ruby ancestor chain — the parent class includes the Mixin (and thus the
+      # concerns) at autoload time, so any subclass automatically picks them
+      # up. See: https://github.com/doorkeeper-gem/doorkeeper/issues/1703
+      #         https://github.com/doorkeeper-gem/doorkeeper/issues/1513
 
       context "when application_class is a STI subclass of Doorkeeper::Application" do
         let!(:custom_application_class) do
@@ -76,11 +74,9 @@ if DOORKEEPER_ORM == :active_record
             enable_application_owner
             application_class "CustomStiApplication"
           end
-
-          Doorkeeper.run_orm_hooks
         end
 
-        it "includes Ownership module in the STI subclass" do
+        it "inherits Ownership from Doorkeeper::Application" do
           expect(CustomStiApplication.ancestors).to include(Doorkeeper::Models::Ownership)
         end
 
@@ -106,11 +102,9 @@ if DOORKEEPER_ORM == :active_record
             orm DOORKEEPER_ORM
             access_token_class "CustomStiAccessToken"
           end
-
-          Doorkeeper.run_orm_hooks
         end
 
-        it "includes PolymorphicResourceOwner::ForAccessToken in the STI subclass" do
+        it "inherits PolymorphicResourceOwner::ForAccessToken from Doorkeeper::AccessToken" do
           expect(CustomStiAccessToken.ancestors).to include(
             Doorkeeper::Models::PolymorphicResourceOwner::ForAccessToken,
           )
@@ -133,14 +127,123 @@ if DOORKEEPER_ORM == :active_record
             orm DOORKEEPER_ORM
             access_grant_class "CustomStiAccessGrant"
           end
-
-          Doorkeeper.run_orm_hooks
         end
 
-        it "includes PolymorphicResourceOwner::ForAccessGrant in the STI subclass" do
+        it "inherits PolymorphicResourceOwner::ForAccessGrant from Doorkeeper::AccessGrant" do
           expect(CustomStiAccessGrant.ancestors).to include(
             Doorkeeper::Models::PolymorphicResourceOwner::ForAccessGrant,
           )
+        end
+      end
+    end
+
+    # Regression test for https://github.com/doorkeeper-gem/doorkeeper/issues/1828
+    #
+    # `rails db:seed` (and any flow that runs without eager_load) can autoload
+    # ActiveRecord::Base lazily from inside `class ApplicationRecord <
+    # ActiveRecord::Base`. The previous fix (#1804) registered an
+    # `on_load(:active_record)` callback that would fire mid-load and raise
+    # `NameError: uninitialized constant ApplicationRecord`. The refactor
+    # removes the on_load surface entirely: model concerns are now included
+    # from each Mixin's `included` block. This subprocess test boots
+    # `doorkeeper/orm/active_record` in a fresh process and replays the
+    # autoload chain to prove nothing in the orm load path registers an
+    # on_load callback (or otherwise depends on AR being pre-loaded).
+    describe "issue #1828 — autoloading without ActiveSupport.on_load(:active_record)" do
+      it "does not raise NameError on uninitialized constant ApplicationRecord" do
+        require "tmpdir"
+        require "English"
+        require "bundler"
+
+        doorkeeper_lib = File.expand_path("../../../../lib", __dir__)
+        # Use the same Gemfile the parent is running under so this passes across
+        # the Appraisal matrix (rails_7_0.gemfile pins rspec-rails ~> 5.0 etc.).
+        gemfile = Bundler.default_gemfile.to_s
+
+        Dir.mktmpdir("doorkeeper-1828-") do |dir|
+          File.write(File.join(dir, "application_record.rb"), <<~RUBY)
+            class ApplicationRecord < ActiveRecord::Base
+              self.abstract_class = true if respond_to?(:abstract_class=)
+            end
+          RUBY
+
+          File.write(File.join(dir, "user.rb"),      "class User < ApplicationRecord; end\n")
+          File.write(File.join(dir, "foo_token.rb"), "class FooToken < ApplicationRecord; end\n")
+          File.write(File.join(dir, "foo_grant.rb"), "class FooGrant < ApplicationRecord; end\n")
+
+          File.write(File.join(dir, "active_record_base_stub.rb"), <<~RUBY)
+            module ActiveRecord
+              class Base
+                def self.abstract_class=(_); end
+              end
+            end
+            ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
+          RUBY
+
+          File.write(File.join(dir, "run.rb"), <<~RUBY)
+            $LOAD_PATH.unshift #{doorkeeper_lib.inspect}
+
+            require "active_support"
+            require "active_support/core_ext/string/inflections"
+
+            module ActiveRecord
+              autoload :Base, #{File.join(dir, "active_record_base_stub.rb").inspect}
+            end
+
+            Object.autoload :User,              #{File.join(dir, "user.rb").inspect}
+            Object.autoload :ApplicationRecord, #{File.join(dir, "application_record.rb").inspect}
+            Object.autoload :FooToken,          #{File.join(dir, "foo_token.rb").inspect}
+            Object.autoload :FooGrant,          #{File.join(dir, "foo_grant.rb").inspect}
+
+            # Minimal Doorkeeper namespace so we can load `doorkeeper/orm/active_record.rb`
+            # without pulling Rails (and therefore without pre-loading AR::Base).
+            module Doorkeeper
+              module Models
+                module Ownership; end
+                module PolymorphicResourceOwner
+                  module ForAccessGrant; end
+                  module ForAccessToken; end
+                end
+              end
+
+              def self.config
+                @config ||= Config.new
+              end
+
+              class Config
+                def enable_application_owner?; false; end
+                def access_grant_model; FooGrant; end
+                def access_token_model; FooToken; end
+              end
+            end
+
+            require "doorkeeper/orm/active_record"
+
+            # Simulate the `config.to_prepare` block in the engine. This is a
+            # no-op after the refactor and must NOT trigger any AR autoload
+            # or on_load callback.
+            Doorkeeper::Orm::ActiveRecord.run_hooks
+
+            # Simulate seed-style host-app code referencing a model after
+            # boot. This triggers the ApplicationRecord autoload chain that
+            # used to re-entrantly fire the on_load(:active_record)
+            # callback. With on_load removed, the chain completes cleanly.
+            User
+
+            puts "OK"
+          RUBY
+
+          env = { "BUNDLE_GEMFILE" => gemfile }
+          cmd = ["bundle", "exec", "ruby", File.join(dir, "run.rb")]
+          output = IO.popen(env, cmd, err: [:child, :out], &:read)
+          status = $CHILD_STATUS.exitstatus
+
+          expect(status).to(
+            eq(0),
+            "Subprocess exited #{status} — issue #1828 fix not in place.\n" \
+            "Output:\n#{output}",
+          )
+          expect(output).to include("OK")
         end
       end
     end

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -105,6 +105,33 @@ RSpec.describe Doorkeeper::Application do
     expect(new_application.secret).to eq("custom_application_secret")
   end
 
+  # Regression for #1830: `Ownership` is now included unconditionally
+  # from `Mixins::Application`'s `included` block (previously gated by
+  # `enable_application_owner?` inside an `on_load(:active_record)` block).
+  # Runtime behavior must be unchanged when the feature is off: the
+  # presence validator is dynamically gated by `confirm_application_owner?`,
+  # and `belongs_to :owner` must be harmless on its own.
+  context "when application_owner is not enabled (default)" do
+    it "leaves the application valid without an owner" do
+      expect(Doorkeeper.config.enable_application_owner?).to be(false)
+      expect(Doorkeeper.config.confirm_application_owner?).to be(false)
+      expect(new_application).to be_valid
+    end
+
+    it "does not fire the :owner presence validator" do
+      expect(new_application.send(:validate_owner?)).to be(false)
+      new_application.valid?
+      expect(new_application.errors[:owner]).to be_empty
+    end
+
+    it "exposes belongs_to :owner without requiring an owner record" do
+      expect(described_class.reflect_on_association(:owner)).not_to be_nil
+      expect(new_application.owner).to be_nil
+      expect(new_application.save).to be(true)
+      expect(new_application.errors[:owner]).to be_empty
+    end
+  end
+
   context "when application_owner is enabled" do
     context "when application owner is not required" do
       before do
@@ -520,6 +547,70 @@ RSpec.describe Doorkeeper::Application do
       it "doesn't include unsafe attributes if current owner isn't the same as owner" do
         expect(app.as_json(current_resource_owner: other_owner))
           .not_to include("redirect_uri")
+      end
+    end
+
+    # Regression test for the Copilot review note on #1830: `Ownership` is
+    # now included unconditionally, so `belongs_to :owner` is always
+    # declared and `respond_to?(:owner)` is always true — even on schemas
+    # that don't carry the `owner_id` / `owner_type` columns. The
+    # `respond_to?(:owner) && owner && ...` guard in `#as_json` must still
+    # short-circuit safely in that shape (no owner columns,
+    # `enable_application_owner` off): `owner` returns nil, the public
+    # attribute branch runs, and nothing raises.
+    if DOORKEEPER_ORM == :active_record
+      context "when the schema lacks owner columns" do
+        before(:all) do
+          ActiveRecord::Base.connection.create_table(:oauth_applications_no_owner) do |t|
+            t.string :name, null: false
+            t.string :uid, null: false
+            t.string :secret
+            t.text :redirect_uri
+            t.string :scopes, default: "", null: false
+            t.boolean :confidential, default: true, null: false
+            t.timestamps
+          end
+        end
+
+        after(:all) do
+          ActiveRecord::Base.connection.drop_table(:oauth_applications_no_owner)
+        end
+
+        let(:no_owner_class) do
+          Class.new(::ActiveRecord::Base) do
+            include Doorkeeper::Orm::ActiveRecord::Mixins::Application
+            self.table_name = "oauth_applications_no_owner"
+          end
+        end
+
+        let(:no_owner_app) do
+          no_owner_class.create!(name: "NoOwnerApp", redirect_uri: "https://example.com")
+        end
+
+        it "leaves the owner columns out of the schema" do
+          expect(no_owner_class.column_names).not_to include("owner_id", "owner_type")
+        end
+
+        it "still declares belongs_to :owner but returns nil lazily" do
+          expect(no_owner_app).to respond_to(:owner)
+          expect(no_owner_app.owner).to be_nil
+        end
+
+        it "renders the public attribute set without raising" do
+          expect(Doorkeeper.config.enable_application_owner?).to be(false)
+          expect { no_owner_app.as_json }.not_to raise_error
+          expect(no_owner_app.as_json).to match(
+            "id" => no_owner_app.id,
+            "name" => "NoOwnerApp",
+            "created_at" => anything,
+          )
+        end
+
+        it "ignores :current_resource_owner without raising" do
+          expect { no_owner_app.as_json(current_resource_owner: owner) }.not_to raise_error
+          expect(no_owner_app.as_json(current_resource_owner: owner))
+            .not_to include("redirect_uri", "secret")
+        end
       end
     end
   end


### PR DESCRIPTION
## Background

#1804 wrapped `Doorkeeper::Orm::ActiveRecord.initialize_configured_associations` in `ActiveSupport.on_load(:active_record)` to fix #1703 (AR loading before `config.active_record.*` framework defaults were applied). #1828 was the unintended consequence: that queued callback can fire **re-entrantly** during host-app `class ApplicationRecord < ActiveRecord::Base` autoload — Ruby resolves the superclass expression first, AR::Base's `run_load_hooks(:active_record)` fires while `ApplicationRecord` is mid-evaluation, and the Doorkeeper callback's `constantize` call on a user-configured class (`FooToken < ApplicationRecord` etc.) raises `NameError: uninitialized constant ApplicationRecord`.

#1829 sidestepped #1828 by flushing the queued callback from a Doorkeeper-registered `after_initialize` block (positioned after `active_record.set_configs`). That works in the simple case, but as @nbulaj pointed out, manually loading `::ActiveRecord::Base` is hacky — and as @luizkowalski / @nov reported, it doesn't fully fix the problem: any other gem or initializer that touches AR before our `after_initialize` runs is still at the mercy of the on_load timing. The root cause is the on_load dependency itself, not the flush ordering.

Per @nbulaj's "At least we can try 👀" on the proposal: cut `ActiveSupport.on_load(:active_record)` out of the orm setup entirely. The three concerns the callback registers are all `include`s into the configured Doorkeeper model classes — they belong in the `included` block of the corresponding Mixin, which already runs at parent-class autoload time, after `Doorkeeper.configure` has applied user settings, and well after AR's framework defaults are in place (the parent class IS an AR-derived class).

## Changes

- `Mixins::AccessGrant`: `include PolymorphicResourceOwner::ForAccessGrant` inside the `included` block
- `Mixins::AccessToken`: `include PolymorphicResourceOwner::ForAccessToken` inside the `included` block
- `Mixins::Application`: `include Ownership` inside the `included` block (unconditional — see note below)
- `Orm::ActiveRecord.initialize_configured_associations` removed; `run_hooks` reduced to a no-op so `Doorkeeper.run_orm_hooks` (and any plugin that checks `respond_to?(:run_hooks)`) stays quiet
- `engine.rb` left untouched (no `after_initialize` flush added — that band-aid is no longer needed because the on_load surface is gone)
- Spec rewrite: dropped the on_load-deferral specs (they enforced a behavior we're removing) and replaced them with assertions that `run_hooks` registers nothing and constantizes no model. STI specs simplified to verify inheritance through the standard ancestor chain. #1828 subprocess regression test retained, updated for the new architecture.

### Why Ownership is unconditional

The previous `if Doorkeeper.config.enable_application_owner?` gate was evaluated inside an on_load block that *re-fired on every `run_orm_hooks` call*, so toggling `enable_application_owner` between tests worked. In an `included` block, the gate evaluates exactly once (at first parent-class autoload), freezing the behavior. The user-visible runtime semantics are unchanged: the only validation `Ownership` actually adds is `validates :owner, presence: true, if: :validate_owner?`, and `validate_owner?` already gates on `Doorkeeper.config.confirm_application_owner?` at validate time. `belongs_to :owner` is lazy on schemas without the `owner_id`/`owner_type` columns — it only errors if the user actually calls `.owner`, which they wouldn't without enabling the feature.

## Verification

- Full spec suite: **1298 examples, 0 failures**
- @ngan's [#1703 reproduction app](https://github.com/ngan/doorkeeper-activerecord-load-issue) with the local fork pinned in: `configs` stays `ActiveSupport::OrderedOptions` across `initialize` and `after_initialize` (same `object_id`), matching the no-doorkeeper baseline. #1703 stays fixed.
- Same repro app: `rails db:seed`, `rails db:migrate`, and a `rails runner` that touches `Doorkeeper::Application.count` / `Doorkeeper::AccessToken.count` / `Doorkeeper::AccessGrant.count` all complete without `NameError`. #1828 stays fixed.
- Subprocess regression test for #1828 (in `spec/lib/doorkeeper/orm/active_record_spec.rb`) replays the autoload chain end-to-end without on_load and exits clean.

## Fixes

- Fixes #1828
- Keeps #1703 fixed (the new architecture is structurally immune — no Doorkeeper code path forces an early AR load)
- Supersedes #1829
