### PR TITLE
Gate `belongs_to :owner` on `enable_application_owner?` at include time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - Please add here
+- [#1832] Fix confusing `belongs_to :owner` side effect: `Doorkeeper::Models::Ownership` is now included only when `enable_application_owner?` is set (read at include time), so models no longer expose a misleading `owner` association/reflection when the application owner feature is disabled and the schema lacks the owner columns.
 
 ## 5.9.2
 

--- a/lib/doorkeeper/orm/active_record/mixins/application.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/application.rb
@@ -9,13 +9,12 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
       self.strict_loading_by_default = false if respond_to?(:strict_loading_by_default)
 
       include ::Doorkeeper::ApplicationMixin
-      # Included unconditionally: this block runs once at parent-class
-      # autoload time, so gating on `enable_application_owner?` would
-      # freeze behavior at first-load time. The actual owner validation
-      # is still gated dynamically via `validate_owner?` →
-      # `confirm_application_owner?`, and `belongs_to :owner` is lazy on
-      # schemas that lack the columns.
-      include ::Doorkeeper::Models::Ownership
+      # `enable_application_owner?` is read once, at parent-class autoload
+      # time (#1831): with the feature off the model exposes no `:owner`
+      # association — avoiding a misleading reflection on schemas that lack
+      # the owner columns. The flag is therefore a load-time switch; turning
+      # it on later requires defining a fresh model class.
+      include ::Doorkeeper::Models::Ownership if Doorkeeper.config.enable_application_owner?
 
       has_many :access_grants,
                foreign_key: :application_id,

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -394,23 +394,19 @@ RSpec.describe Doorkeeper::Config do
 
     if DOORKEEPER_ORM == :active_record
       context "when enabled without confirmation", active_record: true do
-        class ApplicationWithOwner < ActiveRecord::Base
-          include Doorkeeper::Orm::ActiveRecord::Mixins::Application
-        end
+        # The owner association is wired at include time (#1831), so the model
+        # is built after `enable_application_owner` has been configured.
+        let(:application_with_owner) { build_application_model }
 
         before do
           Doorkeeper.configure do
             orm DOORKEEPER_ORM
             enable_application_owner
-
-            application_class "ApplicationWithOwner"
           end
-
-          Doorkeeper.run_orm_hooks
         end
 
         it "adds support for application owner" do
-          instance = ApplicationWithOwner.new(FactoryBot.attributes_for(:application))
+          instance = application_with_owner.new(FactoryBot.attributes_for(:application))
 
           expect(instance).to respond_to :owner
           expect(instance).to be_valid
@@ -424,23 +420,19 @@ RSpec.describe Doorkeeper::Config do
 
     if DOORKEEPER_ORM == :active_record
       context "when enabled with confirmation set to true", active_record: true do
-        class ApplicationWithOwner < ActiveRecord::Base
-          include Doorkeeper::Orm::ActiveRecord::Mixins::Application
-        end
+        # The owner association is wired at include time (#1831), so the model
+        # is built after `enable_application_owner` has been configured.
+        let(:application_with_owner) { build_application_model(name: "ApplicationWithOwner") }
 
         before do
           Doorkeeper.configure do
             orm DOORKEEPER_ORM
             enable_application_owner confirmation: true
-
-            application_class "ApplicationWithOwner"
           end
-
-          Doorkeeper.run_orm_hooks
         end
 
         it "adds support for application owner" do
-          instance = ApplicationWithOwner.new(FactoryBot.attributes_for(:application))
+          instance = application_with_owner.new(FactoryBot.attributes_for(:application))
 
           expect(instance).to respond_to :owner
           expect(instance).not_to be_valid

--- a/spec/lib/doorkeeper/orm/active_record_spec.rb
+++ b/spec/lib/doorkeeper/orm/active_record_spec.rb
@@ -45,8 +45,21 @@ if DOORKEEPER_ORM == :active_record
         )
       end
 
-      it "includes Ownership in Doorkeeper::Application" do
-        expect(Doorkeeper::Application.ancestors).to include(Doorkeeper::Models::Ownership)
+      # `Ownership` is included only when `enable_application_owner` is
+      # configured, read at parent-class autoload time (#1831). The default
+      # config leaves the feature off, so the singleton model never carries
+      # the module (or its `:owner` association).
+      it "does not include Ownership in Doorkeeper::Application by default" do
+        expect(Doorkeeper::Application.ancestors).not_to include(Doorkeeper::Models::Ownership)
+      end
+
+      it "includes Ownership when application owner is enabled" do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          enable_application_owner
+        end
+
+        expect(build_application_model.ancestors).to include(Doorkeeper::Models::Ownership)
       end
     end
 
