### PR TITLE
Compare redirect_uri with simple string comparison per RFC 6749 [#1718]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ User-visible changes worth mentioning.
 ## main
 
 - [#1865] Revoke the token issued for an authorization code when the code is exchanged more than once, per RFC 6749 §4.1.2 / §10.5. Active when the `oauth_access_grants.access_token_id` column exists: new installs get it from the generated migration, existing apps can add it with `rails generate doorkeeper:grant_reuse_revocation`. Closes [#1713].
+- [#1871] **[BREAKING]** `redirect_uri` is now compared to the registered redirect URIs with the simple string comparison required by RFC 6749 §3.1.2.3 (the RFC 8252 §7.3 loopback port exception is kept). Clients relying on the previous lenient matching must send the exact registered URI, closes [#1718].
 - Please add here
 
 ## 6.0.0.beta1

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -15,27 +15,30 @@ module Doorkeeper
           false
         end
 
+        # RFC6749, Section 3.1.2.3 requires the requested redirect URI to be
+        # compared to the registered redirect URIs using the simple string
+        # comparison defined in RFC3986, Section 6.2.1.
+        # @see https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2.3
         def self.matches?(url, client_url)
+          return true if url == client_url
+
+          # RFC8252, Paragraph 7.3 allows the port of loopback interface
+          # redirect URIs to vary at runtime, so it is ignored when both
+          # URIs point to the loopback interface.
+          # @see https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
           url = as_uri(url)
           client_url = as_uri(client_url)
 
-          unless client_url.query.nil?
-            return false unless query_matches?(url.query, client_url.query)
+          return false unless loopback_uri?(url) && loopback_uri?(client_url)
 
-            # Clear out queries so rest of URI can be tested. This allows query
-            # params to be in the request but order not mattering.
-            client_url.query = nil
-          end
-
-          # RFC8252, Paragraph 7.3
-          # @see https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
-          if loopback_uri?(url) && loopback_uri?(client_url)
-            url.port = nil
-            client_url.port = nil
-          end
-
-          url.query = nil
-          url == client_url
+          url.port = nil
+          client_url.port = nil
+          # Compare the reassembled strings rather than the URI objects so the
+          # URI#== normalizations (e.g. an empty path matching "/") don't
+          # widen the exception beyond the port.
+          url.to_s == client_url.to_s
+        rescue URI::InvalidURIError
+          false
         end
 
         def self.loopback_uri?(uri)
@@ -50,14 +53,6 @@ module Doorkeeper
 
         def self.as_uri(url)
           URI.parse(url)
-        end
-
-        def self.query_matches?(query, client_query)
-          return true if client_query.blank? && query.blank?
-          return false if client_query.nil? || query.nil?
-
-          # Will return true independent of query order
-          client_query.split("&").sort == query.split("&").sort
         end
 
         def self.valid_scheme?(uri)

--- a/spec/lib/oauth/authorization_code_request_spec.rb
+++ b/spec/lib/oauth/authorization_code_request_spec.rb
@@ -258,12 +258,12 @@ RSpec.describe Doorkeeper::OAuth::AuthorizationCodeRequest do
     request.authorize
   end
 
-  context "when redirect_uri contains some query params" do
+  context "when redirect_uri contains additional query params" do
     let(:redirect_uri) { "#{client.redirect_uri}?query=q" }
 
-    it "allows query params" do
+    it "responds with invalid_grant" do
       request.validate
-      expect(request.error).to be_nil
+      expect(request.error).to eq(Doorkeeper::Errors::InvalidGrant)
     end
   end
 

--- a/spec/lib/oauth/helpers/uri_checker_spec.rb
+++ b/spec/lib/oauth/helpers/uri_checker_spec.rb
@@ -71,10 +71,34 @@ describe Doorkeeper::OAuth::Helpers::URIChecker do
       expect(described_class).to be_matches(uri, client_uri)
     end
 
-    it "allows additional query parameters" do
+    it "doesn't allow additional query parameters" do
       uri = "http://app.co/?query=hello"
       client_uri = "http://app.co"
-      expect(described_class).to be_matches(uri, client_uri)
+      expect(described_class).not_to be_matches(uri, client_uri)
+    end
+
+    it "doesn't allow a trailing slash difference" do
+      uri = "http://app.co/aaa/"
+      client_uri = "http://app.co/aaa"
+      expect(described_class).not_to be_matches(uri, client_uri)
+    end
+
+    it "doesn't allow a path case difference" do
+      uri = "http://app.co/AAA"
+      client_uri = "http://app.co/aaa"
+      expect(described_class).not_to be_matches(uri, client_uri)
+    end
+
+    it "doesn't allow a host case difference" do
+      uri = "http://APP.CO/aaa"
+      client_uri = "http://app.co/aaa"
+      expect(described_class).not_to be_matches(uri, client_uri)
+    end
+
+    it "doesn't allow a blank query difference" do
+      uri = "http://app.co/aaa?"
+      client_uri = "http://app.co/aaa"
+      expect(described_class).not_to be_matches(uri, client_uri)
     end
 
     it "doesn't allow non-matching domains through" do
@@ -89,6 +113,33 @@ describe Doorkeeper::OAuth::Helpers::URIChecker do
       expect(described_class).not_to be_matches(uri, client_uri)
     end
 
+    it "is false if one of the uris is not a valid URI" do
+      uri = "http://app.co/aaa"
+      client_uri = "http://app.co/ /aaa"
+      expect(described_class).not_to be_matches(uri, client_uri)
+    end
+
+    it "is false if only one of the uris is a loopback URI" do
+      uri = "http://127.0.0.1:5555/auth/callback"
+      client_uri = "http://app.co/auth/callback"
+      expect(described_class).not_to be_matches(uri, client_uri)
+    end
+
+    it "is true for identical custom-scheme URIs" do
+      uri = client_uri = "com.example.app:/oauth/callback"
+      expect(described_class).to be_matches(uri, client_uri)
+    end
+
+    it "is false for non-matching custom-scheme URIs" do
+      uri = "com.example.app:/oauth/callback"
+      client_uri = "com.example.app:/oauth/other"
+      expect(described_class).not_to be_matches(uri, client_uri)
+
+      uri = "com.example.app:/oauth/callback"
+      client_uri = "com.example.other:/oauth/callback"
+      expect(described_class).not_to be_matches(uri, client_uri)
+    end
+
     context "when loopback IP redirect URIs" do
       it "ignores port for same URIs" do
         uri = "http://127.0.0.1:5555/auth/callback"
@@ -96,13 +147,45 @@ describe Doorkeeper::OAuth::Helpers::URIChecker do
         expect(described_class).to be_matches(uri, client_uri)
 
         uri = "http://[::1]:5555/auth/callback"
-        client_uri = "http://[::1]:5555/auth/callback"
+        client_uri = "http://[::1]:48599/auth/callback"
         expect(described_class).to be_matches(uri, client_uri)
       end
 
-      it "doesn't ignore port for URIs with different queries" do
+      it "ignores port when only the request URI specifies one" do
+        uri = "http://127.0.0.1:5555/auth/callback"
+        client_uri = "http://127.0.0.1/auth/callback"
+        expect(described_class).to be_matches(uri, client_uri)
+
+        uri = "http://[::1]:5555/auth/callback"
+        client_uri = "http://[::1]/auth/callback"
+        expect(described_class).to be_matches(uri, client_uri)
+      end
+
+      it "ignores port when only the client URI specifies one" do
+        uri = "http://127.0.0.1/auth/callback"
+        client_uri = "http://127.0.0.1:48599/auth/callback"
+        expect(described_class).to be_matches(uri, client_uri)
+
+        uri = "http://[::1]/auth/callback"
+        client_uri = "http://[::1]:48599/auth/callback"
+        expect(described_class).to be_matches(uri, client_uri)
+      end
+
+      it "doesn't ignore port for URIs with different paths" do
         uri = "http://127.0.0.1:5555/auth/callback"
         client_uri = "http://127.0.0.1:48599/auth/callback2"
+        expect(described_class).not_to be_matches(uri, client_uri)
+      end
+
+      it "doesn't ignore port for URIs with different queries" do
+        uri = "http://127.0.0.1:5555/auth/callback?foo=bar"
+        client_uri = "http://127.0.0.1:48599/auth/callback?foo=baz"
+        expect(described_class).not_to be_matches(uri, client_uri)
+      end
+
+      it "doesn't ignore port for URIs with an empty path vs root path difference" do
+        uri = "http://127.0.0.1:5555"
+        client_uri = "http://127.0.0.1:48599/"
         expect(described_class).not_to be_matches(uri, client_uri)
       end
     end
@@ -138,10 +221,10 @@ describe Doorkeeper::OAuth::Helpers::URIChecker do
         expect(described_class).to be_matches(uri, client_uri)
       end
 
-      it "is true if queries are present, match and in different order" do
+      it "is false if queries are present and match but in different order" do
         uri = "http://app.co/?bing=bang&foo=bar"
         client_uri = "http://app.co/?foo=bar&bing=bang"
-        expect(described_class).to be_matches(uri, client_uri)
+        expect(described_class).not_to be_matches(uri, client_uri)
       end
     end
   end
@@ -155,17 +238,19 @@ describe Doorkeeper::OAuth::Helpers::URIChecker do
       expect(described_class).to be_valid_for_authorization(uri, client_uri)
     end
 
-    it "is true if uri includes blank query" do
+    it "is true if uri includes blank query and client uri is identical" do
       uri = client_uri = "http://app.co/aaa?"
       expect(described_class).to be_valid_for_authorization(uri, client_uri)
+    end
 
+    it "is false if only one of the uris includes a blank query" do
       uri = "http://app.co/aaa?"
       client_uri = "http://app.co/aaa"
-      expect(described_class).to be_valid_for_authorization(uri, client_uri)
+      expect(described_class).not_to be_valid_for_authorization(uri, client_uri)
 
       uri = "http://app.co/aaa"
       client_uri = "http://app.co/aaa?"
-      expect(described_class).to be_valid_for_authorization(uri, client_uri)
+      expect(described_class).not_to be_valid_for_authorization(uri, client_uri)
     end
 
     it "is false if valid and mismatches" do
@@ -204,57 +289,6 @@ describe Doorkeeper::OAuth::Helpers::URIChecker do
       client_uri = "http://app.co/aaa?waffles=abc"
       expect(described_class).to receive(:valid?).with(uri).once
       described_class.valid_for_authorization?(uri, client_uri)
-    end
-  end
-
-  describe ".query_matches?" do
-    it "is true if no queries" do
-      expect(described_class).to be_query_matches("", "")
-      expect(described_class).to be_query_matches(nil, nil)
-    end
-
-    it "is true if same query" do
-      expect(described_class).to be_query_matches("foo", "foo")
-    end
-
-    it "is false if different query" do
-      expect(described_class).not_to be_query_matches("foo", "bar")
-    end
-
-    it "is true if same queries" do
-      expect(described_class).to be_query_matches("foo&bar", "foo&bar")
-    end
-
-    it "is true if same queries, different order" do
-      expect(described_class).to be_query_matches("foo&bar", "bar&foo")
-    end
-
-    it "is false if one different query" do
-      expect(described_class).not_to be_query_matches("foo&bang", "foo&bing")
-    end
-
-    it "is true if same query with same value" do
-      expect(described_class).to be_query_matches("foo=bar", "foo=bar")
-    end
-
-    it "is true if same queries with same values" do
-      expect(described_class).to be_query_matches("foo=bar&bing=bang", "foo=bar&bing=bang")
-    end
-
-    it "is true if same queries with same values, different order" do
-      expect(described_class).to be_query_matches("foo=bar&bing=bang", "bing=bang&foo=bar")
-    end
-
-    it "is false if same query with different value" do
-      expect(described_class).not_to be_query_matches("foo=bar", "foo=bang")
-    end
-
-    it "is false if some queries missing" do
-      expect(described_class).not_to be_query_matches("foo=bar", "foo=bar&bing=bang")
-    end
-
-    it "is false if some queries different value" do
-      expect(described_class).not_to be_query_matches("foo=bar&bing=bang", "foo=bar&bing=banana")
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #1718.

RFC 6749, [Section 3.1.2.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2.3) requires the redirect URI received in the authorization request to be compared to the registered redirect URIs using the simple string comparison defined in RFC 3986, [Section 6.2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.1). This is reiterated in the [OAuth 2.0 Security Best Current Practice](https://www.ietf.org/archive/id/draft-ietf-oauth-security-topics-27.html) draft, since lenient redirect URI matching enables [redirect URI validation attacks](https://www.ietf.org/archive/id/draft-ietf-oauth-security-topics-27.html#name-redirect-uri-validation-att) on the authorization code grant.

`URIChecker.matches?` previously parsed both URIs and compared query parameters order-independently. As a side effect it also accepted:

- additional query parameters when the registered URI had none (e.g. `http://app.co/?query=hello` against registered `http://app.co`)
- reordered query parameters (`?bing=bang&foo=bar` against `?foo=bar&bing=bang`)
- host/scheme case differences and default-port normalization (via `URI#==`)
- a blank query difference (`http://app.co/aaa?` against `http://app.co/aaa`)

`matches?` now compares the two strings for equality. The only exception kept is RFC 8252, [Section 7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3): loopback interface redirect URIs (`127.0.0.1` / `[::1]`) still match regardless of port, so native apps can bind an ephemeral port at runtime. That path still needs URI parsing and is only reached when the plain string comparison fails.

The now unused `query_matches?` helper is removed.

## Breaking change

This is a breaking change targeted at 6.0: clients that currently rely on sending extra or reordered query parameters in `redirect_uri` (at the authorization endpoint or at the token endpoint) must register and send the exact redirect URI string. Loopback redirect URIs are not affected beyond the port.

`valid_for_authorization?` still supports space/newline-separated lists of registered URIs; each entry is now compared with the strict `matches?`.