### PR TITLE
Fix `allow_token_introspection` default returning `false` with custom `application_class` (#1833)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#1834] Fix default `allow_token_introspection` returning `false` when a custom `application_class` is configured. The default proc compared application objects with `==`, which fails when the authorized client and the introspected token's application are resolved as different classes (e.g. a base `Doorkeeper::Application` vs. a configured subclass) even though they reference the same record. It now compares application ids instead.
 - Please add here
 
 ## 5.9.2

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -444,9 +444,9 @@ module Doorkeeper
     option :allow_token_introspection,
            default: (lambda do |token, authorized_client, authorized_token|
              if authorized_token
-               authorized_token.application == token&.application
+               authorized_token.application_id == token&.application_id
              elsif token&.application
-               authorized_client == token.application
+               authorized_client.id == token.application_id
              else
                true
              end

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -371,6 +371,31 @@ RSpec.describe Doorkeeper::TokensController, type: :controller do
       end
     end
 
+    context "when application_class is configured to a custom subclass" do
+      # Regression test for doorkeeper#1833: the default allow_token_introspection
+      # proc compared application objects with `==`, which fails when the
+      # authorized client is resolved as a different (sub)class than the
+      # introspected token's application, even though they reference the same row.
+      let(:custom_application_class) { Class.new(Doorkeeper::Application) }
+
+      before do
+        stub_const("CustomDoorkeeperApplication", custom_application_class)
+        allow(Doorkeeper.config).to receive(:application_model).and_return(CustomDoorkeeperApplication)
+      end
+
+      it "responds with full token introspection when authorized via Client Credentials" do
+        # token_for_introspection.application is a Doorkeeper::Application, while the
+        # authorized client is resolved as CustomDoorkeeperApplication for the same row.
+        expect(token_for_introspection.application).to be_an_instance_of(Doorkeeper::Application)
+
+        request.headers["Authorization"] = basic_auth_header_for_client(client)
+
+        post :introspect, params: { token: token_for_introspection.token }
+
+        expect(json_response).to include("active" => true)
+      end
+    end
+
     context "when token introspection disabled" do
       before do
         Doorkeeper.configure do


### PR DESCRIPTION
## Summary

Fixes #1833.

The default `allow_token_introspection` proc compared application **objects** with `==`:

```ruby
authorized_token.application == token&.application   # authorized_token branch
authorized_client == token.application               # authorized_client branch
```

ActiveRecord `==` requires both the **same class** and the **same id**. That assumption breaks once a custom `application_class` is configured:

- `token.application` is resolved through the `belongs_to :application` association, whose `class_name` is captured at mixin **load time** (defaults to `Doorkeeper::Application`).
- `authorized_client` is resolved at **request time** via `Doorkeeper.config.application_model`, i.e. the configured (sub)class.

So the two sides reference the **same record** but are instantiated as **different classes**, making `==` return `false`. As a result, token introspection authorized via Client Credentials always responded with `{ "active": false }`, even for the client the token was issued to.

## Fix

Compare application **ids** instead of objects. This is class-agnostic and preserves the original intent of the check:

```ruby
if authorized_token
  authorized_token.application_id == token&.application_id
elsif token&.application
  authorized_client.id == token.application_id
else
  true
end
```

Only the comparison method changes — no other behavior is affected. `token_introspection.rb` is untouched; this is a config-level fix.

## Test

Adds a regression spec under `POST #introspect` in `spec/controllers/tokens_controller_spec.rb` that configures `application_model` to a `Doorkeeper::Application` subclass, so the authorized client and the introspected token's application resolve as different classes for the same record. It asserts that introspection via Client Credentials responds with `"active" => true`.

The new spec fails against the previous implementation (`"active" => false`) and passes with the fix.

## Verification

- `bundle exec rspec spec/controllers/tokens_controller_spec.rb spec/lib/config_spec.rb` → all green.
- RuboCop reports no new offenses on the changed files.
- Added a `CHANGELOG.md` entry under `## main`.