### PR TITLE
Fix metadata endpoint 500 with custom controllers outside the doorkeeper namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ User-visible changes worth mentioning.
 - [#1851] Fix duplicate query parameter in the authorization callback when a client's registered `redirect_uri` already contains a parameter with the same name as a response parameter (e.g. `state`). The redirect query was merged with string keys on one side and symbol keys on the other, so a collision emitted the parameter twice (`?state=fixed&code=...&state=user`); the response parameter now overrides the registered one and appears exactly once.
 - [#1852] Fix the `pkce_code_challenge_methods` config validator using line anchors (`^`/`$`) instead of string anchors (`\A`/`\z`), so a multi-line value such as `"plain\ngarbage"` passed validation and was retained as a (never-matching) challenge method instead of being rejected and reset to the default.
 - [#1853] Fix `reuse_access_token` reusing a token that was created with `custom_access_token_attributes` values when the new request doesn't specify any custom attributes. Such requests now only match tokens without custom attributes.
+- [#1854] Fix the RFC 8414 metadata endpoint raising `ActionController::UrlGenerationError` (HTTP 500) when `use_doorkeeper` configures a custom controller whose namespace depth differs from `doorkeeper/metadata` (e.g. `controllers tokens: "custom_tokens"`).
 - Please add here
 
 ## 5.9.3

--- a/lib/doorkeeper/oauth/metadata_response.rb
+++ b/lib/doorkeeper/oauth/metadata_response.rb
@@ -74,7 +74,12 @@ module Doorkeeper
         mapping = Doorkeeper::Rails::Routes.mapping[group]
         return unless mapping
 
-        url_for(controller: mapping[:controllers], action: action)
+        # The leading slash anchors the controller name: without it, Rails
+        # resolves the name relative to the current (doorkeeper/metadata)
+        # namespace whenever their segment depths differ, e.g. a configured
+        # `controllers tokens: "custom_tokens"` would be looked up as
+        # "doorkeeper/custom_tokens" and raise ActionController::UrlGenerationError.
+        url_for(controller: "/#{mapping[:controllers]}", action: action)
       end
 
       def custom_metadata

--- a/spec/requests/endpoints/metadata_spec.rb
+++ b/spec/requests/endpoints/metadata_spec.rb
@@ -189,6 +189,51 @@ RSpec.describe "Authorization Server Metadata endpoint" do
     end
   end
 
+  context "with a custom tokens controller outside the doorkeeper namespace" do
+    # Regression: endpoint_for passed the configured controller name to url_for
+    # unanchored, so Rails resolved it relative to the current
+    # (doorkeeper/metadata) namespace whenever their segment depths differed —
+    # `controllers tokens: "custom_tokens"` was looked up as
+    # "doorkeeper/custom_tokens" and raised ActionController::UrlGenerationError.
+    #
+    # The routes must be redrawn per example (not in before(:all)): route
+    # drawing consults Doorkeeper.config (e.g. allow_token_introspection gates
+    # the introspect route), and before(:all) runs before the global config
+    # reset hook, so it would draw against whatever config the previous example
+    # happened to leave behind.
+    before do
+      @original_disable_clear_and_finalize = Rails.application.routes.disable_clear_and_finalize
+      Rails.application.routes.disable_clear_and_finalize = false
+      Rails.application.routes.draw do
+        use_doorkeeper do
+          controllers tokens: "custom_tokens"
+        end
+      end
+    end
+
+    # The flag must be restored only after the dummy routes are reloaded: if
+    # the captured value is true, restoring it first would make the reload
+    # skip clear!/finalize! and leave the routes unusable for later specs.
+    after do
+      Rails.application.routes.clear!
+
+      load File.expand_path("../../dummy/config/routes.rb", __dir__)
+
+      Rails.application.routes.disable_clear_and_finalize = @original_disable_clear_and_finalize
+    end
+
+    it "advertises the custom controller's endpoints" do
+      get "/.well-known/oauth-authorization-server"
+
+      response_status_should_be(200)
+
+      expect(json_response["authorization_endpoint"]).to eq("http://www.example.com/oauth/authorize")
+      expect(json_response["token_endpoint"]).to eq("http://www.example.com/oauth/token")
+      expect(json_response["revocation_endpoint"]).to eq("http://www.example.com/oauth/revoke")
+      expect(json_response["introspection_endpoint"]).to eq("http://www.example.com/oauth/introspect")
+    end
+  end
+
   context "with custom metadata attributes" do
     before do
       config_is_set(

--- a/spec/routing/custom_controller_routes_spec.rb
+++ b/spec/routing/custom_controller_routes_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Custom controller for routes" do
       orm DOORKEEPER_ORM
     end
 
+    @original_disable_clear_and_finalize = Rails.application.routes.disable_clear_and_finalize
     Rails.application.routes.disable_clear_and_finalize = true
 
     Rails.application.routes.draw do
@@ -56,7 +57,12 @@ RSpec.describe "Custom controller for routes" do
     end
   end
 
+  # The flag is restored before the dummy routes are reloaded so that the
+  # reload runs with the original (normally false) value and finalizes the
+  # route set again.
   after :all do
+    Rails.application.routes.disable_clear_and_finalize = @original_disable_clear_and_finalize
+
     Rails.application.routes.clear!
 
     load File.expand_path("../dummy/config/routes.rb", __dir__)

--- a/spec/routing/scoped_routes_spec.rb
+++ b/spec/routing/scoped_routes_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Scoped routes" do
       allow_token_introspection false
     end
 
+    @original_disable_clear_and_finalize = Rails.application.routes.disable_clear_and_finalize
     Rails.application.routes.disable_clear_and_finalize = true
 
     Rails.application.routes.draw do
@@ -16,7 +17,12 @@ RSpec.describe "Scoped routes" do
     end
   end
 
+  # The flag is restored before the dummy routes are reloaded so that the
+  # reload runs with the original (normally false) value and finalizes the
+  # route set again.
   after :all do
+    Rails.application.routes.disable_clear_and_finalize = @original_disable_clear_and_finalize
+
     Rails.application.routes.clear!
 
     load File.expand_path("../dummy/config/routes.rb", __dir__)


### PR DESCRIPTION
## Summary

The RFC 8414 metadata endpoint added in #1838 raises `ActionController::UrlGenerationError` (HTTP 500) for any application that customizes a controller through `use_doorkeeper` with a name whose namespace depth differs from `doorkeeper/metadata`:

```ruby
Rails.application.routes.draw do
  use_doorkeeper do
    controllers tokens: "custom_tokens"
  end
end
GET /.well-known/oauth-authorization-server
=> ActionController::UrlGenerationError:
   No route matches {action: "create", controller: "doorkeeper/custom_tokens"}
```

## Root cause

`MetadataResponse#endpoint_for` passes the routes mapping's controller name to `url_for` unanchored. Rails' URL generation (`use_relative_controller!`, present since Rails 3) resolves an unanchored controller **relative to the current controller's namespace** whenever the target has fewer path segments. Since the document is served from `doorkeeper/metadata` (2 segments), a top-level custom controller like `custom_tokens` (1 segment) is rewritten to `doorkeeper/custom_tokens`, which has no route. The inverse also holds: a metadata controller nested deeper than the defaults (e.g. `metadata: "admin/oauth/metadata"`) breaks URL generation for every other endpoint.

The existing specs never hit this because `custom_controller_routes_spec.rb` gives all controllers (including metadata) names of the same depth, and only asserts route recognition — the metadata response body is never rendered there.

## Fix

Prefix the controller name with a slash. The leading slash disables Rails' relative controller resolution and is stripped back out during generation, so default configurations are unaffected:

```ruby
url_for(controller: "/#{mapping[:controllers]}", action: action)
```