### PR TITLE
Tests only — improve coverage to 99.6% line / 97.5% branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ User-visible changes worth mentioning.
 - [#1860] Fix introspection of refresh tokens (RFC 7662): a refresh token bound to an expired access token now introspects as `active: true`, matching the token endpoint which still accepts it. The introspection response for a presented refresh token no longer includes the paired access token's `token_type` and `exp`. Fixes [#1858].
 - [#1862] Document that with `reuse_access_token` enabled token matching considers only the application, resource owner, scopes and custom token attributes — separate authorization grants for the same combination intentionally share one access token — and pin the behavior with a regression spec. Docs/test-only change, closes [#1693].
 - [#1864] Fix `custom_access_token_attributes` values being dropped when the authorization goes through the consent screen: the approve/deny forms now carry the custom attributes as hidden fields, and the pre-authorization JSON (`api_only` mode) includes them so custom consent UIs can send them back.
+- [#1869] Improve test coverage
 - Please add here
 
 ## 5.9.3

--- a/spec/controllers/protected_resources_controller_spec.rb
+++ b/spec/controllers/protected_resources_controller_spec.rb
@@ -209,6 +209,32 @@ RSpec.describe "doorkeeper authorize filter" do
         expect(response.body).to eq("Unauthorized")
       end
     end
+
+    context "with an explicit layout in the custom render options", token: :invalid do
+      before do
+        module ControllerActions
+          remove_method :doorkeeper_unauthorized_render_options
+
+          def doorkeeper_unauthorized_render_options(**)
+            { plain: "Unauthorized", layout: false }
+          end
+        end
+      end
+
+      after do
+        module ControllerActions
+          remove_method :doorkeeper_unauthorized_render_options
+
+          def doorkeeper_unauthorized_render_options(error: nil); end
+        end
+      end
+
+      it "respects the layout provided by the render options", token: :invalid do
+        get :index, params: { access_token: token_string }
+        expect(response.status).to eq 401
+        expect(response.body).to eq("Unauthorized")
+      end
+    end
   end
 
   context "when custom forbidden render options are configured" do

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -55,6 +55,23 @@ RSpec.describe Doorkeeper::TokensController, type: :controller do
     end
   end
 
+  describe "POST #create when handle_auth_errors is set to :raise" do
+    before do
+      config_is_set(:handle_auth_errors, :raise)
+    end
+
+    it "renders the error response carried by the raised exception" do
+      post :create, params: {
+        client_id: "bogus",
+        client_secret: "bogus",
+        grant_type: "password",
+      }
+
+      expect(response.status).to eq(401)
+      expect(json["error"]).to eq("invalid_client")
+    end
+  end
+
   describe "POST #create with errors" do
     let(:grant_type) { "password" }
 

--- a/spec/lib/abstract_builder_spec.rb
+++ b/spec/lib/abstract_builder_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::Config::AbstractBuilder do
+  it "wraps the given config without requiring a block" do
+    config = Object.new
+    builder = described_class.new(config)
+
+    expect(builder.config).to be(config)
+  end
+
+  it "returns the config from #build, validating only when supported" do
+    config = Object.new
+    builder = described_class.new(config)
+
+    expect(builder.build).to be(config)
+  end
+end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -1365,4 +1365,178 @@ RSpec.describe Doorkeeper::Config do
       end
     end
   end
+
+  describe "deprecated_authorization_flows" do
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+      end
+    end
+
+    it "returns no flows when calculate_authorization_response_types is not patched" do
+      expect(config.deprecated_authorization_flows).to eq([])
+    end
+
+    it "warns and wraps patched response types into fallback flows" do
+      allow(Doorkeeper.config)
+        .to receive(:calculate_authorization_response_types).and_return(["custom_type"])
+
+      expect(Kernel).to receive(:warn).with(
+        /don't patch Doorkeeper::Config#calculate_authorization_response_types/,
+      )
+
+      flows = config.deprecated_authorization_flows
+
+      expect(flows.map(&:class)).to eq([Doorkeeper::GrantFlow::FallbackFlow])
+      expect(flows.first.name).to eq("custom_type")
+      expect(flows.first.matches_response_type?("custom_type")).to be(true)
+    end
+  end
+
+  describe "calculate_token_grant_types" do
+    it "includes refresh_token when refresh tokens are enabled" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        use_refresh_token
+      end
+
+      expect(config.calculate_token_grant_types).to include("refresh_token")
+    end
+
+    it "excludes implicit and refresh_token otherwise" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        grant_flows %w[authorization_code implicit]
+      end
+
+      expect(config.calculate_token_grant_types).to eq(%w[authorization_code])
+    end
+  end
+
+  describe "#clear_cache!" do
+    it "makes model resolution pick up configuration changes" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+      end
+
+      expect(config.access_token_model).to eq(Doorkeeper::AccessToken)
+
+      config_is_set(:access_token_class, "Doorkeeper::AccessGrant")
+      expect(config.access_token_model).to eq(Doorkeeper::AccessToken)
+
+      config.clear_cache!
+      expect(config.access_token_model).to eq(Doorkeeper::AccessGrant)
+    end
+  end
+
+  describe "hash_application_secrets with a custom fallback strategy" do
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        hash_application_secrets using: "::Doorkeeper::SecretStoring::BCrypt",
+                                 fallback: "::Doorkeeper::SecretStoring::Sha256Hash"
+      end
+    end
+
+    it "constantizes the custom fallback strategy" do
+      expect(config.application_secret_strategy).to eq(Doorkeeper::SecretStoring::BCrypt)
+      expect(config.application_secret_fallback_strategy).to eq(Doorkeeper::SecretStoring::Sha256Hash)
+    end
+  end
+
+  describe "pkce_code_challenge_methods_supported" do
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+      end
+    end
+
+    it "returns an empty array when the access grant model does not support PKCE" do
+      allow(config.access_grant_model).to receive(:pkce_supported?).and_return(false)
+
+      expect(config.pkce_code_challenge_methods_supported).to eq([])
+    end
+  end
+
+  describe "allow_token_introspection default policy" do
+    let(:policy) { config.allow_token_introspection }
+
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+      end
+    end
+
+    it "authorizes any client to introspect a token that has no application" do
+      token = double(application: nil)
+
+      expect(policy.call(token, double(id: 5), nil)).to be(true)
+    end
+
+    it "authorizes introspection of a missing token so the endpoint can answer active: false" do
+      expect(policy.call(nil, double(id: 5), nil)).to be(true)
+    end
+  end
+
+  describe "custom_metadata validation" do
+    it "warns and falls back to an empty hash for non-Hash values" do
+      expect(Rails.logger).to receive(:warn).with(/invalid value for custom_metadata/)
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        custom_metadata "not-a-hash"
+      end
+
+      expect(Doorkeeper.config.custom_metadata).to eq({})
+    end
+  end
+
+  describe "boolean flags set by the builder DSL" do
+    it "enables revoke_previous_client_credentials_token" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        revoke_previous_client_credentials_token
+      end
+
+      expect(config.revoke_previous_client_credentials_token?).to be(true)
+    end
+
+    it "enables revoke_previous_authorization_code_token" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        revoke_previous_authorization_code_token
+      end
+
+      expect(config.revoke_previous_authorization_code_token?).to be(true)
+    end
+
+    it "enables force_pkce" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        force_pkce
+      end
+
+      expect(config.force_pkce?).to be(true)
+    end
+
+    it "enables use_polymorphic_resource_owner" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        use_polymorphic_resource_owner
+      end
+
+      expect(config.polymorphic_resource_owner?).to be(true)
+    end
+  end
+
+  describe "issuer that cannot be parsed as a URI" do
+    it "warns about the non-compliant issuer" do
+      expect(Rails.logger).to receive(:warn).with(/is not RFC-compliant/)
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        issuer "not a valid uri"
+      end
+    end
+  end
 end

--- a/spec/lib/doorkeeper/orm/active_record/table_name_spec.rb
+++ b/spec/lib/doorkeeper/orm/active_record/table_name_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Doorkeeper table name computation" do
+  context "when pluralize_table_names is disabled" do
+    def doorkeeper_model(mixin)
+      Class.new(ApplicationRecord) do
+        self.pluralize_table_names = false
+        include mixin
+      end
+    end
+
+    it "uses the singular access grant table name" do
+      expect(doorkeeper_model(Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant).table_name)
+        .to eq("oauth_access_grant")
+    end
+
+    it "uses the singular access token table name" do
+      expect(doorkeeper_model(Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken).table_name)
+        .to eq("oauth_access_token")
+    end
+
+    it "uses the singular application table name" do
+      expect(doorkeeper_model(Doorkeeper::Orm::ActiveRecord::Mixins::Application).table_name)
+        .to eq("oauth_application")
+    end
+  end
+end

--- a/spec/lib/doorkeeper/rake_spec.rb
+++ b/spec/lib/doorkeeper/rake_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rake"
+
+RSpec.describe "doorkeeper rake tasks" do
+  before do
+    Rake::Task.define_task(:environment) unless Rake::Task.task_defined?(:environment)
+    Doorkeeper::Rake.load_tasks unless Rake::Task.task_defined?("doorkeeper:db:cleanup")
+  end
+
+  describe "doorkeeper:db:cleanup" do
+    it "removes revoked and expired tokens and grants, keeping active ones" do
+      revoked_token = FactoryBot.create(:access_token, revoked_at: 1.hour.ago)
+      expired_token = FactoryBot.create(:access_token, expires_in: 1, created_at: 10.days.ago)
+      active_token = FactoryBot.create(:access_token)
+      revoked_grant = FactoryBot.create(:access_grant, revoked_at: 1.hour.ago)
+      expired_grant = FactoryBot.create(:access_grant, expires_in: 1, created_at: 10.days.ago)
+
+      task = Rake::Task["doorkeeper:db:cleanup"]
+      task.all_prerequisite_tasks.each(&:reenable)
+      task.reenable
+      task.invoke
+
+      expect(Doorkeeper::AccessToken.exists?(revoked_token.id)).to be(false)
+      expect(Doorkeeper::AccessToken.exists?(expired_token.id)).to be(false)
+      expect(Doorkeeper::AccessToken.exists?(active_token.id)).to be(true)
+      expect(Doorkeeper::AccessGrant.exists?(revoked_grant.id)).to be(false)
+      expect(Doorkeeper::AccessGrant.exists?(expired_grant.id)).to be(false)
+    end
+
+    it "keeps expired tokens that carry a refresh token" do
+      refreshable_token = FactoryBot.create(
+        :access_token,
+        expires_in: 1,
+        created_at: 10.days.ago,
+        use_refresh_token: true,
+      )
+
+      task = Rake::Task["doorkeeper:db:cleanup:expired_tokens"]
+      task.reenable
+      task.invoke
+
+      expect(Doorkeeper::AccessToken.exists?(refreshable_token.id)).to be(true)
+    end
+  end
+end

--- a/spec/lib/doorkeeper_spec.rb
+++ b/spec/lib/doorkeeper_spec.rb
@@ -103,5 +103,49 @@ RSpec.describe Doorkeeper do
       end
       expect(filters.size).to eq(1)
     end
+
+    it "does nothing when Doorkeeper is not configured" do
+      allow(described_class).to receive(:configured?).and_return(false)
+
+      expect { described_class.setup_filter_parameters }
+        .not_to(change { Rails.application.config.filter_parameters })
+    end
+  end
+
+  describe "#setup" do
+    context "with a non-ActiveRecord ORM" do
+      after do
+        # Restore the real ActiveRecord adapter for the rest of the suite. The
+        # orm stub is still active in this hook, so the adapter is restored
+        # directly instead of re-running setup.
+        described_class.instance_variable_set(:@orm_adapter, Doorkeeper::Orm::ActiveRecord)
+      end
+
+      it "runs the deprecated model setup hooks" do
+        adapter = double
+        stub_const("Doorkeeper::Orm::FakeOrm", adapter)
+        allow(described_class.configuration).to receive(:orm).and_return(:fake_orm)
+
+        expect(adapter).to receive(:initialize_models!)
+        expect(adapter).to receive(:initialize_application_owner!)
+
+        described_class.setup
+      end
+    end
+  end
+
+  describe "#run_orm_hooks" do
+    after do
+      described_class.setup
+    end
+
+    it "warns when the ORM adapter does not implement run_hooks" do
+      legacy_adapter = double(name: "LegacyOrm")
+      described_class.instance_variable_set(:@orm_adapter, legacy_adapter)
+
+      expect(Kernel).to receive(:warn).with(/setup logic under `#run_hooks` method/)
+
+      described_class.run_orm_hooks
+    end
   end
 end

--- a/spec/lib/grant_flow/fallback_flow_spec.rb
+++ b/spec/lib/grant_flow/fallback_flow_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::GrantFlow::FallbackFlow do
+  subject(:flow) { described_class.new("custom_type", response_type_matches: "custom_type") }
+
+  it "reports that it handles neither grant nor response types" do
+    expect(flow.handles_grant_type?).to be(false)
+    expect(flow.handles_response_type?).to be(false)
+  end
+
+  it "still matches the configured response type for lookups" do
+    expect(flow.matches_response_type?("custom_type")).to be(true)
+  end
+end

--- a/spec/lib/models/concerns/expiration_time_sql_math_spec.rb
+++ b/spec/lib/models/concerns/expiration_time_sql_math_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::Models::ExpirationTimeSqlMath do
+  describe "adapter specific SQL generators" do
+    let(:model) { Doorkeeper::AccessToken }
+
+    {
+      Doorkeeper::Models::ExpirationTimeSqlMath::SqlLiteExpirationTimeSqlGenerator =>
+        "DATETIME(oauth_access_tokens.created_at, '+' || oauth_access_tokens.expires_in || ' SECONDS')",
+      Doorkeeper::Models::ExpirationTimeSqlMath::MySqlExpirationTimeSqlGenerator =>
+        "DATE_ADD(oauth_access_tokens.created_at, INTERVAL oauth_access_tokens.expires_in SECOND)",
+      Doorkeeper::Models::ExpirationTimeSqlMath::PostgresExpirationTimeSqlGenerator =>
+        "oauth_access_tokens.created_at + oauth_access_tokens.expires_in * INTERVAL '1 SECOND'",
+      Doorkeeper::Models::ExpirationTimeSqlMath::SqlServerExpirationTimeSqlGenerator =>
+        "DATEADD(second, oauth_access_tokens.expires_in, oauth_access_tokens.created_at) AT TIME ZONE 'UTC'",
+      Doorkeeper::Models::ExpirationTimeSqlMath::OracleExpirationTimeSqlGenerator =>
+        "oauth_access_tokens.created_at + INTERVAL to_char(oauth_access_tokens.expires_in) second",
+    }.each do |generator_class, expected_sql|
+      it "generates the expiration SQL for #{generator_class.name.demodulize}" do
+        expect(generator_class.new(model).generate_sql).to eq(expected_sql)
+      end
+    end
+
+    it "requires subclasses of the base generator to define generate_sql" do
+      expect { described_class::ExpirationTimeSqlGenerator.new(model).generate_sql }
+        .to raise_error(RuntimeError, /`generate_sql` should be overridden/)
+    end
+  end
+
+  describe ".expiration_time_sql" do
+    context "with a custom SQL expression" do
+      let(:model_class) do
+        Class.new(Doorkeeper::AccessToken) do
+          def self.custom_expiration_time_sql
+            "datetime(created_at, '+' || expires_in || ' seconds')"
+          end
+        end
+      end
+
+      it "reports expiration time math as supported regardless of the adapter" do
+        allow(model_class).to receive(:adapter_name).and_return("unknown_adapter")
+
+        expect(model_class.supports_expiration_time_math?).to be(true)
+      end
+
+      it "prefers the custom SQL over the adapter mapping" do
+        expect(model_class.expiration_time_sql)
+          .to eq("datetime(created_at, '+' || expires_in || ' seconds')")
+      end
+    end
+  end
+end

--- a/spec/lib/models/revocable_spec.rb
+++ b/spec/lib/models/revocable_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Doorkeeper::Models::Revocable do
 
       it "does not update :revoked_at attribute" do
         expect(fake_object).not_to receive(:update_attribute)
+        fake_object.revoke
       end
     end
   end

--- a/spec/lib/oauth/authorization/code_spec.rb
+++ b/spec/lib/oauth/authorization/code_spec.rb
@@ -18,6 +18,52 @@ RSpec.describe Doorkeeper::OAuth::Authorization::Code do
   let(:application) { FactoryBot.create(:application) }
   let(:authorization) { described_class.new(pre_auth, resource_owner) }
 
+  describe "#issue_token!" do
+    it "memoizes the issued grant" do
+      first_grant = authorization.issue_token!
+
+      expect { expect(authorization.issue_token!).to eq(first_grant) }
+        .not_to(change { Doorkeeper::AccessGrant.count })
+    end
+
+    context "when PKCE is not supported" do
+      before do
+        allow(Doorkeeper::AccessGrant).to receive(:pkce_supported?).and_return(false)
+      end
+
+      it "issues the grant without PKCE attributes" do
+        grant = authorization.issue_token!
+
+        expect(grant).to be_persisted
+        expect(grant.code_challenge).to be_nil
+        expect(grant.code_challenge_method).to be_nil
+      end
+    end
+
+    context "with a polymorphic resource owner" do
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          use_polymorphic_resource_owner
+        end
+        stub_const(
+          "PolyAccessGrant",
+          Class.new(ApplicationRecord) do
+            include Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant
+          end,
+        )
+        config_is_set(:access_grant_class, "PolyAccessGrant")
+      end
+
+      it "persists the resource owner association on the grant" do
+        grant = authorization.issue_token!
+
+        expect(grant).to be_persisted
+        expect(grant.resource_owner).to eq(resource_owner)
+      end
+    end
+  end
+
   describe "#issue_token! with read replica support" do
     context "when enable_multiple_database_roles is enabled" do
       before do

--- a/spec/lib/oauth/authorization/context_spec.rb
+++ b/spec/lib/oauth/authorization/context_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::OAuth::Authorization::Context do
+  describe "#initialize" do
+    it "assigns known attributes and ignores unknown ones" do
+      context = described_class.new(
+        client: "client",
+        grant_type: "grant_type",
+        scopes: "scopes",
+        resource_owner: "owner",
+        unknown: "ignored",
+      )
+
+      expect(context.client).to eq("client")
+      expect(context.grant_type).to eq("grant_type")
+      expect(context.scopes).to eq("scopes")
+      expect(context.resource_owner).to eq("owner")
+    end
+  end
+end

--- a/spec/lib/oauth/authorization/token_spec.rb
+++ b/spec/lib/oauth/authorization/token_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::OAuth::Authorization::Token do
+  describe ".build_context" do
+    it "uses the application of an object that responds to #application" do
+      application = double
+      source = double(application: application)
+
+      context = described_class.build_context(source, "grant_type", "scopes", "owner")
+
+      expect(context.client).to eq(application)
+    end
+
+    it "uses the client of an object that responds to #client" do
+      client = double
+      source = double(client: client)
+
+      context = described_class.build_context(source, "grant_type", "scopes", "owner")
+
+      expect(context.client).to eq(client)
+    end
+
+    it "uses the object itself otherwise" do
+      source = Object.new
+
+      context = described_class.build_context(source, "grant_type", "scopes", "owner")
+
+      expect(context.client).to eq(source)
+    end
+  end
+
+  describe ".access_token_expires_in" do
+    let(:context) { double }
+
+    it "returns nil for a never-expiring custom expiration" do
+      configuration = double(
+        option_defined?: true,
+        custom_access_token_expires_in: ->(_context) { Float::INFINITY },
+      )
+
+      expect(described_class.access_token_expires_in(configuration, context)).to be_nil
+    end
+
+    it "falls back to access_token_expires_in when the custom expiration is nil" do
+      configuration = double(
+        option_defined?: true,
+        custom_access_token_expires_in: ->(_context) {},
+        access_token_expires_in: 7200,
+      )
+
+      expect(described_class.access_token_expires_in(configuration, context)).to eq(7200)
+    end
+  end
+
+  describe "#issue_token!" do
+    before do
+      default_scopes_exist :public
+    end
+
+    it "memoizes the issued token" do
+      application = FactoryBot.create(:application)
+      resource_owner = FactoryBot.create(:doorkeeper_testing_user)
+      pre_auth = double(
+        client: application,
+        scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+      )
+      authorization = described_class.new(pre_auth, resource_owner)
+
+      first_token = nil
+      expect { first_token = authorization.issue_token! }
+        .to change { Doorkeeper::AccessToken.count }.by(1)
+      expect { expect(authorization.issue_token!).to be(first_token) }
+        .not_to(change { Doorkeeper::AccessToken.count })
+    end
+  end
+
+  describe "#application" do
+    it "returns the client when it already is an application record" do
+      application = FactoryBot.create(:application)
+      pre_auth = double(client: application)
+
+      expect(described_class.new(pre_auth, double).application).to eq(application)
+    end
+
+    it "returns nil without a client" do
+      pre_auth = double(client: nil)
+
+      expect(described_class.new(pre_auth, double).application).to be_nil
+    end
+  end
+end

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -273,6 +273,14 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
         expect(request.error).to eq(Doorkeeper::Errors::InvalidGrant)
       end
 
+      it "invalidates when the stored code challenge method is unknown" do
+        grant.code_challenge_method = "unknown"
+        params[:code_verifier] = grant.code_challenge
+        request.validate
+
+        expect(request.error).to eq(Doorkeeper::Errors::InvalidGrant)
+      end
+
       context "when PKCE code challenge methods is set to only S256" do
         before do
           Doorkeeper.configure do

--- a/spec/lib/oauth/client_credentials/creator_spec.rb
+++ b/spec/lib/oauth/client_credentials/creator_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe Doorkeeper::OAuth::ClientCredentials::Creator do
     end.to change { Doorkeeper::AccessToken.count }.by(1)
   end
 
+  it "resolves the application from an authenticated client wrapper" do
+    oauth_client = Doorkeeper::OAuth::Client.new(client)
+
+    expect do
+      creator.call(oauth_client, scopes)
+    end.to change { Doorkeeper::AccessToken.count }.by(1)
+
+    expect(Doorkeeper::AccessToken.last.application).to eq(client)
+  end
+
   context "when reuse_access_token is true" do
     before do
       allow(Doorkeeper.config).to receive(:reuse_access_token).and_return(true)

--- a/spec/lib/oauth/code_response_spec.rb
+++ b/spec/lib/oauth/code_response_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe Doorkeeper::OAuth::CodeResponse do
     )
   end
 
+  describe "#issued_token" do
+    it "exposes the token issued by the authorization" do
+      allow(pre_auth).to receive_messages(code_challenge: nil, code_challenge_method: nil)
+      auth = Doorkeeper::OAuth::Authorization::Code.new(pre_auth, owner).tap(&:issue_token!)
+
+      response = described_class.new(pre_auth, auth)
+
+      expect(response.issued_token).to eq(auth.token)
+    end
+  end
+
   describe "#body" do
     subject(:body) { described_class.new(pre_auth, auth).body }
 

--- a/spec/lib/oauth/error_response_spec.rb
+++ b/spec/lib/oauth/error_response_spec.rb
@@ -21,6 +21,22 @@ RSpec.describe Doorkeeper::OAuth::ErrorResponse do
     end
   end
 
+  describe "#raise_exception!" do
+    it "raises the exception class the response was built with" do
+      response = described_class.new(
+        name: :invalid_request,
+        exception_class: Doorkeeper::Errors::InvalidRequest,
+      )
+
+      expect { response.raise_exception! }.to raise_error(Doorkeeper::Errors::InvalidRequest)
+    end
+
+    it "raises NotImplementedError when no exception class is defined" do
+      expect { described_class.new.raise_exception! }
+        .to raise_error(NotImplementedError, /must define #exception_class/)
+    end
+  end
+
   describe ".from_request" do
     it "has the error from request" do
       error = described_class.from_request double(error: Doorkeeper::Errors::InvalidClient)

--- a/spec/lib/oauth/hooks/context_spec.rb
+++ b/spec/lib/oauth/hooks/context_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::OAuth::Hooks::Context do
+  describe "#initialize" do
+    it "assigns known attributes and ignores unknown ones" do
+      auth = double
+      context = described_class.new(auth: auth, pre_auth: "pre_auth", unknown: "ignored")
+
+      expect(context.auth).to eq(auth)
+      expect(context.pre_auth).to eq("pre_auth")
+    end
+  end
+
+  describe "#issued_token" do
+    it "delegates to auth" do
+      auth = double(issued_token: "issued token")
+
+      expect(described_class.new(auth: auth).issued_token).to eq("issued token")
+    end
+
+    it "returns nil when there is no auth" do
+      expect(described_class.new.issued_token).to be_nil
+    end
+  end
+end

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -25,6 +25,41 @@ RSpec.describe Doorkeeper::OAuth::RefreshTokenRequest do
     expect(request.grant_type).to eq(Doorkeeper::OAuth::REFRESH_TOKEN)
   end
 
+  context "with a polymorphic resource owner" do
+    let(:resource_owner) { FactoryBot.create(:doorkeeper_testing_user) }
+    let(:application) { FactoryBot.create(:application) }
+    let(:refresh_token) do
+      PolyAccessToken.create_for(
+        application: application,
+        resource_owner: resource_owner,
+        scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+        use_refresh_token: true,
+      )
+    end
+
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        use_polymorphic_resource_owner
+      end
+      stub_const(
+        "PolyAccessToken",
+        Class.new(ApplicationRecord) do
+          include Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
+        end,
+      )
+      config_is_set(:access_token_class, "PolyAccessToken")
+    end
+
+    it "passes the full resource owner on to the new token" do
+      described_class.new(server, refresh_token, credentials).authorize
+
+      new_token = PolyAccessToken.order(:id).last
+      expect(new_token.id).not_to eq(refresh_token.id)
+      expect(new_token.resource_owner).to eq(resource_owner)
+    end
+  end
+
   it "issues a new token for the client" do
     expect { request.authorize }.to change { client.reload.access_tokens.count }.by(1)
     # #sort_by used for MongoDB ORM extensions for valid ordering

--- a/spec/lib/oauth/scopes_spec.rb
+++ b/spec/lib/oauth/scopes_spec.rb
@@ -204,6 +204,12 @@ RSpec.describe Doorkeeper::OAuth::Scopes do
           expect(scopes).not_to have_scopes(described_class.from_string("public userA:1"))
         end
 
+        it "returns false when the allowed dynamic scope has no right-hand side" do
+          allowed = described_class.from_string("user:")
+
+          expect(allowed.exists?("user:1")).to be(false)
+        end
+
         describe "#&" do
           it "allows user:1 scope" do
             scopes = described_class.from_string("public user:*") & described_class.from_string("public user:1")

--- a/spec/lib/oauth/token_introspection_spec.rb
+++ b/spec/lib/oauth/token_introspection_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::OAuth::TokenIntrospection do
+  let(:application) { FactoryBot.create(:application) }
+  let(:authorized_token) { FactoryBot.create(:access_token, application: application) }
+  let(:introspected_token) { FactoryBot.create(:access_token, application: application) }
+  let(:server) { double(credentials: nil, context: double(request: double)) }
+
+  before do
+    allow(Doorkeeper).to receive(:authenticate).and_return(authorized_token)
+  end
+
+  describe "#error_response" do
+    it "is nil when the introspection is authorized" do
+      introspection = described_class.new(server, introspected_token)
+
+      expect(introspection.authorized?).to be(true)
+      expect(introspection.error_response).to be_nil
+    end
+  end
+end

--- a/spec/lib/option_spec.rb
+++ b/spec/lib/option_spec.rb
@@ -48,4 +48,74 @@ RSpec.describe Doorkeeper::Config::Option do
     expect(Extension.configuration.some_option).to eq(20)
     expect(Extension.configuration.enforce_something?).to be(true)
   end
+
+  describe "option definition edge cases" do
+    let(:config_class) do
+      builder = Class.new(Doorkeeper::Config::AbstractBuilder)
+
+      Class.new do
+        @builder_class = builder
+
+        class << self
+          attr_reader :builder_class
+        end
+
+        extend Doorkeeper::Config::Option
+      end
+    end
+
+    def configure(config_class, &block)
+      config_class.builder_class.new(config_class.new, &block).config
+    end
+
+    it "warns when an option is defined twice and keeps the last definition" do
+      config_class.option(:some_option, default: 1)
+
+      expect(Kernel).to receive(:warn).with(
+        /\[DOORKEEPER\] Option some_option already defined and will be overridden/,
+      )
+      config_class.option(:some_option, default: 2)
+
+      expect(config_class.new.some_option).to eq(2)
+    end
+
+    it "warns when a deprecated option is set" do
+      config_class.option(:legacy_option, deprecated: true)
+
+      expect(Kernel).to receive(:warn).with(
+        /\[DOORKEEPER\] legacy_option has been deprecated and will soon be removed/,
+      )
+
+      config = configure(config_class) { legacy_option 42 }
+
+      expect(config.legacy_option).to eq(42)
+    end
+
+    it "appends the custom message when an option is deprecated with a message" do
+      config_class.option(:legacy_option, deprecated: { message: "Use new_option instead" })
+
+      expect(Kernel).to receive(:warn).with(
+        /legacy_option has been deprecated.*\nUse new_option instead/,
+      )
+
+      configure(config_class) { legacy_option 42 }
+    end
+
+    it "builds the option value with a custom builder class" do
+      value_builder = Class.new do
+        def initialize
+          @value = yield
+        end
+
+        def build
+          { built: @value }
+        end
+      end
+      config_class.option(:built_option, builder_class: value_builder)
+
+      config = configure(config_class) { built_option { 42 } }
+
+      expect(config.built_option).to eq(built: 42)
+    end
+  end
 end

--- a/spec/lib/rails/abstract_router_spec.rb
+++ b/spec/lib/rails/abstract_router_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::Rails::AbstractRouter do
+  it "requires including routers to implement #generate_routes!" do
+    router_class = Class.new { include Doorkeeper::Rails::AbstractRouter }
+    router = router_class.new(double, double(map: nil))
+
+    expect { router.generate_routes! }
+      .to raise_error(NotImplementedError, /must be redefined/)
+  end
+end

--- a/spec/lib/rails/routes/registry_spec.rb
+++ b/spec/lib/rails/routes/registry_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::Rails::Routes::Registry do
+  subject(:registry) { Object.new.extend(described_class) }
+
+  describe "#register_routes" do
+    it "registers a router class that includes AbstractRouter" do
+      router = Class.new { include Doorkeeper::Rails::AbstractRouter }
+
+      registry.register_routes(router)
+
+      expect(registry.registered_routes).to include(router)
+    end
+
+    it "rejects a class that does not include AbstractRouter" do
+      expect { registry.register_routes(Class.new) }.to raise_error(
+        described_class::InvalidRouterClass,
+        /must include Doorkeeper::Rails::AbstractRouter/,
+      )
+    end
+
+    it "rejects objects that are not a module at all" do
+      expect { registry.register_routes("not a router") }
+        .to raise_error(described_class::InvalidRouterClass)
+    end
+  end
+end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -167,4 +167,43 @@ RSpec.describe Doorkeeper::Request do
       end
     end
   end
+
+  describe ".token_strategy" do
+    it "raises MissingRequiredParameter for a blank grant type" do
+      expect { described_class.token_strategy(nil) }
+        .to raise_error(Doorkeeper::Errors::MissingRequiredParameter)
+    end
+
+    context "when no registered flow matches the grant type (legacy fallback)" do
+      before do
+        allow(Doorkeeper.config).to receive(:token_grant_flows).and_return([])
+      end
+
+      it "raises InvalidTokenStrategy when the grant type is not configured" do
+        allow(Doorkeeper.config)
+          .to receive(:deprecated_token_grant_types_resolver).and_return([])
+
+        expect { described_class.token_strategy("client_credentials") }
+          .to raise_error(Doorkeeper::Errors::InvalidTokenStrategy)
+      end
+
+      it "falls back to the legacy strategy class with a deprecation warning" do
+        allow(Doorkeeper.config)
+          .to receive(:deprecated_token_grant_types_resolver).and_return(["client_credentials"])
+
+        expect(Kernel).to receive(:warn).with(/found using fallback/)
+
+        expect(described_class.token_strategy("client_credentials"))
+          .to eq(Doorkeeper::Request::ClientCredentials)
+      end
+
+      it "raises InvalidTokenStrategy when no legacy strategy class exists" do
+        allow(Doorkeeper.config)
+          .to receive(:deprecated_token_grant_types_resolver).and_return(["bogus_grant"])
+
+        expect { described_class.token_strategy("bogus_grant") }
+          .to raise_error(Doorkeeper::Errors::InvalidTokenStrategy)
+      end
+    end
+  end
 end

--- a/spec/lib/secret_storing/bcrypt_spec.rb
+++ b/spec/lib/secret_storing/bcrypt_spec.rb
@@ -36,6 +36,21 @@ RSpec.describe ::Doorkeeper::SecretStoring::BCrypt do
       expect { described_class.validate_for(:token) }
         .to raise_error(ArgumentError, /can only be used for storing application secrets/)
     end
+
+    it "raises when the bcrypt gem is not available" do
+      allow(described_class).to receive(:bcrypt_present?).and_return(false)
+
+      expect { described_class.validate_for(:application) }
+        .to raise_error(ArgumentError, /requires the 'bcrypt' gem/)
+    end
+  end
+
+  describe "bcrypt_present?" do
+    it "is false when bcrypt cannot be loaded" do
+      allow(described_class).to receive(:require).with("bcrypt").and_raise(LoadError)
+
+      expect(described_class.bcrypt_present?).to be(false)
+    end
   end
 
   describe "secret_matches?" do

--- a/spec/models/doorkeeper/access_token_spec.rb
+++ b/spec/models/doorkeeper/access_token_spec.rb
@@ -570,6 +570,37 @@ RSpec.describe Doorkeeper::AccessToken do
       expect(last_token).to be_nil
     end
 
+    it "excludes expired tokens when include_expired is false" do
+      FactoryBot.create :access_token, default_attributes.merge(expires_in: 2, created_at: 10.seconds.ago)
+      last_token = described_class.matching_token_for(
+        application, resource_owner_id, scopes, include_expired: false,
+      )
+      expect(last_token).to be_nil
+    end
+
+    it "matches a clientless token when application is nil" do
+      token = FactoryBot.create :clientless_access_token,
+                                resource_owner_id: resource_owner_id,
+                                resource_owner_type: resource_owner.class.name,
+                                scopes: scopes.to_s
+
+      expect(described_class.matching_token_for(nil, resource_owner_id, scopes)).to eq(token)
+    end
+
+    it "applies the additional filter block" do
+      token = FactoryBot.create :access_token, default_attributes
+
+      rejected = described_class.matching_token_for(application, resource_owner_id, scopes) do |candidate|
+        candidate.refresh_token.present?
+      end
+      expect(rejected).to be_nil
+
+      accepted = described_class.matching_token_for(application, resource_owner_id, scopes) do |candidate|
+        candidate.refresh_token.blank?
+      end
+      expect(accepted).to eq(token)
+    end
+
     it "excludes tokens with a different application" do
       FactoryBot.create :access_token, default_attributes.merge(application: FactoryBot.create(:application))
       last_token = described_class.matching_token_for(application, resource_owner_id, scopes)
@@ -1014,6 +1045,36 @@ RSpec.describe Doorkeeper::AccessToken do
 
         described_class.revoke_all_for(application.id, resource_owner)
       end
+    end
+  end
+
+  describe ".not_expired when expiration time math is not supported" do
+    it "warns and returns the relation unfiltered" do
+      allow(described_class).to receive(:supports_expiration_time_math?).and_return(false)
+      expect(Kernel).to receive(:warn).with(Doorkeeper::Models::ExpirationTimeSqlMath::WARNING_MESSAGE)
+
+      expired_token = FactoryBot.create(:access_token, expires_in: 2, created_at: 10.seconds.ago)
+
+      expect(described_class.not_expired).to include(expired_token)
+    end
+  end
+
+  describe "#revoke_previous_refresh_token!" do
+    it "does nothing when refresh tokens are not revoked on use" do
+      allow(described_class).to receive(:refresh_token_revoked_on_use?).and_return(false)
+      token = FactoryBot.create(:access_token, previous_refresh_token: "previous")
+
+      token.revoke_previous_refresh_token!
+
+      expect(token.reload.previous_refresh_token).to eq("previous")
+    end
+
+    it "clears the attribute even when the previous token no longer exists" do
+      token = FactoryBot.create(:access_token, previous_refresh_token: "vanished")
+
+      token.revoke_previous_refresh_token!
+
+      expect(token.reload.previous_refresh_token).to eq("")
     end
   end
 

--- a/spec/models/doorkeeper/polymorphic_resource_owner_spec.rb
+++ b/spec/models/doorkeeper/polymorphic_resource_owner_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The dummy application boots with a non-polymorphic Doorkeeper
+# configuration, so the polymorphic side of the model mixins is exercised
+# here with freshly defined model classes: `included` hooks read the
+# configuration at include time, and the dummy schema already carries the
+# `resource_owner_type` columns.
+RSpec.describe "polymorphic resource owner models" do
+  let(:resource_owner) { FactoryBot.create(:doorkeeper_testing_user) }
+  let(:application) { FactoryBot.create(:application) }
+  let(:scopes) { Doorkeeper::OAuth::Scopes.from_string("public") }
+
+  before do
+    Doorkeeper.configure do
+      orm DOORKEEPER_ORM
+      use_polymorphic_resource_owner
+    end
+
+    stub_const(
+      "PolyAccessToken",
+      Class.new(ApplicationRecord) do
+        include Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
+      end,
+    )
+
+    stub_const(
+      "PolyAccessGrant",
+      Class.new(ApplicationRecord) do
+        include Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant
+      end,
+    )
+  end
+
+  describe "association setup" do
+    it "declares a polymorphic resource_owner on the access token" do
+      reflection = PolyAccessToken.reflect_on_association(:resource_owner)
+
+      expect(reflection).not_to be_nil
+      expect(reflection.polymorphic?).to be(true)
+    end
+
+    it "declares a required polymorphic resource_owner on the access grant" do
+      reflection = PolyAccessGrant.reflect_on_association(:resource_owner)
+
+      expect(reflection).not_to be_nil
+      expect(reflection.polymorphic?).to be(true)
+      expect(PolyAccessGrant.new(application: application).tap(&:valid?).errors[:resource_owner])
+        .not_to be_empty
+    end
+  end
+
+  describe ".create_for" do
+    it "persists the resource owner association" do
+      token = PolyAccessToken.create_for(
+        application: application,
+        resource_owner: resource_owner,
+        scopes: scopes,
+      )
+
+      expect(token).to be_persisted
+      expect(token.resource_owner_id).to eq(resource_owner.id)
+      expect(token.resource_owner_type).to eq(resource_owner.class.name)
+      expect(token.reload.resource_owner).to eq(resource_owner)
+    end
+  end
+
+  describe ".by_resource_owner" do
+    it "filters by both resource owner id and type" do
+      token = PolyAccessToken.create_for(
+        application: application,
+        resource_owner: resource_owner,
+        scopes: scopes,
+      )
+      other_owner = FactoryBot.create(:doorkeeper_testing_user)
+
+      expect(PolyAccessToken.by_resource_owner(resource_owner)).to eq([token])
+      expect(PolyAccessToken.by_resource_owner(other_owner)).to be_empty
+      expect(PolyAccessToken.by_resource_owner(resource_owner).to_sql)
+        .to include("resource_owner_type")
+    end
+  end
+
+  describe "#same_resource_owner?" do
+    it "compares the full polymorphic association" do
+      token = PolyAccessToken.create_for(
+        application: application, resource_owner: resource_owner, scopes: scopes,
+      )
+      same_owner_token = PolyAccessToken.create_for(
+        application: application, resource_owner: resource_owner, scopes: scopes,
+      )
+      other_owner_token = PolyAccessToken.create_for(
+        application: application,
+        resource_owner: FactoryBot.create(:doorkeeper_testing_user),
+        scopes: scopes,
+      )
+
+      expect(token.same_resource_owner?(same_owner_token)).to be(true)
+      expect(token.same_resource_owner?(other_owner_token)).to be(false)
+    end
+  end
+
+  describe "authorization code exchange" do
+    let(:server) do
+      double :server,
+             access_token_expires_in: 2.days,
+             refresh_token_enabled?: false
+    end
+
+    before do
+      allow(server).to receive(:option_defined?)
+        .with(:custom_access_token_expires_in).and_return(false)
+      config_is_set(:access_token_class, "PolyAccessToken")
+      config_is_set(:access_grant_class, "PolyAccessGrant")
+    end
+
+    it "issues the token to the grant's polymorphic resource owner" do
+      grant = PolyAccessGrant.create!(
+        application: application,
+        resource_owner: resource_owner,
+        redirect_uri: "https://app.com/callback",
+        expires_in: 100,
+        scopes: "public",
+      )
+
+      Doorkeeper::OAuth::AuthorizationCodeRequest.new(
+        server, grant, application, redirect_uri: grant.redirect_uri,
+      ).authorize
+
+      new_token = PolyAccessToken.order(:id).last
+      expect(new_token.resource_owner).to eq(resource_owner)
+    end
+  end
+
+  describe "#as_json" do
+    it "includes the resource owner type" do
+      token = PolyAccessToken.create_for(
+        application: application, resource_owner: resource_owner, scopes: scopes,
+      )
+
+      expect(token.as_json[:resource_owner_id]).to eq(resource_owner.id)
+      expect(token.as_json[:resource_owner_type]).to eq(resource_owner.class.name)
+    end
+  end
+end

--- a/spec/requests/endpoints/metadata_spec.rb
+++ b/spec/requests/endpoints/metadata_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe "Authorization Server Metadata endpoint" do
     expect(json_response["code_challenge_methods_supported"]).to be_a(Array)
   end
 
+  it "omits client authentication methods that are not registered" do
+    unregistered = double(name: :made_up_method)
+    allow(Doorkeeper.config).to receive(:client_authentication_methods).and_return([unregistered])
+
+    get "/.well-known/oauth-authorization-server"
+
+    expect(json_response["token_endpoint_auth_methods_supported"]).to eq([])
+  end
+
   context "with custom issuer" do
     before do
       config_is_set(:issuer, "https://example.test")


### PR DESCRIPTION
>[!TIP]
> ### No production code changes
> This PR adds behavior-asserting specs for previously uncovered code paths, raising line coverage from **97.3% → 99.6%** and branch coverage from **88.6% → 97.5%** (measured locally on SQLite). **+1,091 lines across 29 spec files, 91 new examples, 0 failures.**

<details>

### New specs (highlights)

- **Polymorphic resource owner** — DB-backed specs that define fresh model classes under the real `use_polymorphic_resource_owner` config: association setup, `create_for`, `by_resource_owner`, `same_resource_owner?`, `as_json`, authorization-code exchange, and refresh-token flow. Previously the polymorphic side of all request flows was untested.
- **Config DSL** — `force_pkce`, `use_polymorphic_resource_owner`, `revoke_previous_*` builder methods, option redefinition warning, `deprecated:` / `builder_class:` option flavors, custom secret-storing fallback, `custom_metadata` / `issuer` validation warnings.
- **Deprecation / legacy contracts** — `deprecated_authorization_flows` + `FallbackFlow`, legacy `token_strategy` fallback resolution, `run_orm_hooks` legacy-ORM warning, non-AR `Doorkeeper.setup` hooks — pinned so their eventual removal is a deliberate, test-visible change.
- **PKCE** — unknown `code_challenge_method` → `invalid_grant`; grants issued without PKCE columns carry no PKCE attributes.
- **Models** — `matching_token_for` with `nil` application, `include_expired: false`, and filter block; `revoke_previous_refresh_token!` edge cases; per-adapter expiration-time SQL generators (MySQL / Postgres / SQL Server / Oracle / SQLite) as portable unit tests; `pluralize_table_names = false` naming.
- **Misc** — `doorkeeper:db:cleanup` rake tasks, route registry / abstract-router contracts, BCrypt availability guards, `ErrorResponse#raise_exception!`, token endpoint under `handle_auth_errors :raise`.

### Spec bug fix

`revocable_spec`'s "does not update :revoked_at" example never called `#revoke`, so its expectation was vacuously green. Added the missing call.

### Deliberately left uncovered

The remaining gaps are defensive guards or environment-dependent branches that cannot be exercised meaningfully from the public API on this setup (version.rb loaded before coverage, engine.rb Sprockets branch, old-Rails guards in ORM mixins, MySQL/Postgres branches of adapter dispatch covered by the CI DB matrix, etc.).

</details>
