### PR TITLE
Add Ruby 4 to CI, remove 3.1 (EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,15 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby:
-          - "3.1"
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
         gemfile:
           - gemfiles/rails_7_0.gemfile
           - gemfiles/rails_7_1.gemfile
           - gemfiles/rails_7_2.gemfile
           - gemfiles/rails_8_0.gemfile
-        exclude:
-          - ruby: 3.1
-            gemfile: gemfiles/rails_8_0.gemfile
     steps:
       - name: Repo checkout
         uses: actions/checkout@v7.0.1


### PR DESCRIPTION
* Add Ruby 4 to CI
* Drop 3.1 
* 3.2 left (ended 3 months ago, let's keep it for some time)