### PR TITLE
Carry custom access token attributes through the consent screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ User-visible changes worth mentioning.
 - [#1857] Pin with regression specs that a `+` between scopes in a form-encoded token request is decoded as a space (so `scope=public+write` refreshes fine), while a percent-encoded literal `+` (`%2B`) names a single scope and is rejected when unknown, per RFC 6749 §3.3. Test-only change, closes [#1686].
 - [#1859] Pin with regression specs that a refresh token bound to an expired access token can be revoked (fixed by [#1744]) and that the revoked refresh token is rejected at the token endpoint afterwards. Test-only change, closes [#1671].
 - [#1862] Document that with `reuse_access_token` enabled token matching considers only the application, resource owner, scopes and custom token attributes — separate authorization grants for the same combination intentionally share one access token — and pin the behavior with a regression spec. Docs/test-only change, closes [#1693].
+- [#1864] Fix `custom_access_token_attributes` values being dropped when the authorization goes through the consent screen: the approve/deny forms now carry the custom attributes as hidden fields, and the pre-authorization JSON (`api_only` mode) includes them so custom consent UIs can send them back.
 - Please add here
 
 ## 5.9.3

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -29,6 +29,9 @@
       <%= hidden_field_tag :scope, @pre_auth.scope, id: nil %>
       <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge, id: nil %>
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
+      <% @pre_auth.custom_access_token_attributes.each do |attribute_name, attribute_value| %>
+        <%= hidden_field_tag attribute_name, attribute_value, id: nil %>
+      <% end %>
       <%= submit_tag t('doorkeeper.authorizations.buttons.authorize'), class: "btn btn-success btn-lg btn-block" %>
     <% end %>
     <%= form_tag oauth_authorization_path, method: :delete do %>
@@ -40,6 +43,9 @@
       <%= hidden_field_tag :scope, @pre_auth.scope, id: nil %>
       <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge, id: nil %>
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
+      <% @pre_auth.custom_access_token_attributes.each do |attribute_name, attribute_value| %>
+        <%= hidden_field_tag attribute_name, attribute_value, id: nil %>
+      <% end %>
       <%= submit_tag t('doorkeeper.authorizations.buttons.deny'), class: "btn btn-danger btn-lg btn-block" %>
     <% end %>
   </div>

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -187,7 +187,7 @@ module Doorkeeper
           scope: scope,
           client_name: client.name,
           status: I18n.t("doorkeeper.pre_authorization.status"),
-        }
+        }.reverse_merge(custom_access_token_attributes.symbolize_keys)
       end
     end
   end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -286,6 +286,18 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
     end
   end
 
+  describe "as_json with custom access token attributes" do
+    before do
+      allow(Doorkeeper.config).to receive(:custom_access_token_attributes).and_return([:tenant_name])
+      attributes[:tenant_name] = "alpha"
+    end
+
+    it "includes the custom attributes in the pre authorization" do
+      expect(pre_auth).to be_authorizable
+      expect(pre_auth.as_json).to include(tenant_name: "alpha")
+    end
+  end
+
   describe "#form_post_response?" do
     it { is_expected.to respond_to(:form_post_response?) }
 

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -654,6 +654,35 @@ feature "Authorization Code Flow" do
     end
   end
 
+  context "when custom_access_token_attributes are requested through the consent screen" do
+    background do
+      config_is_set(:custom_access_token_attributes, [:tenant_name])
+    end
+
+    scenario "custom attributes are carried through the consent form into the grant and token" do
+      visit "#{authorization_endpoint_url(client: @client)}&tenant_name=alpha"
+      click_on "Authorize"
+
+      access_grant_should_exist_for(@client, @resource_owner)
+
+      grant = Doorkeeper::AccessGrant.first
+      expect(grant.tenant_name).to eq("alpha")
+
+      create_access_token grant.token, @client
+
+      access_token = Doorkeeper::AccessToken.find_by(token: json_response["access_token"])
+      expect(access_token.tenant_name).to eq("alpha")
+    end
+
+    scenario "consent form omits custom attribute fields when none are supplied" do
+      visit authorization_endpoint_url(client: @client)
+      click_on "Authorize"
+
+      access_grant_should_exist_for(@client, @resource_owner)
+      expect(Doorkeeper::AccessGrant.first.tenant_name).to be_nil
+    end
+  end
+
   context "when custom_access_token_attributes are configured" do
     let(:resource_owner) { FactoryBot.create(:resource_owner) }
     let(:client) { client_exists }


### PR DESCRIPTION
Fixes #1863.

### Summary

`custom_access_token_attributes` present on the `GET /oauth/authorize` request were dropped whenever the flow went through the consent screen: the approve/deny forms in `authorizations/new.html.erb` only forward the standard OAuth parameters, so the `POST /oauth/authorize` built a fresh `PreAuthorization` without them and the grant/token stored `nil`. Auto-approved flows (`skip_authorization`, matching token) were unaffected, which is why the existing factory-based specs never caught it.

### Changes

- `app/views/doorkeeper/authorizations/new.html.erb`: render a hidden field per configured custom attribute (from `@pre_auth.custom_access_token_attributes`) in both the approve and the deny form. The controller already permits these params (`pre_auth_param_fields`), so no controller change is needed.
- `lib/doorkeeper/oauth/pre_authorization.rb`: include the custom attributes in `#as_json` (`pre_auth_hash`), so `api_only` consumers that build their own consent UI from the pre-authorization JSON can send the values back with the approval request. Reserved keys win over a colliding custom attribute name (`reverse_merge`).
- Specs:
  - feature spec driving the real consent flow (authorization request with a custom attribute → consent form → grant → token exchange), plus a no-attribute case pinning that nothing leaks when the attribute isn't supplied;
  - `PreAuthorization#as_json` spec for the new key.
- CHANGELOG entry.

The new feature spec fails without the view change (`grant.tenant_name` is `nil`).