@@ -58,8 +71,23 @@ if DOORKEEPER_ORM == :active_record
       #         https://github.com/doorkeeper-gem/doorkeeper/issues/1513
 
       context "when application_class is a STI subclass of Doorkeeper::Application" do
+        # `Ownership` is included only if `enable_application_owner?` is set
+        # at include time (#1831), so the owner association lives on whichever
+        # base class was defined while the feature was on. We build an
+        # owner-enabled base (standing in for `Doorkeeper::Application` loaded
+        # with the feature on) and STI-subclass it, rather than mutating the
+        # already-loaded singleton — keeping the example order-independent.
+        let(:application_base_class) do
+          Doorkeeper.configure do
+            orm DOORKEEPER_ORM
+            enable_application_owner
+          end
+
+          build_application_model
+        end
+
         let!(:custom_application_class) do
-          Class.new(Doorkeeper::Application) do
+          Class.new(application_base_class) do
             def self.name
               "CustomStiApplication"
             end
@@ -76,7 +104,7 @@ if DOORKEEPER_ORM == :active_record
           end
         end
 
-        it "inherits Ownership from Doorkeeper::Application" do
+        it "inherits Ownership from the application base class" do
           expect(CustomStiApplication.ancestors).to include(Doorkeeper::Models::Ownership)
         end
 

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -105,12 +105,11 @@ RSpec.describe Doorkeeper::Application do
     expect(new_application.secret).to eq("custom_application_secret")
   end
 
-  # Regression for #1830: `Ownership` is now included unconditionally
-  # from `Mixins::Application`'s `included` block (previously gated by
-  # `enable_application_owner?` inside an `on_load(:active_record)` block).
-  # Runtime behavior must be unchanged when the feature is off: the
-  # presence validator is dynamically gated by `confirm_application_owner?`,
-  # and `belongs_to :owner` must be harmless on its own.
+  # Regression for #1831: `Doorkeeper::Models::Ownership` is included only
+  # when `enable_application_owner?` is set at include time. When the feature
+  # is off (the default), the `:owner` association must NOT be declared, so
+  # the model never exposes an owner reflection on schemas that don't carry
+  # the owner columns (the confusing side effect reported in #1831).
   context "when application_owner is not enabled (default)" do
     it "leaves the application valid without an owner" do
       expect(Doorkeeper.config.enable_application_owner?).to be(false)
@@ -118,29 +117,34 @@ RSpec.describe Doorkeeper::Application do
       expect(new_application).to be_valid
     end
 
-    it "does not fire the :owner presence validator" do
-      expect(new_application.send(:validate_owner?)).to be(false)
+    it "does not declare the :owner presence validator" do
+      expect(new_application).not_to respond_to(:validate_owner?)
       new_application.valid?
       expect(new_application.errors[:owner]).to be_empty
     end
 
-    it "exposes belongs_to :owner without requiring an owner record" do
-      expect(described_class.reflect_on_association(:owner)).not_to be_nil
-      expect(new_application.owner).to be_nil
+    it "does not declare the belongs_to :owner association" do
+      expect(described_class.reflect_on_association(:owner)).to be_nil
+      expect(new_application).not_to respond_to(:owner)
       expect(new_application.save).to be(true)
       expect(new_application.errors[:owner]).to be_empty
     end
   end
 
   context "when application_owner is enabled" do
+    # `enable_application_owner` is a load-time switch: the owner association
+    # is wired into the model when its class is defined. We build the model
+    # after enabling the feature so the include-time gate sees it on, rather
+    # than reconfiguring the already-loaded `Doorkeeper::Application`.
+    let(:owner_application_class) { build_application_model }
+    let(:new_application) { owner_application_class.new(FactoryBot.attributes_for(:application)) }
+
     context "when application owner is not required" do
       before do
         Doorkeeper.configure do
           orm DOORKEEPER_ORM
           enable_application_owner
         end
-
-        Doorkeeper.run_orm_hooks
       end
 
       it "is valid given valid attributes" do
@@ -154,8 +158,6 @@ RSpec.describe Doorkeeper::Application do
           orm DOORKEEPER_ORM
           enable_application_owner confirmation: true
         end
