### PR TITLE
ci: pin changelog-enforcer to v3.7.0 (node24 build)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Enforce changelog
         if: |
           steps.changes.outputs.gem_changes == 'true'
-        uses: dangoslen/changelog-enforcer@v3
+        uses: dangoslen/changelog-enforcer@v3.7.0
         with:
           changeLogPath: CHANGELOG.md
           skipLabels: "dependencies"


### PR DESCRIPTION
Companion to [doorkeeper-openid_connect#342](https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/342) — same change, applied to the core lib.

The changelog job uses the floating `dangoslen/changelog-enforcer@v3` tag, which still points at a **node20** build of the action. Every run therefore triggers GitHub's [Node 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). This PR pins the action to `v3.7.0`, the first release built for **node24**.

Unlike the openid_connect repo, no other changes are needed here:

- Dependabot already watches `github-actions` in this repo, so future releases of the action will arrive as regular dependency PRs (which is also why an exact pin stays maintainable).
- `skipLabels: "dependencies"` is already configured, so those Dependabot PRs are exempt from changelog enforcement.

## Changes

- `.github/workflows/changelog.yml`: `dangoslen/changelog-enforcer@v3` → `@v3.7.0`