### PR TITLE
Skip changelog enforcement for dependency update PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,4 +32,5 @@ jobs:
           steps.changes.outputs.gem_changes == 'true'
         uses: dangoslen/changelog-enforcer@v3
         with:
-            changeLogPath: CHANGELOG.md
+          changeLogPath: CHANGELOG.md
+          skipLabels: "dependencies"


### PR DESCRIPTION
### Summary

The changelog enforcer workflow already filters by changed paths, but Dependabot PRs that update `Gemfile` still trigger the check and fail because they don't (and shouldn't) include a CHANGELOG entry.

Add `skipLabels: "dependencies"` to the `changelog-enforcer` step so that PRs labeled `dependencies` (automatically applied by Dependabot) skip the check. The workflow already listens to `labeled`/`unlabeled` activity types, so this works out of the box.

### Other Information

CI on #1843 will pass after merging this PR.