### PR TITLE
Revoke issued tokens when an authorization code is reused [#1713]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#1865] Revoke the token issued for an authorization code when the code is exchanged more than once, per RFC 6749 §4.1.2 / §10.5. Active when the `oauth_access_grants.access_token_id` column exists: new installs get it from the generated migration, existing apps can add it with `rails generate doorkeeper:grant_reuse_revocation`. Closes [#1713].
 - Please add here
 
 ## 6.0.0.beta1
@@ -47,7 +48,6 @@ and changelog below before the update since this version includes breaking chang
 - [#1864] Fix `custom_access_token_attributes` values being dropped when the authorization goes through the consent screen: the approve/deny forms now carry the custom attributes as hidden fields, and the pre-authorization JSON (`api_only` mode) includes them so custom consent UIs can send them back.
 - [#1869] Improve test coverage
 - [#1870] Fix: raise the intended `Doorkeeper::Errors::TokenGeneratorNotFound` / `UnableToGenerateToken` (instead of a confusing `NameError`) when `application_secret_generator` is misconfigured.
-- Please add here
 
 ## 5.9.3
 

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -100,6 +100,15 @@ module Doorkeeper
         column_names.include?("code_challenge")
       end
 
+      # Replay protection for authorization codes (RFC 6749 §4.1.2, §10.5)
+      # is active only when the `access_token_id` column exists (added by
+      # the `doorkeeper:grant_reuse_revocation` generator): the column
+      # records the access token issued when the code was exchanged, so a
+      # second exchange attempt can revoke it.
+      def access_token_revoked_on_reuse?
+        column_names.include?("access_token_id")
+      end
+
       ##
       # Determines the secret storing transformer
       # Unless configured otherwise, uses the plain secret strategy

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -9,6 +9,9 @@ module Doorkeeper
       # @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
       validate :redirect_uri, error: Errors::InvalidGrant
       validate :code_verifier, error: Errors::InvalidGrant
+      # Runs last, so the single-use enforcement it performs only acts once
+      # the caller has proven possession of the code (redirect_uri + PKCE).
+      validate :grant_accessible, error: Errors::InvalidGrant
 
       attr_reader :grant, :client, :redirect_uri, :access_token, :code_verifier,
                   :invalid_request_reason, :missing_param
@@ -46,9 +49,18 @@ module Doorkeeper
             custom_token_attributes_with_data,
             server,
           )
+
+          link_access_token_to_grant
         end
 
         super
+      rescue Errors::InvalidGrantReuse
+        # A concurrent exchange of the same code won the race: the raise
+        # rolled this transaction back, so the revocation must happen
+        # outside of it. `lock!` reloaded the grant after the winning
+        # exchange committed, so the token linkage is visible here.
+        revoke_token_issued_for_grant
+        raise
       end
 
       def resource_owner
@@ -81,7 +93,16 @@ module Doorkeeper
       end
 
       def validate_grant
-        return false unless grant && grant.application_id == client.id
+        grant && grant.application_id == client.id
+      end
+
+      # Checked after redirect_uri and PKCE so that a caller who cannot prove
+      # possession of the code never reaches the reuse handling below.
+      def validate_grant_accessible
+        # Authorization codes are single-use (RFC 6749 §4.1.2): observing a
+        # second exchange attempt denies the request and revokes the tokens
+        # already issued for the code (§10.5).
+        revoke_token_issued_for_grant if grant.revoked?
 
         grant.accessible?
       end
@@ -122,6 +143,22 @@ module Doorkeeper
 
       def revoke_previous_tokens(application, resource_owner)
         Doorkeeper.config.access_token_model.revoke_all_for(application.id, resource_owner)
+      end
+
+      def link_access_token_to_grant
+        return unless grant.class.access_token_revoked_on_reuse?
+
+        grant.class.with_primary_role do
+          grant.update_column(:access_token_id, access_token.id)
+        end
+      end
+
+      def revoke_token_issued_for_grant
+        return unless grant.class.access_token_revoked_on_reuse?
+        return if grant.access_token_id.blank?
+
+        token = Doorkeeper.config.access_token_model.find_by(id: grant.access_token_id)
+        token&.revoke
       end
     end
   end

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -157,8 +157,12 @@ module Doorkeeper
         return unless grant.class.access_token_revoked_on_reuse?
         return if grant.access_token_id.blank?
 
-        token = Doorkeeper.config.access_token_model.find_by(id: grant.access_token_id)
-        token&.revoke
+        # Look the token up on the primary too: a lagging read replica may not
+        # have it yet, which would silently skip the revocation.
+        Doorkeeper.config.access_token_model.with_primary_role do
+          token = Doorkeeper.config.access_token_model.find_by(id: grant.access_token_id)
+          token&.revoke
+        end
       end
     end
   end

--- a/lib/generators/doorkeeper/grant_reuse_revocation_generator.rb
+++ b/lib/generators/doorkeeper/grant_reuse_revocation_generator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Doorkeeper
+  # Generates migration to add the access token reference column to the
+  # access grants table, enabling revocation of previously issued tokens
+  # when an authorization code is reused (RFC 6749 §4.1.2, §10.5).
+  #
+  class GrantReuseRevocationGenerator < ::Rails::Generators::Base
+    include ::Rails::Generators::Migration
+    source_root File.expand_path("templates", __dir__)
+    desc "Support revoking issued tokens on authorization code reuse"
+
+    def self.next_migration_number(path)
+      ActiveRecord::Generators::Base.next_migration_number(path)
+    end
+
+    def grant_reuse_revocation
+      return unless no_access_token_id_column?
+
+      migration_template(
+        "add_access_token_to_access_grants.rb.erb",
+        "db/migrate/add_access_token_to_access_grants.rb",
+        migration_version: migration_version,
+      )
+    end
+
+    private
+
+    def migration_version
+      "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+    end
+
+    def no_access_token_id_column?
+      !ActiveRecord::Base.connection.column_exists?(
+        :oauth_access_grants,
+        :access_token_id,
+      )
+    end
+  end
+end

--- a/lib/generators/doorkeeper/templates/add_access_token_to_access_grants.rb.erb
+++ b/lib/generators/doorkeeper/templates/add_access_token_to_access_grants.rb.erb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddAccessTokenToAccessGrants < ActiveRecord::Migration<%= migration_version %>
+  def change
+    # No index: the column is only read back from an already-loaded grant,
+    # never used to filter queries.
+    add_reference :oauth_access_grants, :access_token, index: false
+  end
+end

--- a/lib/generators/doorkeeper/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/migration.rb.erb
@@ -28,6 +28,18 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
       t.string   :scopes,            null: false, default: ''
       t.datetime :created_at,        null: false
       t.datetime :revoked_at
+
+      # Authorization codes are single-use (RFC 6749 §4.1.2). Doorkeeper
+      # records the access token issued when the code is exchanged, so that
+      # a second exchange attempt revokes the previously issued tokens as
+      # recommended by RFC 6749 §10.5.
+      #
+      # Comment out this line if you don't want a reused authorization code
+      # to revoke the tokens already issued for it.
+      #
+      # No index: the column is only read back from an already-loaded grant,
+      # never used to filter queries.
+      t.references :access_token,    index: false
     end
 
     add_index :oauth_access_grants, :token, unique: true

--- a/spec/dummy/db/migrate/20260716000000_add_access_token_to_access_grants.rb
+++ b/spec/dummy/db/migrate/20260716000000_add_access_token_to_access_grants.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAccessTokenToAccessGrants < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :oauth_access_grants, :access_token, index: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20230205064514) do
+ActiveRecord::Schema.define(version: 20260716000000) do
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20230205064514) do
     t.datetime "revoked_at"
     t.string "scopes"
     t.string "tenant_name"
+    t.bigint "access_token_id"
     unless ENV["WITHOUT_PKCE"]
       t.string   "code_challenge"
       t.string   "code_challenge_method"

--- a/spec/generators/grant_reuse_revocation_generator_spec.rb
+++ b/spec/generators/grant_reuse_revocation_generator_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "generators/doorkeeper/grant_reuse_revocation_generator"
+
+RSpec.describe Doorkeeper::GrantReuseRevocationGenerator do
+  include GeneratorSpec::TestCase
+
+  tests described_class
+  destination ::File.expand_path("tmp/dummy", __dir__)
+
+  # Stub the database column check that backs
+  # GrantReuseRevocationGenerator#no_access_token_id_column? rather than
+  # stubbing that private method directly (see the note in
+  # previous_refresh_token_generator_spec.rb about Thor's `method_added`).
+  def stub_access_token_id_column(exists:)
+    allow(ActiveRecord::Base.connection).to receive(:column_exists?).and_call_original
+    allow(ActiveRecord::Base.connection)
+      .to(receive(:column_exists?)
+      .with(:oauth_access_grants, :access_token_id)
+      .and_return(exists))
+  end
+
+  describe "after running the generator" do
+    before do
+      prepare_destination
+    end
+
+    it "creates a migration with a version specifier" do
+      stub_access_token_id_column(exists: false)
+
+      stub_const("ActiveRecord::VERSION::MAJOR", 5)
+      stub_const("ActiveRecord::VERSION::MINOR", 0)
+
+      run_generator
+
+      assert_migration "db/migrate/add_access_token_to_access_grants.rb" do |migration|
+        assert migration.include?("ActiveRecord::Migration[5.0]\n")
+      end
+    end
+
+    context "when the column already exists" do
+      it "does not create a migration" do
+        stub_access_token_id_column(exists: true)
+
+        run_generator
+
+        assert_no_migration "db/migrate/add_access_token_to_access_grants.rb"
+      end
+    end
+  end
+end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -155,6 +155,100 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
     expect(response.token.plaintext_refresh_token).to be_present
   end
 
+  context "when the authorization code is reused (RFC 6749 §4.1.2)" do
+    it "records the issued access token on the grant" do
+      request.authorize
+
+      expect(grant.reload.access_token_id).to eq(request.access_token.id)
+    end
+
+    it "revokes the token issued for the code when it is exchanged a second time" do
+      request.authorize
+      issued_token = request.access_token
+
+      replay = described_class.new(server, grant.reload, client, params)
+      replay.validate
+
+      expect(replay.error).to eq(Doorkeeper::Errors::InvalidGrant)
+      expect(issued_token.reload).to be_revoked
+    end
+
+    it "revokes the reused access token when reuse_access_token is enabled" do
+      scopes = grant.scopes
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        reuse_access_token
+        default_scopes(*scopes)
+      end
+
+      existing_token = FactoryBot.create(
+        :access_token,
+        application_id: client.id,
+        resource_owner_id: grant.resource_owner_id,
+        resource_owner_type: grant.resource_owner_type,
+        scopes: grant.scopes.to_s,
+      )
+
+      request.authorize
+
+      expect(grant.reload.access_token_id).to eq(existing_token.id)
+
+      replay = described_class.new(server, grant.reload, client, params)
+      replay.validate
+
+      expect(existing_token.reload).to be_revoked
+    end
+
+    it "revokes the winning exchange's token when losing the race for the same code" do
+      issued_token = FactoryBot.create(
+        :access_token,
+        application_id: client.id,
+        resource_owner_id: grant.resource_owner_id,
+        resource_owner_type: grant.resource_owner_type,
+      )
+
+      # Simulate a concurrent exchange committing between validation and the
+      # row lock: the reload performed by `lock!` reveals the revoked grant
+      # with its token linkage.
+      allow(grant).to receive(:lock!) do
+        grant.update_columns(revoked_at: Time.current, access_token_id: issued_token.id)
+      end
+
+      expect { request.authorize }.to raise_error(Doorkeeper::Errors::InvalidGrantReuse)
+      expect(issued_token.reload).to be_revoked
+    end
+
+    it "only denies the request when the access_token_id column is not available" do
+      request.authorize
+      issued_token = request.access_token
+
+      allow(Doorkeeper::AccessGrant).to receive(:access_token_revoked_on_reuse?).and_return(false)
+
+      replay = described_class.new(server, grant.reload, client, params)
+      replay.validate
+
+      expect(replay.error).to eq(Doorkeeper::Errors::InvalidGrant)
+      expect(issued_token.reload).not_to be_revoked
+    end
+
+    it "does not revoke the issued token when the replay cannot prove possession of the code" do
+      request.authorize
+      issued_token = request.access_token
+
+      # A replay that fails the redirect_uri check (RFC 6749 §4.1.3) is
+      # denied before the single-use enforcement runs, so it cannot revoke
+      # the token issued for the code without proving possession of it.
+      replay = described_class.new(
+        server, grant.reload, client, redirect_uri: "https://other.example/callback",
+      )
+      replay.validate
+
+      expect(replay.error).to eq(Doorkeeper::Errors::InvalidGrant)
+      expect(issued_token.reload).not_to be_revoked
+    end
+  end
+
   it "calls configured request callback methods" do
     expect(Doorkeeper.configuration.before_successful_strategy_response)
       .to receive(:call).with(request).once

--- a/spec/requests/flows/authorization_code_errors_spec.rb
+++ b/spec/requests/flows/authorization_code_errors_spec.rb
@@ -95,6 +95,17 @@ RSpec.describe "Authorization Code Flow Errors after authorization" do
     )
   end
 
