### PR TITLE
Add jwt-bearer grant (ID-JAG) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
-- [#PR] Add the `jwt-bearer` grant (`urn:ietf:params:oauth:grant-type:jwt-bearer`, RFC 7523), profiled by the Identity Assertion Authorization Grant (ID-JAG) draft, letting Doorkeeper act as the Resource Authorization Server side of a Cross App Access exchange: it verifies an ID-JAG assertion minted by an external Identity Provider and issues a locally-scoped access token, without ever issuing a refresh token.
+- [#1861] Add the `jwt-bearer` grant (`urn:ietf:params:oauth:grant-type:jwt-bearer`, RFC 7523), profiled by the Identity Assertion Authorization Grant (ID-JAG) draft, letting Doorkeeper act as the Resource Authorization Server side of a Cross App Access exchange: it verifies an ID-JAG assertion minted by an external Identity Provider and issues a locally-scoped access token, without ever issuing a refresh token.
   - Not enabled by default — add `:jwt_bearer` to `grant_flows` to opt in.
   - Restricted to confidential clients by default per ID-JAG §8.1 (relax with `jwt_bearer_allow_public_clients`, not recommended for production).
   - New required config hooks: `jwt_bearer_trusted_issuer`, `jwt_bearer_issuer_key`, `jwt_bearer_resource_owner_from_assertion`. New optional hooks/options: `jwt_bearer_authorize`, `jwt_bearer_replay_store`, `jwt_bearer_audience` (required to actually issue tokens), `jwt_bearer_clock_skew`, `jwt_bearer_allowed_algorithms`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#PR] Add the `jwt-bearer` grant (`urn:ietf:params:oauth:grant-type:jwt-bearer`, RFC 7523), profiled by the Identity Assertion Authorization Grant (ID-JAG) draft, letting Doorkeeper act as the Resource Authorization Server side of a Cross App Access exchange: it verifies an ID-JAG assertion minted by an external Identity Provider and issues a locally-scoped access token, without ever issuing a refresh token.
+  - Not enabled by default — add `:jwt_bearer` to `grant_flows` to opt in.
+  - Restricted to confidential clients by default per ID-JAG §8.1 (relax with `jwt_bearer_allow_public_clients`, not recommended for production).
+  - New required config hooks: `jwt_bearer_trusted_issuer`, `jwt_bearer_issuer_key`, `jwt_bearer_resource_owner_from_assertion`. New optional hooks/options: `jwt_bearer_authorize`, `jwt_bearer_replay_store`, `jwt_bearer_audience` (required to actually issue tokens), `jwt_bearer_clock_skew`, `jwt_bearer_allowed_algorithms`.
+  - Adds a new runtime dependency on the `jwt` gem for JWS decode/verify (RS256, ES256, PS256).
 - [#1838] Add OAuth 2.0 Authorization Server Metadata endpoint (RFC 8414) served at `/.well-known/oauth-authorization-server`. The response is built from your Doorkeeper configuration and advertises the authorization, token, revocation and (when token introspection is enabled) introspection endpoints, supported scopes, response/grant types and PKCE code challenge methods. Two new config options are available: `issuer` (defaults to the request base URL) and `custom_metadata` (a Hash merged into the response, e.g. to advertise an OIDC `userinfo_endpoint`). The controller/response use the RFC 8414 "Metadata" naming so they don't collide with a future OpenID Connect Discovery (`.well-known/openid-configuration`) implementation. Endpoints disabled through `skip_controllers` are omitted from the response instead of raising a route-generation error.
 - [#1839] Send client credentials in the request body (not the query string) in the token endpoint specs, per RFC 6749 §2.3.1. Test-only change: the `*_endpoint_url` helpers now return a path plus a matching `*_endpoint_params` builder so flow specs post credentials through the body.
 - [#1840] Introduce a pluggable client authentication registry (RFC 6749 §2.3).

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |gem|
     "funding_uri" => "https://opencollective.com/doorkeeper-gem",
   }
 
+  gem.add_dependency "jwt", ">= 2.7"
   gem.add_dependency "railties", ">= 5"
   gem.required_ruby_version = ">= 2.7"
 

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -30,6 +30,7 @@ module Doorkeeper
     autoload :AuthorizationCode, "doorkeeper/request/authorization_code"
     autoload :ClientCredentials, "doorkeeper/request/client_credentials"
     autoload :Code, "doorkeeper/request/code"
+    autoload :JwtBearer, "doorkeeper/request/jwt_bearer"
     autoload :Password, "doorkeeper/request/password"
     autoload :RefreshToken, "doorkeeper/request/refresh_token"
     autoload :Token, "doorkeeper/request/token"
@@ -53,6 +54,7 @@ module Doorkeeper
     autoload :InvalidTokenResponse, "doorkeeper/oauth/invalid_token_response"
     autoload :InvalidRequestResponse, "doorkeeper/oauth/invalid_request_response"
     autoload :ForbiddenTokenResponse, "doorkeeper/oauth/forbidden_token_response"
+    autoload :JwtBearerAccessTokenRequest, "doorkeeper/oauth/jwt_bearer_access_token_request"
     autoload :MetadataResponse, "doorkeeper/oauth/metadata_response"
     autoload :NonStandard, "doorkeeper/oauth/nonstandard"
     autoload :PasswordAccessTokenRequest, "doorkeeper/oauth/password_access_token_request"
@@ -84,6 +86,7 @@ module Doorkeeper
     end
 
     module Helpers
+      autoload :JwtBearerAssertion, "doorkeeper/oauth/helpers/jwt_bearer_assertion"
       autoload :ScopeChecker, "doorkeeper/oauth/helpers/scope_checker"
       autoload :URIChecker, "doorkeeper/oauth/helpers/uri_checker"
       autoload :UniqueToken, "doorkeeper/oauth/helpers/unique_token"

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -366,7 +366,7 @@ module Doorkeeper
     # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
     # @return [Boolean] `true` if allow or `false` if forbid the request
     #
-    option :allow_grant_flow_for_client,    default: ->(_grant_flow, _client) { true }
+    option :allow_grant_flow_for_client, default: ->(_grant_flow, _client) { true }
 
     # Allows to forbid specific Application redirect URI's by custom rules.
     # Doesn't forbid any URI by default.
@@ -824,3 +824,7 @@ module Doorkeeper
     end
   end
 end
+
+# Reopens Config to add the jwt_bearer_* options in their own file, keeping
+# this already-large class from growing further (Metrics/ClassLength).
+require "doorkeeper/config/jwt_bearer"

--- a/lib/doorkeeper/config/jwt_bearer.rb
+++ b/lib/doorkeeper/config/jwt_bearer.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  # Reopened here (rather than in config.rb) to keep that already-large
+  # class from growing further; see Metrics/ClassLength.
+  class Config
+    # Fail-closed default for a required `jwt_bearer_*` hook: warns once and returns +result+.
+    def self.jwt_bearer_unconfigured(option_name, result = nil)
+      ->(*) { ::Rails.logger.warn("[DOORKEEPER] #{option_name} is not configured") && result }
+    end
+
+    # JWT Bearer / ID-JAG grant (urn:ietf:params:oauth:grant-type:jwt-bearer):
+    # acts as the Resource AS side of a Cross App Access exchange. Not
+    # enabled unless `:jwt_bearer` is added to `grant_flows`.
+
+    # This AS's issuer identifier (RFC 8414); assertions must present this as their `aud`.
+    option :jwt_bearer_audience, default: nil
+
+    # Clock-skew tolerance, in seconds, for `exp`/`nbf`/`iat`.
+    option :jwt_bearer_clock_skew, default: 60
+
+    # Signature algorithm allow-list; `none`/HMAC are never accepted.
+    option :jwt_bearer_allowed_algorithms, default: %w[RS256 ES256 PS256]
+
+    # ID-JAG §8.1: confidential-client-only unless relaxed (not for production).
+    option :jwt_bearer_allow_public_clients, default: false
+
+    # Required `(issuer) -> Boolean` hook: is `issuer` a trusted IdP? Fails closed by default.
+    option :jwt_bearer_trusted_issuer, default: jwt_bearer_unconfigured(:jwt_bearer_trusted_issuer, false)
+
+    # Required `(issuer, kid) -> key(s)` hook: PEM/`OpenSSL::PKey`/JWK `Hash`/`Array` of those.
+    # Fails closed by default.
+    option :jwt_bearer_issuer_key, default: jwt_bearer_unconfigured(:jwt_bearer_issuer_key)
+
+    # Required `(issuer, subject, client) -> resource_owner` hook. Fails closed by default.
+    option :jwt_bearer_resource_owner_from_assertion,
+           default: jwt_bearer_unconfigured(:jwt_bearer_resource_owner_from_assertion)
+
+    # Optional `(client, resource_owner, scopes, claims) -> Boolean` policy hook; permissive by default.
+    option :jwt_bearer_authorize, default: ->(_client, _resource_owner, _scopes, _claims) { true }
+
+    # Replay protection: responds to `#consume(jti, issuer, expires_at) -> Boolean`
+    # (true only on first use of an `(issuer, jti)` pair). `nil` disables it
+    # (logged once); supplying an app-backed store is strongly recommended.
+    option :jwt_bearer_replay_store, default: nil
+  end
+end

--- a/lib/doorkeeper/config/validations.rb
+++ b/lib/doorkeeper/config/validations.rb
@@ -18,6 +18,7 @@ module Doorkeeper
         validate_refresh_token_flow
         validate_issuer_format
         validate_issuer_metadata_discoverability
+        validate_jwt_bearer_configuration
       end
 
       private
@@ -181,6 +182,20 @@ module Doorkeeper
           "RFC 8414 and RFC 9207 require an https URL with a host and no query " \
           "or fragment component. It is still advertised in the metadata and " \
           "emitted as the iss parameter as-is, but strict clients may reject it.",
+        )
+      end
+
+      # Warn when the jwt_bearer grant flow is enabled but jwt_bearer_audience
+      # is not configured. Every assertion's aud check would then never match
+      # (the audience is nil), so every jwt_bearer request would be rejected.
+      def validate_jwt_bearer_configuration
+        return unless calculate_grant_flows.map(&:to_s).include?("jwt_bearer")
+        return if jwt_bearer_audience.present?
+
+        ::Rails.logger.warn(
+          "[DOORKEEPER] The jwt_bearer grant flow is enabled but jwt_bearer_audience is not configured. " \
+          "Every ID-JAG assertion's `aud` claim check will fail, so every jwt_bearer request will be rejected " \
+          "until you configure jwt_bearer_audience to this Resource AS's own issuer identifier (RFC 8414).",
         )
       end
 

--- a/lib/doorkeeper/grant_flow.rb
+++ b/lib/doorkeeper/grant_flow.rb
@@ -41,5 +41,14 @@ module Doorkeeper
       grant_type_matches: "refresh_token",
       grant_type_strategy: Doorkeeper::Request::RefreshToken,
     )
+
+    # JWT Bearer grant (RFC 7523), profiled by the Identity Assertion
+    # Authorization Grant (ID-JAG) draft. Not enabled by default; add
+    # `:jwt_bearer` to `grant_flows` to opt in.
+    register(
+      :jwt_bearer,
+      grant_type_matches: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      grant_type_strategy: Doorkeeper::Request::JwtBearer,
+    )
   end
 end

--- a/lib/doorkeeper/oauth.rb
+++ b/lib/doorkeeper/oauth.rb
@@ -8,6 +8,7 @@ module Doorkeeper
       PASSWORD = "password",
       CLIENT_CREDENTIALS = "client_credentials",
       REFRESH_TOKEN = "refresh_token",
+      JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer",
     ].freeze
   end
 end

--- a/lib/doorkeeper/oauth/helpers/jwt_bearer_assertion.rb
+++ b/lib/doorkeeper/oauth/helpers/jwt_bearer_assertion.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "jwt"
+
+module Doorkeeper
+  module OAuth
+    module Helpers
+      # Decodes and verifies an ID-JAG assertion (the `jwt-bearer` grant's
+      # `assertion` parameter), per the Identity Assertion Authorization
+      # Grant draft (draft-ietf-oauth-identity-assertion-authz-grant).
+      #
+      # The header is parsed *unverified* only to dispatch on `typ`/`kid`
+      # (never to make a trust decision) before any cryptographic work; every
+      # claim is only trusted once returned from a successful, signature
+      # verified `#verify` call.
+      module JwtBearerAssertion
+        # The `typ` header value mandated by ID-JAG Section 3.1. Any other
+        # value, including the generic `JWT`, is a type-confusion attempt.
+        REQUIRED_TYP = "oauth-id-jag+jwt"
+
+        REQUIRED_CLAIMS = %w[iss sub aud client_id jti exp iat].freeze
+
+        # Result of a #verify call.
+        #
+        # @!attribute claims
+        #   @return [Hash, nil] the verified claims, present only if +success?+
+        Result = Struct.new(:claims) do
+          def success?
+            !claims.nil?
+          end
+        end
+
+        FAILURE = Result.new(nil).freeze
+
+        module_function
+
+        # @param assertion [String] the compact JWT from the `assertion` request parameter
+        # @param client [Doorkeeper::OAuth::Client] the authenticated client
+        # @param config [Doorkeeper::Config] (default: +Doorkeeper.config+)
+        # @return [Result]
+        def verify(assertion, client:, config: Doorkeeper.config)
+          return FAILURE unless assertion.is_a?(String) && assertion.present?
+
+          candidates = resolve_key_candidates(assertion, config)
+          return FAILURE if candidates.blank?
+
+          claims = decode_with_candidates(assertion, candidates, client, config)
+          return FAILURE unless claims
+
+          Result.new(claims)
+        end
+
+        # Unverified header/payload dispatch: resolves which key(s) to
+        # attempt verification against, without trusting any claim yet.
+        def resolve_key_candidates(assertion, config)
+          unverified_payload, unverified_header = peek(assertion)
+          return [] unless unverified_payload && unverified_header
+          return [] unless unverified_header["typ"] == REQUIRED_TYP
+
+          issuer = unverified_payload["iss"]
+          return [] unless issuer.is_a?(String) && issuer.present?
+          return [] unless config.jwt_bearer_trusted_issuer.call(issuer)
+
+          key_candidates(config.jwt_bearer_issuer_key.call(issuer, unverified_header["kid"]))
+        end
+        private_class_method :resolve_key_candidates
+
+        # Parses the header/payload without verifying the signature or
+        # trusting any claim. Used only to resolve which key to verify
+        # against (RFC 7515 `kid`) and which issuer to look it up for.
+        def peek(assertion)
+          JWT.decode(assertion, nil, false)
+        rescue JWT::DecodeError
+          [nil, nil]
+        end
+        private_class_method :peek
+
+        # Normalizes whatever `jwt_bearer_issuer_key` returned into a list of
+        # objects `JWT::JWK.import` can build a key from: a PEM string is
+        # converted via `OpenSSL::PKey.read`, a JWK `Hash`/`OpenSSL::PKey`/
+        # `JWT::JWK::KeyBase` is passed through as-is.
+        #
+        # Deliberately does NOT use `Array(raw_key)` — Ruby's `Kernel#Array`
+        # destructures a single `Hash` (a bare JWK) into `[[key, value], ...]`
+        # pairs rather than wrapping it, which would silently drop the key.
+        def key_candidates(raw_key)
+          return [] if raw_key.blank?
+
+          keys = raw_key.is_a?(Array) ? raw_key : [raw_key]
+
+          keys.compact.filter_map do |key|
+            key.is_a?(String) ? OpenSSL::PKey.read(key) : key
+          rescue OpenSSL::PKey::PKeyError
+            nil
+          end
+        end
+        private_class_method :key_candidates
+
+        # Tries each candidate key until one verifies the signature *and*
+        # every claim. Every failure — bad signature, disallowed algorithm,
+        # audience mismatch, expired/future timestamps, replay, missing
+        # claims, `client_id` mismatch — is folded into the same `nil`
+        # return so the caller cannot distinguish which check failed.
+        def decode_with_candidates(assertion, candidates, client, config)
+          allowed_algorithms = Array(config.jwt_bearer_allowed_algorithms)
+          skew = config.jwt_bearer_clock_skew.to_i
+
+          candidates.each do |key|
+            jwk = begin
+              JWT::JWK.import(key)
+            rescue JWT::JWKError
+              next
+            end
+
+            claims, = JWT.decode(
+              assertion,
+              jwk.verify_key,
+              true,
+              algorithms: allowed_algorithms,
+              verify_aud: true,
+              aud: config.jwt_bearer_audience,
+              verify_expiration: true,
+              exp_leeway: skew,
+              verify_not_before: true,
+              nbf_leeway: skew,
+              required_claims: REQUIRED_CLAIMS,
+              verify_jti: replay_validator(config),
+            )
+
+            next unless valid_iat?(claims, skew)
+            next unless claims["client_id"] == client.uid
+
+            return claims
+          rescue JWT::DecodeError
+            next
+          end
+
+          nil
+        end
+        private_class_method :decode_with_candidates
+
+        # The `jwt` gem's own `verify_iat` has no leeway option, so the
+        # future-dated-iat check (with our configurable clock skew) is done
+        # manually here instead of via a decode option.
+        def valid_iat?(claims, skew)
+          claims["iat"].to_i <= Time.now.to_i + skew
+        end
+        private_class_method :valid_iat?
+
+        # Builds the `verify_jti:` decode option: a `#call(jti, payload)`
+        # validator the `jwt` gem invokes as part of claim verification.
+        # Replay protection is opt-in — with no configured store, every jti
+        # is accepted (a startup warning is logged elsewhere for this case).
+        def replay_validator(config)
+          lambda do |jti, payload|
+            return false if jti.blank?
+
+            store = config.jwt_bearer_replay_store
+            next true unless store
+
+            store.consume(jti, payload["iss"], payload["exp"])
+          end
+        end
+        private_class_method :replay_validator
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/jwt_bearer_access_token_request.rb
+++ b/lib/doorkeeper/oauth/jwt_bearer_access_token_request.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    # Implements the JWT Bearer grant (`urn:ietf:params:oauth:grant-type:jwt-bearer`)
+    # profiled by the Identity Assertion Authorization Grant (ID-JAG) draft.
+    # Lets this server act as the Resource Authorization Server side of a
+    # Cross App Access exchange: it consumes an ID-JAG assertion minted by an
+    # external Identity Provider and, once verified, issues a locally-scoped
+    # access token.
+    #
+    # Minting the ID-JAG itself (the IdP side, RFC 8693 Token Exchange) is
+    # out of scope for this grant.
+    class JwtBearerAccessTokenRequest < BaseRequest
+      include OAuth::Helpers
+
+      validate :client, error: Errors::InvalidClient
+      validate :client_supports_grant_flow, error: Errors::UnauthorizedClient
+      validate :confidential_client, error: Errors::UnauthorizedClient
+      validate :assertion_presence, error: Errors::InvalidRequest
+      validate :assertion, error: Errors::InvalidGrant
+      validate :resource_owner, error: Errors::InvalidGrant
+      validate :authorized, error: Errors::InvalidGrant
+      validate :scopes, error: Errors::InvalidScope
+
+      attr_reader :client, :assertion, :parameters, :resource_owner, :access_token
+
+      def initialize(server, client, assertion, parameters = {})
+        @server          = server
+        @client          = client
+        @assertion       = assertion
+        @parameters      = parameters
+        @original_scopes = parameters[:scope]
+        @grant_type      = Doorkeeper::OAuth::JWT_BEARER
+      end
+
+      private
+
+      def before_successful_response
+        create_access_token
+        super
+      end
+
+      # Per ID-JAG Section 4.4.3 the Resource AS MUST NOT issue a
+      # refresh_token when an ID-JAG is exchanged for an access token, so
+      # this bypasses `find_or_create_access_token` (whose `use_refresh_token`
+      # is derived from the global `refresh_token_enabled?` config, which
+      # doesn't special-case grant type) and calls the token model directly,
+      # the same way `ClientCredentialsRequest` does.
+      def create_access_token
+        context = Authorization::Token.build_context(client, grant_type, scopes, resource_owner)
+
+        @access_token = Doorkeeper.config.access_token_model.find_or_create_for(
+          application: client&.application,
+          resource_owner: resource_owner,
+          scopes: scopes,
+          expires_in: Authorization::Token.access_token_expires_in(server, context),
+          use_refresh_token: false,
+        )
+      end
+
+      def validate_client
+        client.present?
+      end
+
+      def validate_client_supports_grant_flow
+        Doorkeeper.config.allow_grant_flow_for_client?(grant_type, client&.application)
+      end
+
+      # ID-JAG Section 8.1: this grant SHOULD only be supported for
+      # confidential clients; public clients SHOULD use the standard
+      # authorization code grant instead.
+      def validate_confidential_client
+        client.confidential || Doorkeeper.config.jwt_bearer_allow_public_clients
+      end
+
+      def validate_assertion_presence
+        assertion.is_a?(String) && assertion.present?
+      end
+
+      # Every assertion-validation failure below funnels into this single
+      # boolean, and therefore the same `Errors::InvalidGrant` response - the
+      # caller cannot distinguish signature failure from an untrusted issuer
+      # from a replayed jti, by design.
+      def validate_assertion
+        result = Helpers::JwtBearerAssertion.verify(assertion, client: client)
+        @claims = result.claims
+        result.success?
+      end
+
+      def validate_resource_owner
+        @resource_owner = Doorkeeper.config.jwt_bearer_resource_owner_from_assertion.call(
+          claims["iss"], claims["sub"], client,
+        )
+        resource_owner.present?
+      end
+
+      def validate_authorized
+        Doorkeeper.config.jwt_bearer_authorize.call(client, resource_owner, scopes, claims)
+      end
+
+      # ID-JAG Section 4.4.1: if the assertion carries a `scope` claim, the
+      # issued token's scope MUST be the intersection of that and any
+      # `scope` parameter on the token request - the assertion scope is a
+      # ceiling the request can narrow but never expand.
+      def validate_scopes
+        return true if scopes.blank?
+
+        return false if requested_scope.present? && assertion_scope.present? && !assertion_scope.has_scopes?(requested_scope)
+
+        ScopeChecker.valid?(
+          scope_str: scopes.to_s,
+          server_scopes: server.scopes,
+          app_scopes: client.try(:scopes),
+          grant_type: grant_type,
+        )
+      end
+
+      def build_scopes
+        return default_scopes if requested_scope.blank? && assertion_scope.blank?
+        return assertion_scope if requested_scope.blank?
+        return requested_scope if assertion_scope.blank?
+
+        assertion_scope.allowed(requested_scope)
+      end
+
+      def requested_scope
+        return @requested_scope if defined?(@requested_scope)
+
+        @requested_scope = @original_scopes.present? ? OAuth::Scopes.from_string(@original_scopes) : nil
+      end
+
+      def assertion_scope
+        return @assertion_scope if defined?(@assertion_scope)
+
+        scope_claim = claims && claims["scope"]
+        @assertion_scope = scope_claim.present? ? OAuth::Scopes.from_string(scope_claim) : nil
+      end
+
+      attr_reader :claims
+    end
+  end
+end

--- a/lib/doorkeeper/request/jwt_bearer.rb
+++ b/lib/doorkeeper/request/jwt_bearer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Request
+    # Strategy for the jwt-bearer grant (urn:ietf:params:oauth:grant-type:jwt-bearer, ID-JAG).
+    class JwtBearer < Strategy
+      delegate :client, :parameters, to: :server
+
+      def request
+        @request ||= OAuth::JwtBearerAccessTokenRequest.new(
+          Doorkeeper.config,
+          client,
+          parameters[:assertion],
+          parameters,
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/oauth/helpers/jwt_bearer_assertion_spec.rb
+++ b/spec/lib/oauth/helpers/jwt_bearer_assertion_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "openssl"
+require "jwt"
+
+RSpec.describe Doorkeeper::OAuth::Helpers::JwtBearerAssertion do
+  let(:rsa) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:ec_key) { OpenSSL::PKey::EC.generate("prime256v1") }
+  let(:ec_public_key) { OpenSSL::PKey.read(ec_key.public_to_der) }
+  let(:issuer) { "https://idp.example.com" }
+  let(:audience) { "https://rs.example.com" }
+  let(:client) { double(:client, uid: "client-1") }
+
+  let(:config_attrs) do
+    {
+      jwt_bearer_trusted_issuer: ->(iss) { iss == issuer },
+      jwt_bearer_issuer_key: ->(_iss, _kid) { rsa.public_key },
+      jwt_bearer_allowed_algorithms: %w[RS256 ES256 PS256],
+      jwt_bearer_audience: audience,
+      jwt_bearer_clock_skew: 60,
+      jwt_bearer_replay_store: nil,
+    }
+  end
+  let(:config) { double(:config, **config_attrs) }
+
+  def make_assertion(alg: "RS256", key: rsa, header: {}, payload: {})
+    now = Time.now.to_i
+    claims = {
+      "iss" => issuer, "sub" => "user-1", "aud" => audience, "client_id" => "client-1",
+      "jti" => SecureRandom.hex(8), "exp" => now + 300, "iat" => now,
+    }.merge(payload)
+    JWT.encode(claims, key, alg, { typ: "oauth-id-jag+jwt" }.merge(header))
+  end
+
+  def verify(assertion, config: self.config)
+    described_class.verify(assertion, client: client, config: config)
+  end
+
+  def config_with(overrides)
+    double(:config, **config_attrs.merge(overrides))
+  end
+
+  it "returns verified claims for a valid RS256 assertion" do
+    result = verify(make_assertion)
+
+    expect(result).to be_success
+    expect(result.claims["iss"]).to eq(issuer)
+    expect(result.claims["client_id"]).to eq("client-1")
+  end
+
+  it "verifies a valid ES256 assertion" do
+    ec_config = config_with(jwt_bearer_issuer_key: ->(_iss, _kid) { ec_public_key })
+    result = verify(make_assertion(alg: "ES256", key: ec_key), config: ec_config)
+
+    expect(result).to be_success
+  end
+
+  it "verifies a valid PS256 assertion" do
+    result = verify(make_assertion(alg: "PS256"))
+
+    expect(result).to be_success
+  end
+
+  it "rejects a non-string assertion" do
+    expect(verify(nil)).not_to be_success
+    expect(verify(42)).not_to be_success
+  end
+
+  it "rejects a malformed assertion" do
+    expect(verify("not-a-jwt")).not_to be_success
+  end
+
+  it "rejects typ confusion (typ: JWT)" do
+    result = verify(make_assertion(header: { typ: "JWT" }))
+
+    expect(result).not_to be_success
+  end
+
+  it "rejects alg: none" do
+    header = Base64.urlsafe_encode64({ alg: "none", typ: "oauth-id-jag+jwt" }.to_json, padding: false)
+    payload = Base64.urlsafe_encode64(
+      { iss: issuer, sub: "user-1", aud: audience, client_id: "client-1", jti: "x", exp: Time.now.to_i + 300, iat: Time.now.to_i }.to_json,
+      padding: false,
+    )
+    result = verify("#{header}.#{payload}.")
+
+    expect(result).not_to be_success
+  end
+
+  it "rejects an HMAC-signed assertion" do
+    result = verify(make_assertion(alg: "HS256", key: "some-shared-secret"))
+
+    expect(result).not_to be_success
+  end
+
+  it "rejects an assertion from an untrusted issuer" do
+    result = verify(make_assertion(payload: { "iss" => "https://evil.example.com" }))
+
+    expect(result).not_to be_success
+  end
+
+  it "rejects an assertion when no key can be resolved" do
+    unresolvable_config = config_with(jwt_bearer_issuer_key: ->(_iss, _kid) { nil })
+    result = verify(make_assertion, config: unresolvable_config)
+
+    expect(result).not_to be_success
+  end
+
+  it "rejects a tampered signature" do
+    assertion = make_assertion
+    tampered = "#{assertion[0..-2]}#{assertion[-1] == "A" ? "B" : "A"}"
+
+    expect(verify(tampered)).not_to be_success
+  end
+
+  it "rejects an audience mismatch" do
+    result = verify(make_assertion(payload: { "aud" => "https://someone-else.example.com" }))
+
+    expect(result).not_to be_success
+  end
+
+  it "rejects an expired assertion" do
+    result = verify(make_assertion(payload: { "exp" => Time.now.to_i - 1000 }))
+
+    expect(result).not_to be_success
+  end
+
+  it "accepts an assertion just inside the clock-skew tolerance" do
+    result = verify(make_assertion(payload: { "exp" => Time.now.to_i - 30 }))
+
+    expect(result).to be_success
+  end
+
+  it "rejects an assertion issued too far in the future" do
+    result = verify(make_assertion(payload: { "iat" => Time.now.to_i + 1000, "exp" => Time.now.to_i + 1300 }))
+
+    expect(result).not_to be_success
+  end
+
+  it "rejects an assertion not yet valid per its nbf claim" do
+    result = verify(make_assertion(payload: { "nbf" => Time.now.to_i + 1000 }))
+
+    expect(result).not_to be_success
+  end
+
+  it "rejects an assertion missing a required claim" do
+    result = verify(make_assertion(payload: { "jti" => nil }))
+
+    expect(result).not_to be_success
+  end
+
+  it "rejects an assertion whose client_id claim does not match the authenticated client" do
+    result = verify(make_assertion(payload: { "client_id" => "someone-else" }))
+
+    expect(result).not_to be_success
+  end
+
+  it "rejects a replayed assertion when a replay store is configured" do
+    store = Class.new do
+      def initialize
+        @seen = {}
+      end
+
+      def consume(jti, iss, _exp)
+        key = "#{iss}:#{jti}"
+        return false if @seen[key]
+
+        @seen[key] = true
+        true
+      end
+    end.new
+    replay_config = config_with(jwt_bearer_replay_store: store)
+
+    assertion = make_assertion
+    expect(verify(assertion, config: replay_config)).to be_success
+    expect(verify(assertion, config: replay_config)).not_to be_success
+  end
+
+  it "allows reuse when no replay store is configured" do
+    assertion = make_assertion
+
+    expect(verify(assertion)).to be_success
+    expect(verify(assertion)).to be_success
+  end
+
+  it "accepts a PEM string from the key resolver" do
+    pem_config = config_with(jwt_bearer_issuer_key: ->(_iss, _kid) { rsa.public_key.to_pem })
+
+    expect(verify(make_assertion, config: pem_config)).to be_success
+  end
+
+  it "accepts a JWK Hash from the key resolver" do
+    jwk_hash = JWT::JWK.new(rsa.public_key).export
+    jwk_config = config_with(jwt_bearer_issuer_key: ->(_iss, _kid) { jwk_hash })
+
+    expect(verify(make_assertion, config: jwk_config)).to be_success
+  end
+
+  it "tries multiple candidate keys until one verifies" do
+    wrong_key = OpenSSL::PKey::RSA.generate(2048).public_key
+    multi_config = config_with(jwt_bearer_issuer_key: ->(_iss, _kid) { [wrong_key, rsa.public_key] })
+
+    expect(verify(make_assertion, config: multi_config)).to be_success
+  end
+end

--- a/spec/lib/oauth/jwt_bearer_access_token_request_spec.rb
+++ b/spec/lib/oauth/jwt_bearer_access_token_request_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "openssl"
+require "jwt"
+
+RSpec.describe Doorkeeper::OAuth::JwtBearerAccessTokenRequest do
+  subject(:request) do
+    described_class.new(server, client, assertion, parameters)
+  end
+
+  let(:rsa) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:issuer) { "https://idp.example.com" }
+  let(:audience) { "https://rs.example.com" }
+  let(:owner) { FactoryBot.build_stubbed(:resource_owner) }
+  let(:application) { FactoryBot.create(:application, confidential: true) }
+  let(:client) { Doorkeeper::OAuth::Client.new(application) }
+  let(:parameters) { {} }
+
+  let(:server) do
+    double(
+      :server,
+      default_scopes: Doorkeeper::OAuth::Scopes.new,
+      access_token_expires_in: 2.hours,
+      custom_access_token_expires_in: ->(_context) { nil },
+    )
+  end
+
+  let(:assertion) { make_assertion }
+
+  def make_assertion(subject: owner.name, client_id: client.uid, alg: "RS256", key: rsa, payload: {})
+    now = Time.now.to_i
+    claims = {
+      "iss" => issuer, "sub" => subject, "aud" => audience, "client_id" => client_id,
+      "jti" => SecureRandom.hex(8), "exp" => now + 300, "iat" => now,
+    }.merge(payload)
+    JWT.encode(claims, key, alg, { typ: "oauth-id-jag+jwt" })
+  end
+
+  # NOTE: blocks passed to `jwt_bearer_*` options below must only close over
+  # this method's own parameters, never over `let`/instance-variable state
+  # directly - `Doorkeeper.configure do ... end` is `instance_eval`'d against
+  # the config Builder, so a nested block created while `self` is the Builder
+  # keeps the Builder as `self` when later invoked, and `let`/`@ivar` lookups
+  # follow `self` at call time (unlike local variables, which are true
+  # lexical closures) - referencing a `let` there raises NoMethodError on the
+  # Builder instead of resolving to the example.
+  def configure_jwt_bearer(resource_owner:, issuer_key:, allow_public_clients: false, authorize: ->(*) { true })
+    Doorkeeper.configure do
+      orm DOORKEEPER_ORM
+      grant_flows %w[jwt_bearer]
+      jwt_bearer_audience "https://rs.example.com"
+      jwt_bearer_trusted_issuer { |iss| iss == "https://idp.example.com" }
+      jwt_bearer_issuer_key { |_iss, _kid| issuer_key }
+      jwt_bearer_resource_owner_from_assertion { |_iss, _sub, _client| resource_owner }
+      jwt_bearer_allow_public_clients allow_public_clients
+      jwt_bearer_authorize(&authorize)
+    end
+  end
+
+  before do
+    allow(server).to receive(:option_defined?).with(:custom_access_token_expires_in).and_return(true)
+    configure_jwt_bearer(resource_owner: owner, issuer_key: rsa.public_key)
+  end
+
+  it "issues a new token for the client and resource owner" do
+    expect { request.authorize }.to change { Doorkeeper::AccessToken.count }.by(1)
+
+    token = Doorkeeper::AccessToken.last
+    expect(token.application_id).to eq(application.id)
+    expect(token.resource_owner_id).to eq(owner.id)
+  end
+
+  it "never issues a refresh token" do
+    request.authorize
+
+    expect(Doorkeeper::AccessToken.last.refresh_token).to be_nil
+  end
+
+  it "does not issue a token without a client" do
+    request = described_class.new(server, nil, assertion, parameters)
+
+    expect { request.authorize }.not_to(change { Doorkeeper::AccessToken.count })
+    expect(request.error).to eq(Doorkeeper::Errors::InvalidClient)
+  end
+
+  it "does not issue a token for a public client by default" do
+    public_application = FactoryBot.create(:application, confidential: false)
+    public_client = Doorkeeper::OAuth::Client.new(public_application)
+    request = described_class.new(server, public_client, make_assertion(client_id: public_client.uid), parameters)
+
+    expect { request.authorize }.not_to(change { Doorkeeper::AccessToken.count })
+    expect(request.error).to eq(Doorkeeper::Errors::UnauthorizedClient)
+  end
+
+  it "issues a token for a public client when jwt_bearer_allow_public_clients is enabled" do
+    configure_jwt_bearer(resource_owner: owner, issuer_key: rsa.public_key, allow_public_clients: true)
+    public_application = FactoryBot.create(:application, confidential: false)
+    public_client = Doorkeeper::OAuth::Client.new(public_application)
+    request = described_class.new(server, public_client, make_assertion(client_id: public_client.uid), parameters)
+
+    expect { request.authorize }.to change { Doorkeeper::AccessToken.count }.by(1)
+  end
+
+  it "does not issue a token when the assertion parameter is missing" do
+    request = described_class.new(server, client, nil, parameters)
+
+    expect { request.authorize }.not_to(change { Doorkeeper::AccessToken.count })
+    expect(request.error).to eq(Doorkeeper::Errors::InvalidRequest)
+  end
+
+  it "does not issue a token when the assertion fails verification" do
+    request = described_class.new(server, client, "not-a-jwt", parameters)
+
+    expect { request.authorize }.not_to(change { Doorkeeper::AccessToken.count })
+    expect(request.error).to eq(Doorkeeper::Errors::InvalidGrant)
+  end
+
+  it "does not issue a token when no resource owner can be resolved from the assertion" do
+    configure_jwt_bearer(resource_owner: nil, issuer_key: rsa.public_key)
+
+    expect { request.authorize }.not_to(change { Doorkeeper::AccessToken.count })
+    expect(request.error).to eq(Doorkeeper::Errors::InvalidGrant)
+  end
+
+  it "does not issue a token when jwt_bearer_authorize denies the request" do
+    configure_jwt_bearer(resource_owner: owner, issuer_key: rsa.public_key, authorize: ->(*) { false })
+
+    expect { request.authorize }.not_to(change { Doorkeeper::AccessToken.count })
+    expect(request.error).to eq(Doorkeeper::Errors::InvalidGrant)
+  end
+
+  it "passes the client, resource owner, scopes and verified claims to jwt_bearer_authorize" do
+    seen = {}
+    configure_jwt_bearer(
+      resource_owner: owner,
+      issuer_key: rsa.public_key,
+      authorize: lambda do |c, o, s, claims|
+        seen[:client] = c
+        seen[:owner] = o
+        seen[:scopes] = s
+        seen[:claims] = claims
+        true
+      end,
+    )
+
+    request.authorize
+
+    expect(seen[:client]).to eq(client)
+    expect(seen[:owner]).to eq(owner)
+    expect(seen[:claims]["iss"]).to eq(issuer)
+  end
+
+  context "with scopes" do
+    let(:default_scopes) { Doorkeeper::OAuth::Scopes.from_string("read write") }
+
+    before do
+      allow(server).to receive_messages(default_scopes: default_scopes, scopes: default_scopes)
+    end
+
+    it "narrows the assertion scope to the requested scope" do
+      request = described_class.new(
+        server, client, make_assertion(payload: { "scope" => "read write" }), { scope: "read" },
+      )
+
+      request.authorize
+
+      expect(Doorkeeper::AccessToken.last.scopes).to eq(Doorkeeper::OAuth::Scopes.from_array(["read"]))
+    end
+
+    it "uses the assertion scope as-is when no scope is requested" do
+      request = described_class.new(server, client, make_assertion(payload: { "scope" => "read write" }), {})
+
+      request.authorize
+
+      expect(Doorkeeper::AccessToken.last.scopes).to eq(Doorkeeper::OAuth::Scopes.from_array(%w[read write]))
+    end
+
+    it "rejects a request for scope broader than the assertion grants" do
+      request = described_class.new(
+        server, client, make_assertion(payload: { "scope" => "read" }), { scope: "read write" },
+      )
+
+      request.authorize
+
+      expect(request.error).to eq(Doorkeeper::Errors::InvalidScope)
+    end
+  end
+end

