### PR TITLE
Fix NameError when `application_secret_generator` is misconfigured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ User-visible changes worth mentioning.
 - [#1862] Document that with `reuse_access_token` enabled token matching considers only the application, resource owner, scopes and custom token attributes — separate authorization grants for the same combination intentionally share one access token — and pin the behavior with a regression spec. Docs/test-only change, closes [#1693].
 - [#1864] Fix `custom_access_token_attributes` values being dropped when the authorization goes through the consent screen: the approve/deny forms now carry the custom attributes as hidden fields, and the pre-authorization JSON (`api_only` mode) includes them so custom consent UIs can send them back.
 - [#1869] Improve test coverage
+- [#1870] Fix: raise the intended `Doorkeeper::Errors::TokenGeneratorNotFound` / `UnableToGenerateToken` (instead of a confusing `NameError`) when `application_secret_generator` is misconfigured.
 - Please add here
 
 ## 5.9.3

--- a/lib/doorkeeper/orm/active_record/mixins/application.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/application.rb
@@ -116,9 +116,9 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
 
         return generator if generator.respond_to?(:generate)
 
-        raise Errors::UnableToGenerateToken, "#{generator} does not respond to `.generate`."
+        raise Doorkeeper::Errors::UnableToGenerateToken, "#{generator} does not respond to `.generate`."
       rescue NameError
-        raise Errors::TokenGeneratorNotFound, "#{generator_name} not found"
+        raise Doorkeeper::Errors::TokenGeneratorNotFound, "#{generator_name} not found"
       end
 
       def generate_uid

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -105,6 +105,40 @@ RSpec.describe Doorkeeper::Application do
     expect(new_application.secret).to eq("custom_application_secret")
   end
 
+  describe "#authorized_tokens" do
+    it "returns non-revoked tokens only" do
+      application = FactoryBot.create(:application)
+      active_token = FactoryBot.create(:access_token, application: application)
+      FactoryBot.create(:access_token, application: application, revoked_at: 1.hour.ago)
+
+      expect(application.authorized_tokens).to eq([active_token])
+    end
+  end
+
+  it "raises an error when the configured secret generator is not found" do
+    Doorkeeper.configure do
+      orm DOORKEEPER_ORM
+      application_secret_generator "UnknownSecretGenerator"
+    end
+
+    expect { new_application.save }.to raise_error(
+      Doorkeeper::Errors::TokenGeneratorNotFound, /UnknownSecretGenerator/,
+    )
+  end
+
+  it "raises an error when the secret generator does not respond to generate" do
+    stub_const("InvalidSecretGenerator", Class.new)
+
+    Doorkeeper.configure do
+      orm DOORKEEPER_ORM
+      application_secret_generator "InvalidSecretGenerator"
+    end
+
+    expect { new_application.save }.to raise_error(
+      Doorkeeper::Errors::UnableToGenerateToken, /does not respond to/,
+    )
+  end
+
   # Regression for #1831: `Doorkeeper::Models::Ownership` is included only
   # when `enable_application_owner?` is set at include time. When the feature
   # is off (the default), the `:owner` association must NOT be declared, so


### PR DESCRIPTION
## Summary

`Doorkeeper::Application#secret_generator` is supposed to raise `Doorkeeper::Errors::TokenGeneratorNotFound` when the configured `application_secret_generator` class doesn't exist, and `Doorkeeper::Errors::UnableToGenerateToken` when the class doesn't respond to `.generate`. Neither error could actually be raised: the application mixin is defined with compact module nesting (`module Doorkeeper::Orm::ActiveRecord::Mixins`), so the bare `Errors` constant in the method body never resolves to `Doorkeeper::Errors`. Both error paths instead crashed with:

```
NameError: uninitialized constant Doorkeeper::Orm::ActiveRecord::Mixins::Application::Errors
```

This turns a helpful configuration error ("`FooGenerator` not found") into a confusing constant-resolution failure pointing at Doorkeeper internals.

## Changes

- Qualify both raises as `Doorkeeper::Errors::UnableToGenerateToken` / `Doorkeeper::Errors::TokenGeneratorNotFound` in `lib/doorkeeper/orm/active_record/mixins/application.rb`.
- Add regression specs pinning both error paths (unknown generator class, generator without `.generate`), plus a spec for the `#authorized_tokens` association scope which was previously uncovered.
- CHANGELOG entry.

## Notes

- The same bare-constant pattern elsewhere in the mixins resolves fine when it's inside `included do ... end` blocks (evaluated in the model class context under `Doorkeeper` autoload paths) — only these two raises in an instance method body were affected.
- No behavior change for correctly configured generators; `Doorkeeper::SecretStoring::*` paths are untouched.