+  it "revokes the token issued for the code when it is exchanged twice (RFC 6749 §4.1.2)" do
+    post token_endpoint_url, params: token_endpoint_params(code: @authorization.token, client: @client)
+
+    issued_token = Doorkeeper::AccessToken.by_token(json_response["access_token"])
+
+    post token_endpoint_url, params: token_endpoint_params(code: @authorization.token, client: @client)
+
+    expect(json_response).to include("error" => "invalid_grant")
+    expect(issued_token.reload).to be_revoked
+  end
+
   it "returns :invalid_grant error for invalid grant code" do
     post token_endpoint_url, params: token_endpoint_params(code: "invalid", client: @client)
 


### PR DESCRIPTION
## Summary

Fixes #1713. RFC 6749 §4.1.2 requires authorization codes to be single-use and says the authorization server SHOULD revoke (when possible) all tokens previously issued based on a code that is presented more than once; §10.5 lists the same behavior as a security consideration for compromised codes. Doorkeeper already denies the second exchange with `invalid_grant`, but the token issued by the first exchange stayed valid.

## Design

Doorkeeper had no link between a grant and the token its exchange produced, so this PR records one: a new **optional** `oauth_access_grants.access_token_id` column stores the id of the access token returned by the exchange, written inside the same locked transaction that revokes the grant.

