### PR TITLE
Force PKCE for all clients, including confidential ones (RFC 9700)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#1839] Send client credentials in the request body (not the query string) in the token endpoint specs, per RFC 6749 §2.3.1. Test-only change: the `*_endpoint_url` helpers now return a path plus a matching `*_endpoint_params` builder so flow specs post credentials through the body.
+- [#1842] **[BREAKING]** `force_pkce` now requires PKCE for all clients, including confidential ones, in line with the OAuth 2.0 Security BCP (RFC 9700) and OAuth 2.1. Previously confidential clients were exempt. If you enable `force_pkce` and have confidential clients that do not yet send a `code_challenge`/`code_verifier`, their authorization requests will start to be rejected.
 - Please add here
 
 ## 5.9.3

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -64,7 +64,7 @@ module Doorkeeper
         @missing_param =
           if grant&.uses_pkce? && code_verifier.blank?
             :code_verifier
-          elsif client && !client.confidential && Doorkeeper.config.force_pkce? && code_verifier.blank?
+          elsif client && Doorkeeper.config.force_pkce? && code_verifier.blank?
             :code_verifier
           elsif redirect_uri.blank?
             :redirect_uri

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -147,7 +147,6 @@ module Doorkeeper
 
       def validate_code_challenge
         return true unless Doorkeeper.config.force_pkce?
-        return true if client.confidential
         return true if code_challenge.present?
 
         @invalid_request_reason = :invalid_code_challenge

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -188,8 +188,8 @@ Doorkeeper.configure do
   #
   # revoke_previous_authorization_code_token
 
-  # Require non-confidential clients to use PKCE when using an authorization code
-  # to obtain an access_token (disabled by default)
+  # Require all clients (including confidential ones) to use PKCE when using an
+  # authorization code to obtain an access_token (disabled by default)
   #
   # force_pkce
 

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -176,10 +176,15 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
       end
 
       context "when the app is confidential" do
-        it "issues a new token for the client" do
+        it "does not issue a token" do
           expect do
             request.authorize
-          end.to change { client.reload.access_tokens.count }.by(1)
+          end.not_to change { client.reload.access_tokens.count }
+        end
+
+        it "responds with invalid_request for the missing code_verifier" do
+          request.validate
+          expect(request.error).to eq(Doorkeeper::Errors::InvalidRequest)
         end
       end
 

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -403,10 +403,11 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
           application.update(confidential: true)
         end
 
-        it "accepts a blank code_challenge" do
+        it "does not accept a blank code_challenge" do
           attributes[:code_challenge] = " "
 
-          expect(pre_auth).to be_authorizable
+          expect(pre_auth).not_to be_authorizable
+          expect(pre_auth.error_response.description).to eq(translated_invalid_request_error_message(:invalid_code_challenge, nil))
         end
 
         it "accepts a code challenge" do


### PR DESCRIPTION
## Summary

This continues @ThisIsMissEm's work in #1773. It **supersedes #1773**. Closes #1654.

> [!NOTE]
> Based on @ThisIsMissEm's change in #1773, with a fix to preserve the #1762 error-handling behaviour for missing clients.

When `force_pkce` is enabled, confidential clients were previously exempt from the PKCE requirement. This PR removes that exemption so that **all** clients — public and confidential — must use PKCE, in line with the [OAuth 2.0 Security BCP (RFC 9700)](https://www.rfc-editor.org/rfc/rfc9700) and the upcoming OAuth 2.1 specification.

## What changed

- `pre_authorization.rb` — removed `return true if client.confidential` from `validate_code_challenge`, so the authorize endpoint requires `code_challenge` from all clients.
- `authorization_code_request.rb` — removed the `!client.confidential` condition from the `force_pkce` check at the token endpoint.

## Difference from #1773

The original PR removed the `client &&` guard along with `!client.confidential`, which caused a regression: when the client is missing (`nil`), the request would return `InvalidRequest` (missing `code_verifier`) instead of the correct `InvalidClient`. This was fixed by #1762 and must not be regressed.

This PR keeps `client &&` intact — only `!client.confidential` is removed:

```ruby
# Before
elsif client && !client.confidential && Doorkeeper.config.force_pkce? && code_verifier.blank?

# This PR
elsif client && Doorkeeper.config.force_pkce? && code_verifier.blank?
```

The existing "missing app → InvalidClient" test passes without modification, confirming no regression.

## Breaking change

If you enable `force_pkce` and have confidential clients that do not yet send `code_challenge`/`code_verifier`, their authorization requests will start to be rejected. This aligns with RFC 9700's recommendation that PKCE should be required for all clients.