### PR TITLE
Backport #1853: Fix token reuse ignoring custom attributes when the request has none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-visible changes worth mentioning.
 
 - Please add here
 
+## 5.9.4
+
+- [#1853] Fix `reuse_access_token` reusing a token that was created with `custom_access_token_attributes` values when the new request doesn't specify any custom attributes. Such requests now only match tokens without custom attributes.
+
 ## 5.9.3
 
 - [#1834] Fix default `allow_token_introspection` returning `false` when a custom `application_class` is configured. The default proc compared application objects with `==`, which fails when the authorized client and the introspected token's application are resolved as different classes (e.g. a base `Doorkeeper::Application` vs. a configured subclass) even though they reference the same record. It now compares application ids instead.

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -89,7 +89,8 @@ module Doorkeeper
       # @param custom_attributes [Nilable Hash]
       #   A nil value, or hash with keys corresponding to the custom attributes
       #   configured with the `custom_access_token_attributes` config option.
-      #   A nil value will ignore custom attributes.
+      #   A nil value will ignore custom attributes, while an empty hash will
+      #   only match tokens that have no custom attributes set.
       #
       # @return [Doorkeeper::AccessToken, nil] Access Token instance or
       #   nil if matching record was not found
@@ -124,7 +125,8 @@ module Doorkeeper
       # @param custom_attributes [Nilable Hash]
       #   A nil value, or hash with keys corresponding to the custom attributes
       #   configured with the `custom_access_token_attributes` config option.
-      #   A nil value will ignore custom attributes.
+      #   A nil value will ignore custom attributes, while an empty hash will
+      #   only match tokens that have no custom attributes set.
       #
       # @return [Doorkeeper::AccessToken, nil] Access Token instance or
       #   nil if matching record was not found
@@ -220,7 +222,10 @@ module Doorkeeper
         scopes = Doorkeeper::OAuth::Scopes.from_string(scopes) if scopes.is_a?(String)
 
         if Doorkeeper.config.reuse_access_token
-          custom_attributes = extract_custom_attributes(token_attributes).presence
+          # An empty hash must stay distinct from nil here: nil ignores custom
+          # attributes when matching, while an empty hash only matches tokens
+          # that have no custom attributes set.
+          custom_attributes = extract_custom_attributes(token_attributes)
           access_token = matching_token_for(
             application, resource_owner, scopes, custom_attributes: custom_attributes, include_expired: false,
           )

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -45,8 +45,11 @@ module Doorkeeper
         end
 
         def find_active_existing_token_for(client, scopes, attributes)
+          # An empty hash must stay distinct from nil here: nil ignores custom
+          # attributes when matching, while an empty hash only matches tokens
+          # that have no custom attributes set.
           custom_attributes = Doorkeeper.config.access_token_model
-            .extract_custom_attributes(attributes).presence
+            .extract_custom_attributes(attributes)
           Doorkeeper.config.access_token_model.matching_token_for(
             client, nil, scopes, custom_attributes: custom_attributes, include_expired: false,
           )

--- a/spec/lib/oauth/client_credentials/creator_spec.rb
+++ b/spec/lib/oauth/client_credentials/creator_spec.rb
@@ -86,6 +86,40 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Creator do
         expect(result).not_to eq(existing_token)
       end
     end
+
+    context "when custom access token attributes are used" do
+      before do
+        allow(Doorkeeper.config).to receive(:custom_access_token_attributes).and_return([:tenant_name])
+      end
+
+      it "does not return an existing token with custom attributes when the request has none" do
+        existing_token = creator.call(client, scopes, tenant_name: "Me")
+
+        result = creator.call(client, scopes)
+
+        expect(Doorkeeper::AccessToken.count).to eq(2)
+        expect(result).not_to eq(existing_token)
+        expect(result.custom_attributes[:tenant_name]).to be_nil
+      end
+
+      it "returns an existing token when the custom attributes match" do
+        existing_token = creator.call(client, scopes, tenant_name: "Me")
+
+        result = creator.call(client, scopes, tenant_name: "Me")
+
+        expect(Doorkeeper::AccessToken.count).to eq(1)
+        expect(result).to eq(existing_token)
+      end
+
+      it "returns an existing token without custom attributes when the request has none" do
+        existing_token = creator.call(client, scopes)
+
+        result = creator.call(client, scopes)
+
+        expect(Doorkeeper::AccessToken.count).to eq(1)
+        expect(result).to eq(existing_token)
+      end
+    end
   end
 
   context "when reuse_access_token is false" do

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -665,6 +665,107 @@ RSpec.describe Doorkeeper::AccessToken do
         last_token = described_class.matching_token_for(application, resource_owner, scopes, custom_attributes: nil)
         expect(last_token).to eq(token)
       end
+
+      it "does not return a token with custom attributes if an empty hash is passed" do
+        FactoryBot.create :access_token, default_attributes.merge(custom_attributes)
+        last_token = described_class.matching_token_for(application, resource_owner, scopes, custom_attributes: {})
+        expect(last_token).to be_nil
+      end
+
+      it "returns a token without custom attributes if an empty hash is passed" do
+        token = FactoryBot.create :access_token, default_attributes
+        last_token = described_class.matching_token_for(application, resource_owner, scopes, custom_attributes: {})
+        expect(last_token).to eq(token)
+      end
+    end
+  end
+
+  describe ".find_or_create_for" do
+    let(:resource_owner)    { FactoryBot.create :resource_owner }
+    let(:application)       { FactoryBot.create :application }
+    let(:scopes) { Doorkeeper::OAuth::Scopes.from_string("public write") }
+
+    context "when reuse_access_token is enabled and custom access token attributes are used" do
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          reuse_access_token
+          custom_access_token_attributes [:tenant_name]
+        end
+        default_scopes_exist(*scopes.all)
+      end
+
+      let!(:tenant_token) do
+        described_class.find_or_create_for(
+          application: application,
+          resource_owner: resource_owner,
+          scopes: scopes,
+          expires_in: 2.hours,
+          use_refresh_token: false,
+          tenant_name: "Me",
+        )
+      end
+
+      it "does not reuse a token that has custom attributes when the request has none" do
+        token = described_class.find_or_create_for(
+          application: application,
+          resource_owner: resource_owner,
+          scopes: scopes,
+          expires_in: 2.hours,
+          use_refresh_token: false,
+        )
+
+        expect(token).not_to eq(tenant_token)
+        expect(token.custom_attributes[:tenant_name]).to be_nil
+      end
+
+      it "reuses a token when the custom attributes match" do
+        token = described_class.find_or_create_for(
+          application: application,
+          resource_owner: resource_owner,
+          scopes: scopes,
+          expires_in: 2.hours,
+          use_refresh_token: false,
+          tenant_name: "Me",
+        )
+
+        expect(token).to eq(tenant_token)
+      end
+
+      it "reuses a token without custom attributes when the request has none" do
+        plain_token = described_class.find_or_create_for(
+          application: application,
+          resource_owner: resource_owner,
+          scopes: scopes,
+          expires_in: 2.hours,
+          use_refresh_token: false,
+        )
+
+        token = described_class.find_or_create_for(
+          application: application,
+          resource_owner: resource_owner,
+          scopes: scopes,
+          expires_in: 2.hours,
+          use_refresh_token: false,
+        )
+
+        expect(token).to eq(plain_token)
+        expect(token).not_to eq(tenant_token)
+      end
+
+      it "does not reuse a token when the request has different custom attributes" do
+        token = described_class.find_or_create_for(
+          application: application,
+          resource_owner: resource_owner,
+          scopes: scopes,
+          expires_in: 2.hours,
+          use_refresh_token: false,
+          tenant_name: "Other",
+        )
+
+        expect(token).not_to eq(tenant_token)
+        expect(token.custom_attributes[:tenant_name]).to eq("Other")
+      end
     end
   end
 


### PR DESCRIPTION
>[!NOTE]
>
> Cherry-pick of #1853 for the `v5.9-stable` branch.
> 
> See #1853 for full details and discussion.