### PR TITLE
[test] Document `reuse_access_token` matching scope and pin it with a regression spec [#1693]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ User-visible changes worth mentioning.
 - [#1855] Perform the fallback secret upgrade-on-access write (plain → hashed token or application secret) through the primary database role, so `enable_multiple_database_roles` setups no longer attempt the write on a read replica when the lookup happens in a request routed to the reading role.
 - [#1857] Pin with regression specs that a `+` between scopes in a form-encoded token request is decoded as a space (so `scope=public+write` refreshes fine), while a percent-encoded literal `+` (`%2B`) names a single scope and is rejected when unknown, per RFC 6749 §3.3. Test-only change, closes [#1686].
 - [#1859] Pin with regression specs that a refresh token bound to an expired access token can be revoked (fixed by [#1744]) and that the revoked refresh token is rejected at the token endpoint afterwards. Test-only change, closes [#1671].
+- [#1862] Document that with `reuse_access_token` enabled token matching considers only the application, resource owner, scopes and custom token attributes — separate authorization grants for the same combination intentionally share one access token — and pin the behavior with a regression spec. Docs/test-only change, closes [#1693].
 - Please add here
 
 ## 5.9.3

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -150,6 +150,15 @@ Doorkeeper.configure do
   # token found for the application, resources owner and/or set of scopes.
   # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
   #
+  # Matching considers only the application, resource owner, scopes, custom access token
+  # attributes (see +custom_access_token_attributes+) and whether a refresh token is
+  # expected — not the authorization request that produced the token. Separate authorization
+  # grants for the same combination share a single access token, so concurrent sessions of
+  # the same client become interdependent (e.g. refreshing the token in one session revokes
+  # it for the others). If you need independent tokens per session or device, keep this
+  # option disabled or differentiate the sessions with +custom_access_token_attributes+.
+  # See https://github.com/doorkeeper-gem/doorkeeper/issues/1693
+  #
   # You can not enable this option together with +hash_token_secrets+.
   #
   # reuse_access_token

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -179,6 +179,33 @@ feature "Authorization Code Flow" do
     )
   end
 
+  # Regression test for #1693: `reuse_access_token` matches tokens by
+  # application, resource owner, scopes and custom token attributes — it does
+  # not track which authorization grant produced the token. Exchanging two
+  # independently issued grants for the same combination therefore yields one
+  # shared access token by design.
+  scenario "separate authorization grants share the access token when token reuse is enabled" do
+    config_is_set(:reuse_access_token, true)
+
+    visit authorization_endpoint_url(client: @client)
+    click_on "Authorize"
+    create_access_token Doorkeeper::AccessGrant.first.token, @client
+    first_token = json_response.fetch("access_token")
+
+    # A valid matching token now exists, so the second authorization request
+    # skips the consent screen and immediately redirects back with a new grant.
+    visit authorization_endpoint_url(client: @client)
+    i_should_be_on_client_callback(@client)
+
+    second_grant = Doorkeeper::AccessGrant.order(:id).last
+    expect(second_grant.token).not_to eq(Doorkeeper::AccessGrant.order(:id).first.token)
+
+    create_access_token second_grant.token, @client
+
+    expect(Doorkeeper::AccessToken.count).to eq(1)
+    expect(json_response).to include("access_token" => first_token)
+  end
+
   # RFC 6749 does not define a scope parameter for the authorization_code
   # token request (§4.1.3): access token scopes always come from the
   # authorization grant, and a scope parameter sent to the token endpoint


### PR DESCRIPTION
Closes #1693.

### What

With `reuse_access_token` enabled, token matching considers only the **application, resource owner, scopes and custom token attributes** (plus whether a refresh token is expected, since #1850) — it does not track which authorization grant produced the token. Exchanging two independently issued authorization codes for the same combination therefore returns one shared access token.

As confirmed in the issue discussion, this is intended behavior (rationale in #383), but it surprises users running concurrent sessions of the same client: the sessions become interdependent, and refreshing the shared token in one session revokes it for the others.

This PR treats the confusion as a documentation gap:

- **Initializer template**: the `reuse_access_token` section now spells out what matching is based on, warns that separate authorization grants share a single token (with the concurrent-sessions consequence), and points to the workarounds — keep the option disabled, or differentiate sessions via `custom_access_token_attributes`.
- **Regression spec**: a new authorization_code flow scenario pins the shared-token behavior end-to-end (two separate grants → one access token), so any future change to the matching semantics is caught deliberately rather than by accident.

### Why no behavior change

`reuse_access_token` explicitly trades per-grant token isolation for fewer rows in `oauth_access_tokens`. Making it grant-aware would defeat its purpose; users who need independent token chains already have supported paths (the custom-attributes path is covered by model specs since #1853).

Docs/test-only change.