### PR TITLE
[1/3] Send client credentials in the request body in token endpoint specs (RFC 6749 §2.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#1839] Send client credentials in the request body (not the query string) in the token endpoint specs, per RFC 6749 §2.3.1. Test-only change: the `*_endpoint_url` helpers now return a path plus a matching `*_endpoint_params` builder so flow specs post credentials through the body.
 - Please add here
 
 ## 5.9.3

--- a/spec/requests/flows/authorization_code_errors_spec.rb
+++ b/spec/requests/flows/authorization_code_errors_spec.rb
@@ -60,11 +60,11 @@ RSpec.describe "Authorization Code Flow Errors after authorization" do
 
   it "returns :invalid_grant error when posting an already revoked grant code" do
     # First successful request
-    post token_endpoint_url(code: @authorization.token, client: @client)
+    post token_endpoint_url, params: token_endpoint_params(code: @authorization.token, client: @client)
 
     # Second attempt with same token
     expect do
-      post token_endpoint_url(code: @authorization.token, client: @client)
+      post token_endpoint_url, params: token_endpoint_params(code: @authorization.token, client: @client)
     end.not_to(change { Doorkeeper::AccessToken.count })
 
     expect(json_response).to match(
@@ -74,7 +74,7 @@ RSpec.describe "Authorization Code Flow Errors after authorization" do
   end
 
   it "returns :invalid_grant error for invalid grant code" do
-    post token_endpoint_url(code: "invalid", client: @client)
+    post token_endpoint_url, params: token_endpoint_params(code: "invalid", client: @client)
 
     access_token_should_not_exist
 

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -155,7 +155,7 @@ feature "Authorization Code Flow" do
     click_on "Authorize"
 
     authorization_code = Doorkeeper::AccessGrant.first.token
-    page.driver.post token_endpoint_url(
+    page.driver.post token_endpoint_url, token_endpoint_params(
       code: authorization_code,
       client_id: @client.uid,
       redirect_uri: @client.redirect_uri,
@@ -174,7 +174,7 @@ feature "Authorization Code Flow" do
     click_on "Authorize"
 
     authorization_code = Doorkeeper::AccessGrant.first.token
-    page.driver.post token_endpoint_url(
+    page.driver.post token_endpoint_url, token_endpoint_params(
       code: authorization_code,
       client_secret: @client.secret,
       redirect_uri: @client.redirect_uri,
@@ -334,7 +334,7 @@ feature "Authorization Code Flow" do
         click_on "Authorize"
 
         authorization_code = current_params["code"]
-        page.driver.post token_endpoint_url(
+        page.driver.post token_endpoint_url, token_endpoint_params(
           code: authorization_code,
           client_id: @client.uid,
           redirect_uri: @client.redirect_uri,
@@ -353,7 +353,7 @@ feature "Authorization Code Flow" do
         click_on "Authorize"
 
         authorization_code = current_params["code"]
-        page.driver.post token_endpoint_url(
+        page.driver.post token_endpoint_url, token_endpoint_params(
           code: authorization_code,
           client_id: @client.uid,
           redirect_uri: @client.redirect_uri,
@@ -413,7 +413,7 @@ feature "Authorization Code Flow" do
         click_on "Authorize"
 
         authorization_code = current_params["code"]
-        page.driver.post token_endpoint_url(
+        page.driver.post token_endpoint_url, token_endpoint_params(
           code: authorization_code,
           client: @client,
           code_verifier: code_challenge,
@@ -543,7 +543,7 @@ feature "Authorization Code Flow" do
         allow_any_instance_of(Doorkeeper::AccessGrant)
           .to receive(:revoked?).and_return(false, true)
 
-        page.driver.post token_endpoint_url(code: authorization_code, client: @client)
+        page.driver.post token_endpoint_url, token_endpoint_params(code: authorization_code, client: @client)
 
         expect(json_response).to match(
           "error" => "invalid_grant",
@@ -573,7 +573,7 @@ feature "Authorization Code Flow" do
     end
 
     it "copies custom attributes from the grant into the token" do
-      page.driver.post token_endpoint_url(code: grant.token, client: client)
+      page.driver.post token_endpoint_url, token_endpoint_params(code: grant.token, client: client)
 
       access_token = Doorkeeper::AccessToken.find_by(token: json_response["access_token"])
       expect(access_token.tenant_name).to eq("Tenant 1")

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Client Credentials Request" do
       headers = authorization client.uid, client.secret
       params  = { grant_type: "client_credentials" }
 
-      post "/oauth/token", params: params, headers: headers
+      post token_endpoint_url, params: params, headers: headers
 
       expect(json_response).to match(
         "access_token" => Doorkeeper::AccessToken.first.token,
@@ -30,7 +30,7 @@ RSpec.describe "Client Credentials Request" do
         headers = authorization client.uid, client.secret
         params  = { grant_type: "client_credentials", scope: "write" }
 
-        post "/oauth/token", params: params, headers: headers
+        post token_endpoint_url, params: params, headers: headers
 
         expect(json_response).to include(
           "access_token" => Doorkeeper::AccessToken.first.token,
@@ -43,7 +43,7 @@ RSpec.describe "Client Credentials Request" do
           headers = authorization client.uid, client.secret
           params  = { grant_type: "client_credentials", scope: "public" }
 
-          post "/oauth/token", params: params, headers: headers
+          post token_endpoint_url, params: params, headers: headers
 
           expect(json_response).to include(
             "access_token" => Doorkeeper::AccessToken.first.token,
@@ -57,7 +57,7 @@ RSpec.describe "Client Credentials Request" do
           headers = authorization client.uid, client.secret
           params  = { grant_type: "client_credentials", scope: "random" }
 
-          post "/oauth/token", params: params, headers: headers
+          post token_endpoint_url, params: params, headers: headers
 
           expect(response.status).to eq(400)
           expect(json_response).to match(
@@ -83,7 +83,7 @@ RSpec.describe "Client Credentials Request" do
       headers = authorization client.uid, client.secret
       params  = { grant_type: "client_credentials" }
 
-      post "/oauth/token", params: params, headers: headers
+      post token_endpoint_url, params: params, headers: headers
 
       expect(json_response).to match(
         "error" => "unauthorized_client",
@@ -97,7 +97,7 @@ RSpec.describe "Client Credentials Request" do
       headers = authorization client.uid, client.secret
       params  = { grant_type: "client_credentials" }
 
-      post "/oauth/token", params: params, headers: headers
+      post token_endpoint_url, params: params, headers: headers
 
       expect(json_response).to match(
         "access_token" => Doorkeeper::AccessToken.first.token,
@@ -120,7 +120,7 @@ RSpec.describe "Client Credentials Request" do
       params  = { grant_type: "client_credentials" }
 
       expect do
-        post "/oauth/token", params: params, headers: headers
+        post token_endpoint_url, params: params, headers: headers
       end.to change { Doorkeeper::AccessToken.count }.by(1)
 
       token = Doorkeeper::AccessToken.first
@@ -139,7 +139,7 @@ RSpec.describe "Client Credentials Request" do
       params  = { grant_type: "client_credentials" }
 
       expect do
-        post "/oauth/token", params: params, headers: headers
+        post token_endpoint_url, params: params, headers: headers
       end.to change { Doorkeeper::AccessToken.count }.by(1)
 
       token = Doorkeeper::AccessToken.first
@@ -157,7 +157,7 @@ RSpec.describe "Client Credentials Request" do
       headers = authorization client.uid, client.secret
       params  = { grant_type: "client_credentials" }
 
-      post "/oauth/token", params: params, headers: headers
+      post token_endpoint_url, params: params, headers: headers
 
       expect(json_response).to match(
         "error" => "invalid_scope",
@@ -171,7 +171,7 @@ RSpec.describe "Client Credentials Request" do
       headers = {}
       params  = { grant_type: "client_credentials" }
 
-      post "/oauth/token", params: params, headers: headers
+      post token_endpoint_url, params: params, headers: headers
 
       expect(response.status).to eq(401)
 
@@ -191,12 +191,12 @@ RSpec.describe "Client Credentials Request" do
       headers = authorization client.uid, client.secret
       params  = { grant_type: "client_credentials" }
 
-      post "/oauth/token", params: params, headers: headers
+      post token_endpoint_url, params: params, headers: headers
       expect(json_response).to include("access_token" => Doorkeeper::AccessToken.first.token)
 
       token = Doorkeeper::AccessToken.first
 
-      post "/oauth/token", params: params, headers: headers
+      post token_endpoint_url, params: params, headers: headers
       expect(json_response).to include("access_token" => Doorkeeper::AccessToken.last.token)
 
       expect(token.reload).to be_revoked
@@ -215,7 +215,7 @@ RSpec.describe "Client Credentials Request" do
         headers = authorization client.uid, client.secret
         params  = { grant_type: "client_credentials" }
 
-        post "/oauth/token", params: params, headers: headers
+        post token_endpoint_url, params: params, headers: headers
 
         expect(json_response).to match(
           "error" => "invalid_token_reuse",

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
     context "with valid user credentials" do
       it "does not issue new token" do
         expect do
-          post password_token_endpoint_url(client: @client, resource_owner: @resource_owner)
+          post token_endpoint_url, params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner)
         end.not_to(change { Doorkeeper::AccessToken.count })
       end
     end
@@ -32,7 +32,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
       context "with confidential client authorized using Basic auth" do
         it "issues a new token" do
           expect do
-            post password_token_endpoint_url(
+            post token_endpoint_url, params: password_token_endpoint_params(
               resource_owner: @resource_owner,
             ), headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(@client) }
           end.to(change { Doorkeeper::AccessToken.count })
@@ -64,7 +64,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
             @client.update(name: "sample app")
 
             expect do
-              post password_token_endpoint_url(
+              post token_endpoint_url, params: password_token_endpoint_params(
                 client_id: @client.uid,
                 client_secret: "foobar",
                 resource_owner: @resource_owner,
@@ -82,7 +82,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
             @client.update(name: "admin")
 
             expect do
-              post password_token_endpoint_url(client_id: @client.uid, resource_owner: @resource_owner)
+              post token_endpoint_url, params: password_token_endpoint_params(client_id: @client.uid, resource_owner: @resource_owner)
             end.to change { Doorkeeper::AccessToken.count }.by(1)
 
             token = Doorkeeper::AccessToken.first
@@ -95,7 +95,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
         context "when client_secret absent" do
           it "issues a new token" do
             expect do
-              post password_token_endpoint_url(client_id: @client.uid, resource_owner: @resource_owner)
+              post token_endpoint_url, params: password_token_endpoint_params(client_id: @client.uid, resource_owner: @resource_owner)
             end.to change { Doorkeeper::AccessToken.count }.by(1)
 
             token = Doorkeeper::AccessToken.first
@@ -108,7 +108,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
         context "when client_secret present" do
           it "issues a new token" do
             expect do
-              post password_token_endpoint_url(client: @client, resource_owner: @resource_owner)
+              post token_endpoint_url, params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner)
             end.to change { Doorkeeper::AccessToken.count }.by(1)
 
             token = Doorkeeper::AccessToken.first
@@ -120,7 +120,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
           context "when client_secret incorrect" do
             it "doesn't issue new token" do
               expect do
-                post password_token_endpoint_url(
+                post token_endpoint_url, params: password_token_endpoint_params(
                   client_id: @client.uid,
                   client_secret: "foobar",
                   resource_owner: @resource_owner,
@@ -140,7 +140,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
       context "with confidential/private client" do
         it "issues a new token" do
           expect do
-            post password_token_endpoint_url(client: @client, resource_owner: @resource_owner)
+            post token_endpoint_url, params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner)
           end.to change { Doorkeeper::AccessToken.count }.by(1)
 
           token = Doorkeeper::AccessToken.first
@@ -152,7 +152,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
         context "when client_secret absent" do
           it "doesn't issue new token" do
             expect do
-              post password_token_endpoint_url(client_id: @client.uid, resource_owner: @resource_owner)
+              post token_endpoint_url, params: password_token_endpoint_params(client_id: @client.uid, resource_owner: @resource_owner)
             end.not_to(change { Doorkeeper::AccessToken.count })
 
             expect(response.status).to eq(401)
@@ -167,7 +167,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
       it "issues a refresh token if enabled" do
         config_is_set(:refresh_token_enabled, true)
 
-        post password_token_endpoint_url(client: @client, resource_owner: @resource_owner)
+        post token_endpoint_url, params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner)
 
         token = Doorkeeper::AccessToken.first
         expect(json_response).to include("refresh_token" => token.refresh_token)
@@ -178,7 +178,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
 
         client_is_authorized(@client, @resource_owner)
 
-        post password_token_endpoint_url(client: @client, resource_owner: @resource_owner)
+        post token_endpoint_url, params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner)
 
         expect(Doorkeeper::AccessToken.count).to be(1)
         expect(json_response).to include("access_token" => Doorkeeper::AccessToken.first.token)
@@ -191,7 +191,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
 
         it "issues new token" do
           expect do
-            post password_token_endpoint_url(client: @client, resource_owner: @resource_owner, scope: "public")
+            post token_endpoint_url, params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner, scope: "public")
           end.to change { Doorkeeper::AccessToken.count }.by(1)
 
           token = Doorkeeper::AccessToken.first
@@ -214,7 +214,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
 
         it "issues a new token without client credentials" do
           expect do
-            post password_token_endpoint_url(resource_owner: @resource_owner)
+            post token_endpoint_url, params: password_token_endpoint_params(resource_owner: @resource_owner)
           end.to(change { Doorkeeper::AccessToken.count }.by(1))
 
           token = Doorkeeper::AccessToken.first
@@ -223,9 +223,9 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
           expect(json_response).to include("access_token" => token.token)
         end
 
-        it "doesn't issue a new token with invalid client credentials in query string" do
+        it "doesn't issue a new token with invalid client credentials in the request body" do
           expect do
-            post password_token_endpoint_url(
+            post token_endpoint_url, params: password_token_endpoint_params(
               resource_owner: @resource_owner,
               client_id: "invalid",
               client_secret: "invalid",
@@ -243,7 +243,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
           invalid_client = Doorkeeper::OAuth::Client::Credentials.new("invalid", "invalid")
 
           expect do
-            post password_token_endpoint_url(
+            post token_endpoint_url, params: password_token_endpoint_params(
               resource_owner: @resource_owner,
             ), headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(invalid_client) }
           end.not_to(change { Doorkeeper::AccessToken.count })
@@ -264,7 +264,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
 
         it "doesn't issue a new token without client credentials" do
           expect do
-            post password_token_endpoint_url(resource_owner: @resource_owner)
+            post token_endpoint_url, params: password_token_endpoint_params(resource_owner: @resource_owner)
           end.not_to(change { Doorkeeper::AccessToken.count })
 
           expect(response.status).to eq(401)
@@ -284,7 +284,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
 
       it "issues new token without any scope" do
         expect do
-          post password_token_endpoint_url(client: @client, resource_owner: @resource_owner)
+          post token_endpoint_url, params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner)
         end.to change { Doorkeeper::AccessToken.count }.by(1)
 
         token = Doorkeeper::AccessToken.first
@@ -305,7 +305,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
         default_scopes_exist :public, :admin
 
         expect do
-          post password_token_endpoint_url(client: @client, resource_owner: @resource_owner)
+          post token_endpoint_url, params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner)
         end.to change { Doorkeeper::AccessToken.count }.by(1)
 
         token = Doorkeeper::AccessToken.first
@@ -321,7 +321,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
         default_scopes_exist :public, :read, :update
 
         expect do
-          post password_token_endpoint_url(client: @client, resource_owner: @resource_owner)
+          post token_endpoint_url, params: password_token_endpoint_params(client: @client, resource_owner: @resource_owner)
         end.to change { Doorkeeper::AccessToken.count }.by(1)
 
         token = Doorkeeper::AccessToken.first
@@ -337,7 +337,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
     context "with invalid scopes" do
       it "doesn't issue new token" do
         expect do
-          post password_token_endpoint_url(
+          post token_endpoint_url, params: password_token_endpoint_params(
             client: @client,
             resource_owner: @resource_owner,
             scope: "random",
@@ -346,7 +346,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
       end
 
       it "returns invalid_scope error" do
-        post password_token_endpoint_url(
+        post token_endpoint_url, params: password_token_endpoint_params(
           client: @client,
           resource_owner: @resource_owner,
           scope: "random",
@@ -363,7 +363,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
     context "with invalid user credentials" do
       it "doesn't issue new token with bad password" do
         expect do
-          post password_token_endpoint_url(
+          post token_endpoint_url, params: password_token_endpoint_params(
             client: @client,
             resource_owner_username: @resource_owner.name,
             resource_owner_password: "wrongpassword",
@@ -373,7 +373,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
 
       it "doesn't issue new token without credentials" do
         expect do
-          post password_token_endpoint_url(client: @client)
+          post token_endpoint_url, params: password_token_endpoint_params(client: @client)
         end.not_to(change { Doorkeeper::AccessToken.count })
       end
 
@@ -381,13 +381,13 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
         config_is_set(:resource_owner_from_credentials) { false }
 
         expect do
-          post password_token_endpoint_url(client: @client)
+          post token_endpoint_url, params: password_token_endpoint_params(client: @client)
         end.not_to(change { Doorkeeper::AccessToken.count })
 
         config_is_set(:resource_owner_from_credentials) { nil }
 
         expect do
-          post password_token_endpoint_url(client: @client)
+          post token_endpoint_url, params: password_token_endpoint_params(client: @client)
         end.not_to(change { Doorkeeper::AccessToken.count })
       end
     end
@@ -395,7 +395,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
     context "with invalid confidential client credentials" do
       it "doesn't issue new token with bad client credentials" do
         expect do
-          post password_token_endpoint_url(
+          post token_endpoint_url, params: password_token_endpoint_params(
             client_id: @client.uid,
             client_secret: "bad_secret",
             resource_owner: @resource_owner,
@@ -407,7 +407,7 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
     context "with invalid public client id" do
       it "doesn't issue new token with bad client id" do
         expect do
-          post password_token_endpoint_url(client_id: "bad_id", resource_owner: @resource_owner)
+          post token_endpoint_url, params: password_token_endpoint_params(client_id: "bad_id", resource_owner: @resource_owner)
         end.not_to(change { Doorkeeper::AccessToken.count })
       end
     end

--- a/spec/requests/flows/refresh_token_spec.rb
+++ b/spec/requests/flows/refresh_token_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Refresh Token Flow" do
     end
 
     it "client gets the refresh token and refreshes it" do
-      post token_endpoint_url(code: @authorization.token, client: @client)
+      post token_endpoint_url, params: token_endpoint_params(code: @authorization.token, client: @client)
 
       token = Doorkeeper::AccessToken.first
 
@@ -33,7 +33,7 @@ RSpec.describe "Refresh Token Flow" do
 
       expect(@authorization.reload).to be_revoked
 
-      post refresh_token_endpoint_url(client: @client, refresh_token: token.refresh_token)
+      post refresh_token_endpoint_url, params: refresh_token_endpoint_params(client: @client, refresh_token: token.refresh_token)
 
       new_token = Doorkeeper::AccessToken.last
       expect(json_response).to include(
@@ -59,7 +59,7 @@ RSpec.describe "Refresh Token Flow" do
 
     context "when refresh_token revoked on use" do
       it "client requests a token with refresh token" do
-        post refresh_token_endpoint_url(
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
           client: @client, refresh_token: @token.refresh_token,
         )
         expect(json_response).to include(
@@ -70,7 +70,7 @@ RSpec.describe "Refresh Token Flow" do
 
       it "client requests a token with expired access token" do
         @token.update_attribute :expires_in, -100
-        post refresh_token_endpoint_url(
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
           client: @client, refresh_token: @token.refresh_token,
         )
         expect(json_response).to include(
@@ -86,7 +86,7 @@ RSpec.describe "Refresh Token Flow" do
       end
 
       it "client request a token with refresh token" do
-        post refresh_token_endpoint_url(
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
           client: @client, refresh_token: @token.refresh_token,
         )
         expect(json_response).to include(
@@ -97,7 +97,7 @@ RSpec.describe "Refresh Token Flow" do
 
       it "client request a token with expired access token" do
         @token.update_attribute :expires_in, -100
-        post refresh_token_endpoint_url(
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
           client: @client, refresh_token: @token.refresh_token,
         )
         expect(json_response).to include(
@@ -136,7 +136,7 @@ RSpec.describe "Refresh Token Flow" do
       end
 
       it "issues a new token without client_secret when refresh token was issued to a public client" do
-        post refresh_token_endpoint_url(
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
           client_id: public_client.uid,
           refresh_token: token_for_public_client.refresh_token,
         )
@@ -149,13 +149,13 @@ RSpec.describe "Refresh Token Flow" do
       end
 
       it "returns an error without credentials" do
-        post refresh_token_endpoint_url(refresh_token: token_for_private_client.refresh_token)
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(refresh_token: token_for_private_client.refresh_token)
 
         expect(json_response).to include("error" => "invalid_grant")
       end
 
       it "returns an error with wrong credentials" do
-        post refresh_token_endpoint_url(
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
           client_id: "1",
           client_secret: "1",
           refresh_token: token_for_private_client.refresh_token,
@@ -168,7 +168,7 @@ RSpec.describe "Refresh Token Flow" do
     end
 
     it "client gets an error for invalid refresh token" do
-      post refresh_token_endpoint_url(client: @client, refresh_token: "invalid")
+      post refresh_token_endpoint_url, params: refresh_token_endpoint_params(client: @client, refresh_token: "invalid")
 
       expect(json_response).to match(
         "error" => "invalid_grant",
@@ -178,7 +178,7 @@ RSpec.describe "Refresh Token Flow" do
 
     it "client gets an error for revoked access token" do
       @token.revoke
-      post refresh_token_endpoint_url(client: @client, refresh_token: @token.refresh_token)
+      post refresh_token_endpoint_url, params: refresh_token_endpoint_params(client: @client, refresh_token: @token.refresh_token)
 
       expect(json_response).to match(
         "error" => "invalid_grant",
@@ -188,7 +188,7 @@ RSpec.describe "Refresh Token Flow" do
 
     it "second of simultaneous client requests get an error for revoked access token" do
       allow_any_instance_of(Doorkeeper::AccessToken).to receive(:revoked?).and_return(false, true)
-      post refresh_token_endpoint_url(client: @client, refresh_token: @token.refresh_token)
+      post refresh_token_endpoint_url, params: refresh_token_endpoint_params(client: @client, refresh_token: @token.refresh_token)
 
       expect(json_response).to match(
         "error" => "invalid_grant",
@@ -205,7 +205,7 @@ RSpec.describe "Refresh Token Flow" do
         User.authenticate! params[:username], params[:password]
       end
       create_resource_owner
-      _another_token = post password_token_endpoint_url(
+      _another_token = post token_endpoint_url, params: password_token_endpoint_params(
         client: @client, resource_owner: resource_owner,
       )
       last_token.update(created_at: 5.seconds.ago)
@@ -222,7 +222,7 @@ RSpec.describe "Refresh Token Flow" do
 
     context "when refresh_token revoked on use" do
       it "client request a token after creating another token with the same user" do
-        post refresh_token_endpoint_url(
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
           client: @client, refresh_token: @token.refresh_token,
         )
 
@@ -237,7 +237,7 @@ RSpec.describe "Refresh Token Flow" do
       end
 
       it "client request a token after creating another token with the same user" do
-        post refresh_token_endpoint_url(
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
           client: @client, refresh_token: @token.refresh_token,
         )
 
@@ -264,7 +264,7 @@ RSpec.describe "Refresh Token Flow" do
       end
 
       it "copies custom attributes from the previous token into the new token" do
-        post refresh_token_endpoint_url(
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
           client: @client, refresh_token: @token.refresh_token,
         )
 

--- a/spec/support/helpers/request_spec_helper.rb
+++ b/spec/support/helpers/request_spec_helper.rb
@@ -63,7 +63,7 @@ module RequestSpecHelper
   end
 
   def create_access_token(authorization_code, client, code_verifier = nil)
-    page.driver.post token_endpoint_url(code: authorization_code, client: client, code_verifier: code_verifier)
+    page.driver.post token_endpoint_url, token_endpoint_params(code: authorization_code, client: client, code_verifier: code_verifier)
   end
 
   def i_should_see_translated_error_message(key)

--- a/spec/support/helpers/url_helper.rb
+++ b/spec/support/helpers/url_helper.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
 
 module UrlHelper
-  def token_endpoint_url(options = {})
-    parameters = {
+  def token_endpoint_url
+    "/oauth/token"
+  end
+
+  def token_endpoint_params(options = {})
+    {
       code: options[:code],
       client_id: options[:client_id] || options[:client].try(:uid),
       client_secret: options[:client_secret] || options[:client].try(:secret),
       redirect_uri: options[:redirect_uri] || options[:client].try(:redirect_uri),
       grant_type: options[:grant_type] || "authorization_code",
       code_verifier: options[:code_verifier],
-      code_challenge_method: options[:code_challenge_method],
     }.reject { |_, v| v.blank? }
-    "/oauth/token?#{build_query(parameters)}"
   end
 
-  def password_token_endpoint_url(options = {})
-    parameters = {
-      code: options[:code],
+  def password_token_endpoint_params(options = {})
+    {
       client_id: options[:client_id] || options[:client].try(:uid),
       client_secret: options[:client_secret] || options[:client].try(:secret),
       username: options[:resource_owner_username] || options[:resource_owner].try(:name),
@@ -24,7 +25,6 @@ module UrlHelper
       scope: options[:scope],
       grant_type: "password",
     }.reject { |_, v| v.blank? }
-    "/oauth/token?#{build_query(parameters)}"
   end
 
   def authorization_endpoint_url(options = {})
@@ -41,14 +41,17 @@ module UrlHelper
     "/oauth/authorize?#{build_query(parameters)}"
   end
 
-  def refresh_token_endpoint_url(options = {})
-    parameters = {
+  def refresh_token_endpoint_url
+    "/oauth/token"
+  end
+
+  def refresh_token_endpoint_params(options = {})
+    {
       refresh_token: options[:refresh_token],
       client_id: options[:client_id] || options[:client].try(:uid),
       client_secret: options[:client_secret] || options[:client].try(:secret),
       grant_type: options[:grant_type] || "refresh_token",
     }.reject { |_, v| v.blank? }
-    "/oauth/token?#{build_query(parameters)}"
   end
 
   def revocation_token_endpoint_url


### PR DESCRIPTION
## Summary

This is part of the work to take over #1772 from @ThisIsMissEm, split into reviewable pieces. This PR is the first step (test-only, no functional change) and can be merged independently.

> [!NOTE]
> Based on test changes originally authored by @ThisIsMissEm in #1772, cleaned up and extracted as a standalone PR.

The token endpoint specs were passing client credentials (including `client_secret`) through the query string. RFC 6749 §2.3.1 explicitly requires that client credentials in the request body "MUST NOT be included in the request URI." This PR moves them to the request body where they belong.

## What changed

The `url_helper.rb` test helpers are refactored into two parts:

- `token_endpoint_url` / `refresh_token_endpoint_url` — now return just the path (`/oauth/token`)
- `token_endpoint_params(options)` / `refresh_token_endpoint_params(options)` / `password_token_endpoint_params(options)` — build the params hash separately

All flow specs (`authorization_code`, `client_credentials`, `password`, `refresh_token`) and the token endpoint spec are updated to use `post url, params: params` instead of encoding credentials in the URL.

## Why split this out

This is the largest chunk of the #1772 diff by line count, but it's entirely mechanical and involves no functional change. Extracting it keeps the subsequent registry PR focused on the actual design.