### PR TITLE
Add regression specs for `+`-separated scopes on token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ User-visible changes worth mentioning.
 - [#1853] Fix `reuse_access_token` reusing a token that was created with `custom_access_token_attributes` values when the new request doesn't specify any custom attributes. Such requests now only match tokens without custom attributes.
 - [#1854] Fix the RFC 8414 metadata endpoint raising `ActionController::UrlGenerationError` (HTTP 500) when `use_doorkeeper` configures a custom controller whose namespace depth differs from `doorkeeper/metadata` (e.g. `controllers tokens: "custom_tokens"`).
 - [#1855] Perform the fallback secret upgrade-on-access write (plain → hashed token or application secret) through the primary database role, so `enable_multiple_database_roles` setups no longer attempt the write on a read replica when the lookup happens in a request routed to the reading role.
+- [#1857] Pin with regression specs that a `+` between scopes in a form-encoded token request is decoded as a space (so `scope=public+write` refreshes fine), while a percent-encoded literal `+` (`%2B`) names a single scope and is rejected when unknown, per RFC 6749 §3.3. Test-only change, closes [#1686].
 - Please add here
 
 ## 5.9.3

--- a/spec/requests/flows/refresh_token_spec.rb
+++ b/spec/requests/flows/refresh_token_spec.rb
@@ -197,6 +197,54 @@ RSpec.describe "Refresh Token Flow" do
     end
   end
 
+  # Regression specs for https://github.com/doorkeeper-gem/doorkeeper/issues/1686
+  #
+  # In `application/x-www-form-urlencoded` payloads (and query strings) a "+"
+  # is the encoding of a space, so Rack turns `scope=public+write` into the
+  # space-delimited scope list "public write" before Doorkeeper sees it. A
+  # literal "+" inside a scope value has to be sent percent-encoded as %2B and
+  # names a different, single scope (RFC 6749 §3.3 allows "+" in scope tokens).
+  describe "refreshing the token with '+' in the scope parameter" do
+    before do
+      @token = FactoryBot.create(
+        :access_token,
+        application: @client,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        use_refresh_token: true,
+        scopes: "public write",
+      )
+    end
+
+    it "treats '+' between scopes as an encoded space" do
+      post refresh_token_endpoint_url,
+           params: raw_form_refresh_params(scope: "public+write"),
+           headers: { "CONTENT_TYPE" => "application/x-www-form-urlencoded" }
+
+      new_token = Doorkeeper::AccessToken.last
+      expect(json_response).to include(
+        "access_token" => new_token.token,
+        "scope" => "public write",
+      )
+    end
+
+    it "treats a percent-encoded '+' as part of a single scope name and rejects it when unknown" do
+      post refresh_token_endpoint_url,
+           params: raw_form_refresh_params(scope: "public%2Bwrite"),
+           headers: { "CONTENT_TYPE" => "application/x-www-form-urlencoded" }
+
+      expect(json_response).to include("error" => "invalid_scope")
+    end
+
+    def raw_form_refresh_params(scope:)
+      "grant_type=refresh_token" \
+        "&client_id=#{CGI.escape(@client.uid)}" \
+        "&client_secret=#{CGI.escape(@client.secret)}" \
+        "&refresh_token=#{CGI.escape(@token.refresh_token)}" \
+        "&scope=#{scope}"
+    end
+  end
+
   context "when refreshing the token with multiple sessions (devices)" do
     before do
       # enable password auth to simulate other devices


### PR DESCRIPTION
Closes #1686.

The issue reported that refreshing a token with scopes separated by `+` (`scope=public+write`) returns `invalid_scope`, while the same format works when issuing a token — an apparent inconsistency.

There is no inconsistency: in `application/x-www-form-urlencoded` payloads (and query strings) `+` is the standard encoding of a space, so Rack decodes `scope=public+write` into the space-delimited scope list `public write` before Doorkeeper ever sees it. A *literal* `+` must be percent-encoded as `%2B`, and then it names a single scope token — `+` is a valid scope character per [RFC 6749 §3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3) — which is correctly rejected when the server doesn't define such a scope.

The original report (doorkeeper 4.2.6 / Rails 5.2) most likely hit a client that percent-encoded the `+`, or a scope that wasn't a subset of the refresh token's scopes.