### PR TITLE
Pin ignored scope parameter on authorization_code token requests (RFC 6749 §4.1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ User-visible changes worth mentioning.
   - See the [Upgrade Guide](https://github.com/doorkeeper-gem/doorkeeper/wiki/Migration-from-old-versions) for detailed breaking changes, deprecations and migration steps.
 - [#1842] **[BREAKING]** `force_pkce` now requires PKCE for all clients, including confidential ones, in line with the OAuth 2.0 Security BCP (RFC 9700) and OAuth 2.1. Previously confidential clients were exempt. If you enable `force_pkce` and have confidential clients that do not yet send a `code_challenge`/`code_verifier`, their authorization requests will start to be rejected.
 - [#1845] Fix `NameError` when the config option DSL (`Doorkeeper::Config::Option`) is extended into a class that does not define `self.builder_class`. The guard raised `Doorkeeper::MissingConfigurationBuilderClass`, a constant that was never defined, so callers saw `uninitialized constant` instead of the intended message. The error is now defined as `Doorkeeper::Errors::MissingConfigurationBuilderClass` (a `DoorkeeperError`) and referenced correctly.
+- [#1846] Document and pin with regression specs that a `scope` parameter sent to the token endpoint is ignored for the `authorization_code` grant (RFC 6749 §4.1.3 does not define one): the access token always inherits the scopes of the authorization grant, and the response reports the actual granted `scope`. No behavior change.
 - Please add here
 
 ## 5.9.3

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -13,6 +13,9 @@ module Doorkeeper
       attr_reader :grant, :client, :redirect_uri, :access_token, :code_verifier,
                   :invalid_request_reason, :missing_param
 
+      # A scope parameter is deliberately not read here: RFC 6749 does not
+      # define one for the authorization_code token request (§4.1.3), so it
+      # is ignored and the access token inherits the scopes of the grant.
       def initialize(server, grant, client, parameters = {})
         super()
         @server = server

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -150,6 +150,51 @@ feature "Authorization Code Flow" do
     )
   end
 
+  # RFC 6749 does not define a scope parameter for the authorization_code
+  # token request (§4.1.3): access token scopes always come from the
+  # authorization grant, and a scope parameter sent to the token endpoint
+  # is ignored (see issue #1765).
+  context "when a scope parameter is sent to the token endpoint" do
+    background do
+      optional_scopes_exist :write
+      @client.update(scopes: "default write")
+    end
+
+    scenario "the token is issued with the grant's scopes, not the requested ones" do
+      visit authorization_endpoint_url(client: @client, scope: "default")
+      click_on "Authorize"
+
+      authorization_code = Doorkeeper::AccessGrant.first.token
+      page.driver.post token_endpoint_url, token_endpoint_params(
+        code: authorization_code,
+        client: @client,
+        scope: "write",
+      )
+
+      access_token_should_exist_for(@client, @resource_owner)
+
+      expect(Doorkeeper::AccessToken.first.scopes.to_s).to eq("default")
+      expect(json_response.fetch("scope")).to eq("default")
+    end
+
+    scenario "an unknown scope value is ignored as well" do
+      visit authorization_endpoint_url(client: @client, scope: "default")
+      click_on "Authorize"
+
+      authorization_code = Doorkeeper::AccessGrant.first.token
+      page.driver.post token_endpoint_url, token_endpoint_params(
+        code: authorization_code,
+        client: @client,
+        scope: "admin",
+      )
+
+      access_token_should_exist_for(@client, @resource_owner)
+
+      expect(Doorkeeper::AccessToken.first.scopes.to_s).to eq("default")
+      expect(json_response.fetch("scope")).to eq("default")
+    end
+  end
+
   scenario "resource owner requests an access token with authorization code but without secret" do
     visit authorization_endpoint_url(client: @client)
     click_on "Authorize"


### PR DESCRIPTION
## Summary of changes

Resolves #1765, which asked whether the token endpoint accepting a `scope` parameter for the `authorization_code` grant "may be a bug, or be having unintended side-effects".

**Investigation result: Doorkeeper already behaves correctly — this is a test-only change pinning that behavior.**

- `AuthorizationCodeRequest` never reads `parameters[:scope]`; the access token is always created with `grant.scopes`, so a `scope` sent at code-exchange time (whether a valid client scope or an unknown value) has no effect on the issued token. Silently ignoring parameters not defined for the request is the standard RFC 6749 server behavior.
- Only the `client_credentials`, `password` and `refresh_token` strategies read `parameters[:scope]` — exactly the grant types where RFC 6749 defines the parameter (§4.4.2, §4.3.2, §6). The `refresh_token` strategy additionally rejects scopes not contained in the original token, per §6.
- The token response always reports the actual granted `scope`, satisfying §5.1 (scope is REQUIRED in the response when it differs from the one the client requested).

### What changed

- Regression specs in `spec/requests/flows/authorization_code_spec.rb`: exchanging a code with `scope=write` (a valid client scope broader than the grant) or `scope=admin` (unknown) issues a token with the grant's scopes only, and the response advertises the actual scope. Any future change that starts honoring the parameter will trip these tests.
- A comment in `AuthorizationCodeRequest` documenting that not reading `scope` is deliberate.
- CHANGELOG entry (no behavior change).

Rejecting the parameter outright was considered and not pursued: RFC 6749 does not require it, and it would break existing clients (e.g. those following the Mastodon documentation referenced in the issue, which sends `scope` at the token endpoint).