The reference lives on the grant (not the token) deliberately:

- With `reuse_access_token`, an exchange can return a pre-existing token. A grant-side reference still captures exactly what the exchange handed out, so replaying that code revokes the right token. A token-side `grant_id` set at creation would miss this case.
- Grants are one-time-use, so one reference per grant is complete — "all tokens previously issued based on that authorization code" is always the single token (access + its refresh token, same record) the exchange returned.

Following the `previous_refresh_token` / PKCE convention, the behavior is **gated on column presence** (`AccessGrant.access_token_revoked_on_reuse?`):

- New installs get the column through the install migration template (with a comment explaining how to opt out).
- Existing apps opt in with the new generator: `rails generate doorkeeper:grant_reuse_revocation`.
- Without the column, behavior is unchanged.

Both replay-detection paths revoke the linked token:

1. The normal path — the request is denied with `invalid_grant` as before. Revocation is deferred to the last validation step (`validate_grant_accessible`, after the `redirect_uri` and PKCE checks), so a replay that cannot prove possession of the code is rejected *without* revoking anything. Only a caller that presents the correct `redirect_uri` and code verifier can trigger revocation.
2. The concurrency race — `Errors::InvalidGrantReuse` raised after `grant.lock!`. The revocation happens after the raise leaves the transaction, so the rollback cannot undo it (`lock!` has already reloaded the grant with the winning exchange's committed linkage).

Revoking an already-revoked token is a no-op (`Revocable#revoke` preserves the original `revoked_at`), so grants revoked through other flows (e.g. a user revoking an application) replay harmlessly.