-
-        Doorkeeper.run_orm_hooks
       end
 
       it "is invalid without an owner" do
@@ -524,15 +526,23 @@ RSpec.describe Doorkeeper::Application do
 
     context "when called with authorized resource owner" do
       let(:other_owner) { FactoryBot.create(:doorkeeper_testing_user) }
-      let(:app) { FactoryBot.create(:application, secret: "123123123", owner: owner) }
+
+      # Build the model after enabling the owner feature so `belongs_to :owner`
+      # is declared (the gate is evaluated at include time, see #1831).
+      let(:owner_application_class) { build_application_model }
+      let(:app) do
+        owner_application_class.new(FactoryBot.attributes_for(:application)).tap do |application|
+          application.secret = "123123123"
+          application.owner = owner
+          application.save!
+        end
+      end
 
       before do
         Doorkeeper.configure do
           orm DOORKEEPER_ORM
           enable_application_owner confirmation: false
         end
-
-        Doorkeeper.run_orm_hooks
       end
 
       it "includes all the attributes" do
@@ -550,14 +560,13 @@ RSpec.describe Doorkeeper::Application do
       end
     end
 
-    # Regression test for the Copilot review note on #1830: `Ownership` is
-    # now included unconditionally, so `belongs_to :owner` is always
-    # declared and `respond_to?(:owner)` is always true — even on schemas
-    # that don't carry the `owner_id` / `owner_type` columns. The
-    # `respond_to?(:owner) && owner && ...` guard in `#as_json` must still
-    # short-circuit safely in that shape (no owner columns,
-    # `enable_application_owner` off): `owner` returns nil, the public
-    # attribute branch runs, and nothing raises.
+    # Regression test for #1831: when `enable_application_owner` is off,
+    # `belongs_to :owner` is NOT declared, so a schema without the
+    # `owner_id` / `owner_type` columns no longer exposes a misleading
+    # `:owner` association. The `respond_to?(:owner) && owner && ...` guard
+    # in `#as_json` must still short-circuit safely in that shape (no owner
+    # columns, `enable_application_owner` off): `respond_to?(:owner)` is
+    # false, the public attribute branch runs, and nothing raises.
     if DOORKEEPER_ORM == :active_record
       context "when the schema lacks owner columns" do
         before(:all) do
@@ -591,9 +600,10 @@ RSpec.describe Doorkeeper::Application do
           expect(no_owner_class.column_names).not_to include("owner_id", "owner_type")
         end
 
-        it "still declares belongs_to :owner but returns nil lazily" do
-          expect(no_owner_app).to respond_to(:owner)
-          expect(no_owner_app.owner).to be_nil
+        it "does not declare belongs_to :owner when the feature is off" do
+          expect(Doorkeeper.config.enable_application_owner?).to be(false)
+          expect(no_owner_class.reflect_on_association(:owner)).to be_nil
+          expect(no_owner_app).not_to respond_to(:owner)
         end
 
         it "renders the public attribute set without raising" do
@@ -617,10 +627,9 @@ RSpec.describe Doorkeeper::Application do
 
   if DOORKEEPER_ORM == :active_record
     context "when custom model class configured", active_record: true do
-      class CustomApp < ::ActiveRecord::Base
-        include Doorkeeper::Orm::ActiveRecord::Mixins::Application
-      end
-
+      # `CustomApp` is rebuilt inside each context's `before`, after the
+      # owner feature is configured, so its include-time owner gate (#1831)
+      # reflects that context's `enable_application_owner` setting.
       let(:new_application) { CustomApp.new(FactoryBot.attributes_for(:application)) }
 
       context "without confirmation" do
@@ -631,7 +640,7 @@ RSpec.describe Doorkeeper::Application do
             enable_application_owner confirmation: false
           end
 
-          Doorkeeper.run_orm_hooks
+          stub_const("CustomApp", build_application_model)
         end
 
         it "is valid given valid attributes" do
@@ -639,7 +648,7 @@ RSpec.describe Doorkeeper::Application do
         end
       end
 
-      context "without confirmation" do
+      context "with confirmation" do
         before do
           Doorkeeper.configure do
             orm DOORKEEPER_ORM
@@ -647,7 +656,7 @@ RSpec.describe Doorkeeper::Application do
             enable_application_owner confirmation: true
           end
 
-          Doorkeeper.run_orm_hooks
+          stub_const("CustomApp", build_application_model)
         end
 
         it "is invalid without owner" do

