### PR TITLE
Drop Ruby 3.1 from CI matrix and bump required_ruby_version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,10 @@ jobs:
       !(   contains(github.event.pull_request.title,  '[ci skip]')
         || contains(github.event.pull_request.title,  '[skip ci]'))
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         ruby:
-          - "3.1"
           - "3.2"
           - "3.3"
           - "3.4"
@@ -30,9 +29,6 @@ jobs:
           - gemfiles/rails_7_1.gemfile
           - gemfiles/rails_7_2.gemfile
           - gemfiles/rails_8_0.gemfile
-        exclude:
-          - ruby: 3.1
-            gemfile: gemfiles/rails_8_0.gemfile
     steps:
       - name: Repo checkout
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - Please add here
+- [#1837] Drop Ruby 3.1 support: bump `required_ruby_version` to `>= 3.2` and remove Ruby 3.1 from the CI matrix. Ruby 3.1 reached EOL on 2025-03-25, and since i18n 1.15.0 uses the Ruby 3.2+ `Fiber[:i18n_config]` storage API, Ruby 3.1 builds fail with `NoMethodError`.
 
 ## 5.9.3
 

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   }
 
   gem.add_dependency "railties", ">= 5"
-  gem.required_ruby_version = ">= 2.7"
+  gem.required_ruby_version = ">= 3.2"
 
   gem.add_development_dependency "appraisal"
   gem.add_development_dependency "capybara"


### PR DESCRIPTION
Ruby 3.1 reached EOL on 2025-03-25. Since i18n 1.15.0 (released 2026-06-17) uses `Fiber[:i18n_config]` (Ruby 3.2+ Fiber storage API), the Ruby 3.1 CI jobs now fail with `NoMethodError` on every run.

>[!NOTE]
> #### This is the same root cause addressed in doorkeeper-openid_connect:
> - https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/314

Changes:
- Remove Ruby 3.1 from CI matrix (and its `exclude` entry)
- Set `fail-fast: false` to prevent one job's failure from cancelling siblings
- Bump `required_ruby_version` from `>= 2.7` to `>= 3.2`