--- a/spec/requests/endpoints/jwt_bearer_spec.rb
+++ b/spec/requests/endpoints/jwt_bearer_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "openssl"
+require "jwt"
+
+RSpec.describe "JWT Bearer (ID-JAG) grant" do
+  let(:rsa) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:issuer) { "https://idp.example.com" }
+  let(:audience) { "https://rs.example.com" }
+
+  def make_assertion(key, subject:, client_id:, alg: "RS256", payload: {})
+    now = Time.now.to_i
+    claims = {
+      "iss" => issuer, "sub" => subject, "aud" => audience, "client_id" => client_id,
+      "jti" => SecureRandom.hex(8), "exp" => now + 300, "iat" => now,
+    }.merge(payload)
+    JWT.encode(claims, key, alg, { typ: "oauth-id-jag+jwt" })
+  end
+
+  before do
+    client_exists(confidential: true)
+    create_resource_owner
+
+    config_is_set(:grant_flows, %w[jwt_bearer])
+    config_is_set(:jwt_bearer_audience, audience)
+    config_is_set(:jwt_bearer_trusted_issuer, ->(iss) { iss == issuer })
+    config_is_set(:jwt_bearer_issuer_key, ->(_iss, _kid) { rsa.public_key })
+    config_is_set(:jwt_bearer_resource_owner_from_assertion, ->(_iss, _sub, _client) { @resource_owner })
+  end
+
+  it "issues an access token for a valid assertion, with a confidential client" do
+    assertion = make_assertion(rsa, subject: @resource_owner.name, client_id: @client.uid)
+
+    post "/oauth/token",
+         params: { grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer", assertion: assertion },
+         headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(@client) }
+
+    expect(response).to have_http_status(:ok)
+    expect(json_response).to include("access_token")
+    expect(json_response).not_to include("refresh_token")
+    expect(Doorkeeper::AccessToken.first.application_id).to eq(@client.id)
+  end
+
+  it "rejects a public client by default" do
+    client_exists(confidential: false)
+    assertion = make_assertion(rsa, subject: @resource_owner.name, client_id: @client.uid)
+
+    post "/oauth/token",
+         params: { grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer", assertion: assertion },
+         headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(@client) }
+
+    expect(json_response).to include("error" => "unauthorized_client")
+  end
+
+  it "rejects a replayed assertion when a replay store is configured" do
+    store = Object.new
+    def store.consume(jti, _iss, _exp)
+      @seen ||= {}
+      return false if @seen[jti]
+
+      @seen[jti] = true
+      true
+    end
+    config_is_set(:jwt_bearer_replay_store, store)
+
+    assertion = make_assertion(rsa, subject: @resource_owner.name, client_id: @client.uid)
+
+    post "/oauth/token",
+         params: { grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer", assertion: assertion },
+         headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(@client) }
+    expect(response).to have_http_status(:ok)
+
+    post "/oauth/token",
+         params: { grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer", assertion: assertion },
+         headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(@client) }
+    expect(json_response).to include("error" => "invalid_grant")
+  end
+
+  it "rejects a tampered signature" do
+    assertion = make_assertion(rsa, subject: @resource_owner.name, client_id: @client.uid)
+    tampered = "#{assertion[0..-2]}#{assertion[-1] == "A" ? "B" : "A"}"
+
+    post "/oauth/token",
+         params: { grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer", assertion: tampered },
+         headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(@client) }
+
+    expect(json_response).to include("error" => "invalid_grant")
+  end
+
+  it "narrows scope to the intersection of requested and assertion scope" do
+    config_is_set(:default_scopes, Doorkeeper::OAuth::Scopes.from_string("read write"))
+    assertion = make_assertion(rsa, subject: @resource_owner.name, client_id: @client.uid, payload: { "scope" => "read write" })
+
+    post "/oauth/token",
+         params: { grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer", assertion: assertion, scope: "read" },
+         headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(@client) }
+
+    expect(response).to have_http_status(:ok)
+    expect(Doorkeeper::AccessToken.first.scopes).to eq(Doorkeeper::OAuth::Scopes.from_array(["read"]))
+  end
+
+  it "rejects a request missing the assertion parameter" do
+    post "/oauth/token",
+         params: { grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer" },
+         headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(@client) }
+
+    expect(json_response).to include("error" => "invalid_request")
+  end
+
+  it "rejects an assertion from an untrusted issuer" do
+    assertion = make_assertion(rsa, subject: @resource_owner.name, client_id: @client.uid, payload: { "iss" => "https://evil.example.com" })
+
+    post "/oauth/token",
+         params: { grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer", assertion: assertion },
+         headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(@client) }
+
+    expect(json_response).to include("error" => "invalid_grant")
+  end
+
+  it "rejects a request with the wrong client_secret, even with an otherwise-valid assertion" do
+    assertion = make_assertion(rsa, subject: @resource_owner.name, client_id: @client.uid)
+
+    post "/oauth/token",
+         params: {
+           grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+           assertion: assertion,
+           client_id: @client.uid,
+           client_secret: "wrong-secret",
+         }
+
+    expect(response).to have_http_status(:unauthorized)
+    expect(json_response).to include("error" => "invalid_client")
+    expect(Doorkeeper::AccessToken.count).to be_zero
+  end
+
+  it "returns unsupported_grant_type when the jwt_bearer flow is not enabled" do
+    config_is_set(:grant_flows, %w[client_credentials])
+    assertion = make_assertion(rsa, subject: @resource_owner.name, client_id: @client.uid)
+
+    post "/oauth/token",
+         params: { grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer", assertion: assertion },
+         headers: { "HTTP_AUTHORIZATION" => basic_auth_header_for_client(@client) }
+
+    expect(json_response).to include("error" => "unsupported_grant_type")
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `jwt-bearer` grant (`urn:ietf:params:oauth:grant-type:jwt-bearer`, RFC 7523) profiled by the [Identity Assertion Authorization Grant (ID-JAG) draft](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/), letting Doorkeeper act as the **Resource Authorization Server** side of a Cross App Access exchange: it verifies an ID-JAG assertion minted by an external Identity Provider and issues a locally-scoped access token. Minting the ID-JAG itself (the IdP side, RFC 8693 Token Exchange) is out of scope.

This mirrors equivalent PRs already up for the Node.js (`node-oauth2-server`), Python (`authlib`) and Go (`go-oauth2/oauth2`) OAuth2 libraries as part of the same cross-ecosystem Cross App Access rollout.

## Design

- **Not enabled by default** — add `:jwt_bearer` to `grant_flows` to opt in, same as every other non-default flow.
- **Client authentication is inherited "for free".** Doorkeeper resolves and authenticates the client (including `client_secret` verification) generically in `Server#client`, *before* any grant-specific request class runs — same as every other grant type. This new grant additionally checks `client.confidential` and rejects public clients by default per ID-JAG §8.1 (relaxable via `jwt_bearer_allow_public_clients`, not recommended for production).
- **Uses the `jwt` gem** (new runtime dependency) rather than hand-rolling JWS verification — it already provides `aud`/`exp`/`nbf` claim validation with configurable leeway and a `verify_jti` hook, which this grant wires up to an optional pluggable replay store.
- **Scope is narrowed, never expanded**: the assertion's own `scope` claim (if present) is a ceiling on what the request can ask for, matching RFC 6749 §3.3 narrowing semantics used elsewhere in this gem (e.g. refresh tokens).
- **Never issues a refresh token** (ID-JAG §4.4.3) — bypasses the generic `find_or_create_access_token` helper (whose `use_refresh_token` derives from the global `refresh_token_enabled?` setting) and calls the token model directly with `use_refresh_token: false`, the same approach `ClientCredentialsRequest` already uses.
- **Non-leaky errors**: every assertion-validation failure (bad `typ`, disallowed `alg`, untrusted issuer, unresolvable key, bad signature, claim mismatch, replay) funnels into the same `Result` failure value and the same `Errors::InvalidGrant`, so a response can't be used to distinguish which check failed.
- New `jwt_bearer_*` config/options live in their own file (`lib/doorkeeper/config/jwt_bearer.rb`, reopening `Doorkeeper::Config`) rather than growing the already-near-the-limit `lib/doorkeeper/config.rb` further.

## Involved parts of the project

- `lib/doorkeeper/oauth/helpers/jwt_bearer_assertion.rb` (new) — the decode/verify pipeline.
- `lib/doorkeeper/oauth/jwt_bearer_access_token_request.rb`, `lib/doorkeeper/request/jwt_bearer.rb` (new) — the grant/strategy, following the existing `BaseRequest`/`Strategy` pattern (modeled closely on `PasswordAccessTokenRequest`/`ClientCredentialsRequest`).
- `lib/doorkeeper/grant_flow.rb` — registers the new flow.
- `lib/doorkeeper/config/jwt_bearer.rb` (new), `lib/doorkeeper/config/validations.rb` — new config options + a boot-time warning if `:jwt_bearer` is enabled without `jwt_bearer_audience` configured.
- `lib/doorkeeper.rb`, `lib/doorkeeper/oauth.rb` — autoload wiring + the new `JWT_BEARER` grant-type constant.
- `doorkeeper.gemspec` — new runtime dependency on `jwt` (`>= 2.7`).

**OAuth2 workflow involved:** token endpoint only (`grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`). No changes to the authorization or revocation/introspection endpoints.

## Added tests?

Yes:
- `spec/lib/oauth/helpers/jwt_bearer_assertion_spec.rb` — unit coverage of the decode/verify helper (23 examples): RS256/ES256/PS256, `typ` confusion, `alg` allow-list (`none`/`HS256`), untrusted issuer, unresolvable key, tampered signature, audience mismatch, expired/future/clock-skew-boundary timestamps, missing claims, `client_id` mismatch, replay (with and without a configured store), PEM/JWK/multi-candidate-key resolver shapes.
- `spec/lib/oauth/jwt_bearer_access_token_request_spec.rb` — request-class unit tests (13 examples): client/public-client/assertion/resource-owner/authorize-hook validation, scope narrowing, no-refresh-token issuance.
- `spec/requests/endpoints/jwt_bearer_spec.rb` — full end-to-end `POST /oauth/token` coverage (9 examples), including proving client authentication is genuinely enforced (**wrong `client_secret` is rejected even with an otherwise-valid assertion**).

`bundle exec rake spec` (1536 examples, 0 failures) and `bundle exec rubocop` are clean on all touched files (the one remaining `Lint/MissingSuper` warning on the new request class matches the same, already-unaddressed pattern in `PasswordAccessTokenRequest`).

## OAuth2 standard

- [RFC 7523](https://www.rfc-editor.org/rfc/rfc7523) — JWT Bearer grant.
- [ID-JAG draft](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/) — the profile this grant implements (type header, required claims, audience-as-issuer-identifier, scope narrowing, no-refresh-token, confidential-client-only, replay protection referenced directly in code comments).
- RFC 6749 §5.2 — all failures map to existing `Errors::*` classes; no new error classes were needed.

## Reproduction

```ruby
Doorkeeper.configure do
  grant_flows %w[jwt_bearer]
  jwt_bearer_audience "https://your-resource-server.example.com"
  jwt_bearer_trusted_issuer { |issuer| MyIdpRegistry.trusted?(issuer) }
  jwt_bearer_issuer_key { |issuer, kid| MyIdpRegistry.jwks_for(issuer, kid) }
  jwt_bearer_resource_owner_from_assertion { |issuer, subject, client| User.find_by(federated_id: subject) }
end
```
```
POST /oauth/token
grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<ID-JAG JWT>
```
See `spec/requests/endpoints/jwt_bearer_spec.rb` for a fully worked example (mints a self-signed test assertion and exchanges it end-to-end).

---

Opening as a **Draft PR** for early feedback on the design (particularly the new `jwt` dependency and the confidential-client-only default) before polishing further.