--- a/spec/support/helpers/application_model_helper.rb
+++ b/spec/support/helpers/application_model_helper.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Helpers for exercising Doorkeeper's Application model under different
+# `enable_application_owner` configurations.
+#
+# As of #1832 (fixes #1831) `Mixins::Application` includes
+# `Doorkeeper::Models::Ownership` only when `enable_application_owner?` is set —
+# the mixin's `included` block runs once, when the model class is first
+# defined. The global `config.before` hook (see spec_helper) resets
+# Doorkeeper to its default (owner disabled)
+# before every example, and the real `Doorkeeper::Application` singleton is
+# autoloaded once with the feature off. So a test that needs the owner
+# association present must build a *fresh* model class AFTER enabling the
+# feature, rather than reconfiguring the already-loaded class at runtime
+# (`run_orm_hooks` is a no-op and cannot retro-fit associations).
+module ApplicationModelHelper
+  # Builds a brand-new Application model whose mixin `included` block runs
+  # under the Doorkeeper configuration currently in effect.
+  #
+  # Pass +name+ when the test reads validation error messages (e.g.
+  # `errors[:owner]`): ActiveModel resolves the model name to build the
+  # message, which raises on an anonymous class.
+  def build_application_model(name: nil, table_name: "oauth_applications")
+    model = Class.new(::ActiveRecord::Base) do
+      self.table_name = table_name
+      include Doorkeeper::Orm::ActiveRecord::Mixins::Application
+    end
+    model.define_singleton_method(:name) { name } if name
+    model
+  end
+end
+
+RSpec.configure do |config|
+  config.include ApplicationModelHelper
+end


### PR DESCRIPTION
### Problem

Since #1830 (ab58c37), `Doorkeeper::Models::Ownership` is included unconditionally from `Mixins::Application`'s `included` block. This means `belongs_to :owner` is always declared — even when `enable_application_owner` is not set and the schema lacks the `owner_id`/`owner_type` columns. The `:owner` reflection is visible, but calling `owner_type` raises `NoMethodError`, which is confusing.

### Root cause

The original commit chose unconditional inclusion to avoid "freezing" the gate at first-load time. In practice, the real constraint was that the test suite exercised the enabled behavior by reconfiguring `Doorkeeper.configure { enable_application_owner }` at runtime and calling `Doorkeeper.run_orm_hooks` — which is now a no-op. Since `ActiveSupport::Concern`'s `included` block runs only once, the association could never be retro-fitted onto an already-loaded model, so the tests relied on it being always present.

Note: gating the `:owner` association on the flag also restores the pre-#1830 behavior — the old `on_load(:active_record)` path included `Ownership` conditionally (`if enable_application_owner?`), so OFF-by-default never declared the association. #1830's unconditional include was the regression; this PR is not a new user-facing behavior change.

### Fix

Gate the association and its presence validation on `enable_application_owner?` inside `Ownership`'s `included` block:

```ruby
included do
  if Doorkeeper.config.enable_application_owner?
    belongs_to :owner, polymorphic: true, optional: true
    validates :owner, presence: true, if: :validate_owner?
  end
end
```

This mirrors how `PolymorphicResourceOwner::ForAccessGrant` / `ForAccessToken` gate `belongs_to :resource_owner` — same pattern, same timing.

`enable_application_owner?` reads `option_set?` (an instance variable check), so this introduces no `constantize` call (#1703 safe) and no `ActiveSupport.on_load(:active_record)` (#1828 safe).

Also synced the now-stale comment above `include ::Doorkeeper::Models::Ownership` in `Mixins::Application`, which still argued for unconditional inclusion.

### Test changes

`enable_application_owner` is now formally a **load-time switch**: its effect is evaluated once when the model class is defined. Tests that exercise the enabled path can no longer reconfigure an already-loaded singleton.

Introduced `build_application_model` helper (`spec/support/helpers/application_model_helper.rb`) that builds a fresh `ActiveRecord::Base` subclass with `Mixins::Application` included **after** the feature is configured. This keeps examples order-independent and avoids mutating the global `Doorkeeper::Application`.

The two #1830 regression specs that asserted "`:owner` association is present even when the feature is off" are inverted to assert the opposite — the intended behavioral change of this PR.

Also fixed a pre-existing label typo: duplicate `"without confirmation"` → `"with confirmation"`.

Closes #1831
