### PR TITLE
[test] Add regression specs for revoking refresh tokens of expired access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ User-visible changes worth mentioning.
 - [#1854] Fix the RFC 8414 metadata endpoint raising `ActionController::UrlGenerationError` (HTTP 500) when `use_doorkeeper` configures a custom controller whose namespace depth differs from `doorkeeper/metadata` (e.g. `controllers tokens: "custom_tokens"`).
 - [#1855] Perform the fallback secret upgrade-on-access write (plain → hashed token or application secret) through the primary database role, so `enable_multiple_database_roles` setups no longer attempt the write on a read replica when the lookup happens in a request routed to the reading role.
 - [#1857] Pin with regression specs that a `+` between scopes in a form-encoded token request is decoded as a space (so `scope=public+write` refreshes fine), while a percent-encoded literal `+` (`%2B`) names a single scope and is rejected when unknown, per RFC 6749 §3.3. Test-only change, closes [#1686].
+- [#1859] Pin with regression specs that a refresh token bound to an expired access token can be revoked (fixed by [#1744]) and that the revoked refresh token is rejected at the token endpoint afterwards. Test-only change, closes [#1671].
 - Please add here
 
 ## 5.9.3

--- a/spec/requests/flows/revoke_token_spec.rb
+++ b/spec/requests/flows/revoke_token_spec.rb
@@ -281,6 +281,62 @@ RSpec.describe "Revoke Token Flow" do
     end
   end
 
+  # Regression specs for https://github.com/doorkeeper-gem/doorkeeper/issues/1671,
+  # fixed by #1744: revoking a refresh token must work even after the access
+  # token it is bound to has expired.
+  context "with a refresh token bound to an expired access token" do
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        use_refresh_token
+      end
+    end
+
+    let(:access_token) do
+      FactoryBot.create(
+        :access_token,
+        application: public_client_application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        use_refresh_token: true,
+      ).tap do |token|
+        token.update!(created_at: token.created_at - token.expires_in - 1)
+      end
+    end
+
+    it "revokes the refresh token" do
+      post revocation_token_endpoint_url,
+           params: {
+             client_id: public_client_application.uid,
+             token: access_token.refresh_token,
+             token_type_hint: "refresh_token",
+           }
+
+      expect(response).to be_successful
+      expect(access_token.reload).to be_revoked
+    end
+
+    it "rejects a refresh attempt made with the revoked refresh token" do
+      post revocation_token_endpoint_url,
+           params: {
+             client_id: public_client_application.uid,
+             token: access_token.refresh_token,
+             token_type_hint: "refresh_token",
+           }
+
+      expect(response).to be_successful
+
+      post refresh_token_endpoint_url,
+           params: refresh_token_endpoint_params(
+             client_id: public_client_application.uid,
+             refresh_token: access_token.refresh_token,
+           )
+
+      expect(response).to have_http_status(:bad_request)
+      expect(json_response).to include("error" => "invalid_grant")
+    end
+  end
+
   context "without client authentication, when skip_client_authentication_for_password_grant is false (the default)" do
     before do
       Doorkeeper.configure do


### PR DESCRIPTION
## Summary

Issue #1671 reported that a refresh token bound to an already-expired access token could not be revoked: `POST /oauth/revoke` returned 200 OK, but the refresh token remained usable at the token endpoint. This was fixed in v5.8.1 by #1744, which routes refresh-token revocations through `Doorkeeper::RevocableTokens::RevocableRefreshToken`, whose `revocable?` only checks the revoked flag and no longer depends on the paired access token being unexpired.

The fix landed without a request-level regression spec covering the reporter's exact scenario, so this PR pins it end to end:

- A public client revokes the refresh token of an expired access token via `POST /oauth/revoke` with `token_type_hint=refresh_token` → 200, and the token is actually revoked.
- A subsequent `grant_type=refresh_token` request with the revoked refresh token is rejected with `invalid_grant`.

The second example is the part of the original report that had no coverage at all: `spec/controllers/tokens_controller_spec.rb` already asserts the revoked flag, but nothing verified that the revoked refresh token is rejected by the token endpoint afterwards.

Test-only change, no behavior change.

## Note

The second concern raised in the issue thread (introspecting a refresh token bound to an expired access token responds with `active: false` even though the token is still usable) is a separate, still-unfixed problem, now split out into #1858.

Closes #1671