### PR TITLE
Fix introspection of refresh tokens bound to expired access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ User-visible changes worth mentioning.
 - [#1855] Perform the fallback secret upgrade-on-access write (plain → hashed token or application secret) through the primary database role, so `enable_multiple_database_roles` setups no longer attempt the write on a read replica when the lookup happens in a request routed to the reading role.
 - [#1857] Pin with regression specs that a `+` between scopes in a form-encoded token request is decoded as a space (so `scope=public+write` refreshes fine), while a percent-encoded literal `+` (`%2B`) names a single scope and is rejected when unknown, per RFC 6749 §3.3. Test-only change, closes [#1686].
 - [#1859] Pin with regression specs that a refresh token bound to an expired access token can be revoked (fixed by [#1744]) and that the revoked refresh token is rejected at the token endpoint afterwards. Test-only change, closes [#1671].
+- [#1860] Fix introspection of refresh tokens (RFC 7662): a refresh token bound to an expired access token now introspects as `active: true`, matching the token endpoint which still accepts it. The introspection response for a presented refresh token no longer includes the paired access token's `token_type` and `exp`. Fixes [#1858].
 - [#1862] Document that with `reuse_access_token` enabled token matching considers only the application, resource owner, scopes and custom token attributes — separate authorization grants for the same combination intentionally share one access token — and pin the behavior with a regression spec. Docs/test-only change, closes [#1693].
 - Please add here
 

--- a/app/controllers/doorkeeper/tokens_controller.rb
+++ b/app/controllers/doorkeeper/tokens_controller.rb
@@ -34,7 +34,7 @@ module Doorkeeper
 
     # OAuth 2.0 Token Introspection - https://datatracker.ietf.org/doc/html/rfc7662
     def introspect
-      introspection = OAuth::TokenIntrospection.new(server, token)
+      introspection = OAuth::TokenIntrospection.new(server, token, token_type: presented_token_type)
 
       if introspection.authorized?
         render json: introspection.to_json, status: 200
@@ -136,6 +136,15 @@ module Doorkeeper
       return unless token
 
       RevocableTokens::RevocableRefreshToken.new(token)
+    end
+
+    # Revocation (RFC 7009) and introspection (RFC 7662) deliberately share
+    # the same request shape — `token` plus an optional `token_type_hint` —
+    # so both actions resolve the presented token through #revocable_token.
+    # The wrapper type doubles as the record of which credential the client
+    # actually presented.
+    def presented_token_type
+      revocable_token.is_a?(RevocableTokens::RevocableRefreshToken) ? :refresh_token : :access_token
     end
 
     def access_token

--- a/lib/doorkeeper/oauth/token_introspection.rb
+++ b/lib/doorkeeper/oauth/token_introspection.rb
@@ -8,9 +8,13 @@ module Doorkeeper
     class TokenIntrospection
       attr_reader :token, :error, :invalid_request_reason
 
-      def initialize(server, token)
+      # +token_type+ tells which credential of the token record the caller
+      # actually received (:access_token or :refresh_token), so the "active"
+      # state and the response describe the presented token per RFC 7662 §2.2.
+      def initialize(server, token, token_type: :access_token)
         @server = server
         @token = token
+        @token_type = token_type
       end
 
       def authorized?
@@ -106,12 +110,19 @@ module Doorkeeper
           active: true,
           scope: @token.scopes_string,
           client_id: @token.try(:application).try(:uid),
-          token_type: @token.token_type,
           iat: @token.created_at.to_i,
         }
-        # `exp` is OPTIONAL per RFC 7662 §2.2; omit it for non-expiring tokens
-        # so clients don't interpret `0` as "expired at 1970-01-01".
-        response[:exp] = @token.expires_at.to_i if @token.expires_at
+
+        # `token_type` (RFC 6749 §7.1) and `exp` describe the access token:
+        # a refresh token is not a Bearer credential and has no expiry of its
+        # own, so both are omitted (they are OPTIONAL per RFC 7662 §2.2) when
+        # a refresh token is presented.
+        unless refresh_token_presented?
+          response[:token_type] = @token.token_type
+          # `exp` is OPTIONAL per RFC 7662 §2.2; omit it for non-expiring tokens
+          # so clients don't interpret `0` as "expired at 1970-01-01".
+          response[:exp] = @token.expires_at.to_i if @token.expires_at
+        end
 
         customize_response(response)
       end
@@ -176,9 +187,18 @@ module Doorkeeper
         end
       end
 
-      # Token can be valid only if it is not expired or revoked.
+      # The presented token can be valid only if it is not revoked; an access
+      # token must additionally be unexpired. A refresh token has no expiry of
+      # its own and stays usable at the token endpoint after its paired access
+      # token expires, so that expiry is not consulted here.
       def valid_token?
-        @token&.accessible?
+        return false if @token.blank?
+
+        refresh_token_presented? ? !@token.revoked? : @token.accessible?
+      end
+
+      def refresh_token_presented?
+        @token_type == :refresh_token
       end
 
       def valid_authorized_token?

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -686,6 +686,60 @@ RSpec.describe Doorkeeper::TokensController, type: :controller do
       end
     end
 
+    context "when a refresh token is introspected" do
+      let(:token_for_introspection) do
+        FactoryBot.create(:access_token, application: client, use_refresh_token: true)
+      end
+
+      before do
+        request.headers["Authorization"] = basic_auth_header_for_client(client)
+      end
+
+      it "responds with the state of the refresh token, without access token type and expiry" do
+        post :introspect, params: { token: token_for_introspection.refresh_token }
+
+        expect(json_response).to match(
+          "active" => true,
+          "client_id" => client.uid,
+          "scope" => nil,
+          "iat" => an_instance_of(Integer),
+        )
+      end
+
+      it "responds with the state of the refresh token when token_type_hint is refresh_token" do
+        post :introspect, params: {
+          token: token_for_introspection.refresh_token,
+          token_type_hint: "refresh_token",
+        }
+
+        expect(json_response).to match(
+          "active" => true,
+          "client_id" => client.uid,
+          "scope" => nil,
+          "iat" => an_instance_of(Integer),
+        )
+      end
+
+      # Regression test for doorkeeper#1858: the refresh token stays usable at
+      # the token endpoint after the paired access token expires, so it must
+      # introspect as active.
+      it "responds with active state when the paired access token has expired" do
+        token_for_introspection.update!(created_at: 1.year.ago)
+
+        post :introspect, params: { token: token_for_introspection.refresh_token }
+
+        expect(json_response).to include("active" => true)
+      end
+
+      it "responds with only active state when the token has been revoked" do
+        token_for_introspection.update!(revoked_at: 1.year.ago)
+
+        post :introspect, params: { token: token_for_introspection.refresh_token }
+
+        expect(json_response).to match("active" => false)
+      end
+    end
+
     context "when unauthorized (no bearer token or client credentials)" do
       let(:token_for_introspection) { FactoryBot.create(:access_token) }
 

--- a/spec/requests/endpoints/introspection_spec.rb
+++ b/spec/requests/endpoints/introspection_spec.rb
@@ -41,6 +41,40 @@ RSpec.describe "Introspection endpoint" do
     expect(json_response).not_to include("active")
   end
 
+  # Regression spec for doorkeeper#1858: a refresh token bound to an expired
+  # access token is still accepted by the token endpoint, so introspecting it
+  # must report active: true.
+  context "when introspecting a refresh token bound to an expired access token" do
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        use_refresh_token
+      end
+    end
+
+    let(:access_token) do
+      FactoryBot.create(:access_token, application: client, use_refresh_token: true).tap do |token|
+        token.update!(created_at: token.created_at - token.expires_in - 1)
+      end
+    end
+
+    it "reports the refresh token as active and the token endpoint accepts it" do
+      post introspection_endpoint_url,
+           params: { token: access_token.refresh_token },
+           headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(client) }
+
+      expect(response).to be_successful
+      expect(json_response).to include("active" => true)
+      expect(json_response).not_to include("exp", "token_type")
+
+      post refresh_token_endpoint_url,
+           params: refresh_token_endpoint_params(client: client, refresh_token: access_token.refresh_token)
+
+      expect(response).to be_successful
+      expect(json_response).to include("access_token", "refresh_token")
+    end
+  end
+
   it "rejects the request when it uses more than one client authentication method (RFC 6749 §2.3)" do
     post introspection_endpoint_url,
          params: {


### PR DESCRIPTION
## Summary

Fixes #1858 (split out from #1671): introspecting a refresh token whose paired access token had expired returned `{"active": false}`, while the token endpoint still accepted the same refresh token and issued new tokens. Per RFC 7662 §2.2 the `active` field describes the token presented in the request, but `TokenIntrospection#valid_token?` always checked `AccessToken#accessible?` — i.e. the *access token's* expiry — regardless of which credential was presented.

## Changes

`TokensController` already knows which credential it resolved (`by_token` vs `by_refresh_token`, honoring `token_type_hint`), so it now passes that along via a new `token_type:` keyword on `TokenIntrospection#initialize`. The keyword defaults to `:access_token`, so existing callers and subclasses keep the previous behavior.

When the presented token is a refresh token:

- `active` is based on `revoked?` alone — mirroring how the token endpoint (`RefreshTokenRequest`) and revocation (`RevocableTokens::RevocableRefreshToken`, #1744) already treat refresh tokens.
- The success response omits `token_type` and `exp`. Both are OPTIONAL per RFC 7662 §2.2 and describe the paired access token: a refresh token is not a Bearer credential and has no expiry of its own. Without this, an expired-but-active introspection would report `active: true` alongside an `exp` in the past, which is contradictory for resource servers that honor `exp`.

Behavior note: introspecting a *live* refresh token previously returned `token_type: "Bearer"` and the paired access token's `exp`; those two fields are no longer included for presented refresh tokens (mentioned in the CHANGELOG entry).