### PR TITLE
Reject a non-string `scope` parameter with `invalid_request` instead of a 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#1865] Revoke the token issued for an authorization code when the code is exchanged more than once, per RFC 6749 §4.1.2 / §10.5. Active when the `oauth_access_grants.access_token_id` column exists: new installs get it from the generated migration, existing apps can add it with `rails generate doorkeeper:grant_reuse_revocation`. Closes [#1713].
 - [#1871] **[BREAKING]** `redirect_uri` is now compared to the registered redirect URIs with the simple string comparison required by RFC 6749 §3.1.2.3 (the RFC 8252 §7.3 loopback port exception is kept). Clients relying on the previous lenient matching must send the exact registered URI, closes [#1718].
+- [#1876] Fix: reject a non-string `scope` parameter (e.g. `scope[a]=b`, which Rack parses into a Hash) with `invalid_request` (RFC 6749 §3.3) instead of an unhandled 500. `Scopes.from_string` now raises `Errors::InvalidScopeParameter` for a non-string argument — turned into `invalid_request` by the token endpoint's `rescue_from`, so every grant type is covered — and the authorization endpoint rejects it up front in pre-authorization validation. The crash was reachable unauthenticated, before client authentication.
 - Please add here
 
 ## 6.0.0.beta1

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -50,6 +50,16 @@ module Doorkeeper
       end
     end
 
+    # Raised when the `scope` parameter is present but not a string — e.g.
+    # `scope[a]=b`, which Rack parses into a Hash. Its octets cannot be split
+    # into scope tokens, so the request is malformed (RFC 6749 §3.3) and must
+    # be answered with `invalid_request` rather than an unhandled 500.
+    class InvalidScopeParameter < DoorkeeperError
+      def type
+        :invalid_request
+      end
+    end
+
     class BaseResponseError < DoorkeeperError
       attr_reader :response
 

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -58,6 +58,13 @@ module Doorkeeper
       def type
         :invalid_request
       end
+
+      # Maps to `invalid_request.unknown` ("... or is otherwise malformed").
+      # Without a reason the token endpoint would translate `nil` and return a
+      # blank error_description.
+      def reason
+        :unknown
+      end
     end
 
     class BaseResponseError < DoorkeeperError

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -123,7 +123,15 @@ module Doorkeeper
                            :scope
                          end
 
-        @missing_param.nil?
+        # A structured `scope` (e.g. `scope[a]=b`, parsed by Rack into a Hash)
+        # is malformed (RFC 6749 §3.3). Reject it here — before validate_scopes
+        # reaches Scopes.from_string — so the authorization endpoint answers
+        # invalid_request instead of letting the raised error surface as a 500.
+        @missing_param.nil? && scope_param_well_formed?
+      end
+
+      def scope_param_well_formed?
+        @scope.nil? || @scope.is_a?(String)
       end
 
       def validate_response_type

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -123,11 +123,17 @@ module Doorkeeper
                            :scope
                          end
 
+        return false unless @missing_param.nil?
+
         # A structured `scope` (e.g. `scope[a]=b`, parsed by Rack into a Hash)
         # is malformed (RFC 6749 §3.3). Reject it here — before validate_scopes
         # reaches Scopes.from_string — so the authorization endpoint answers
         # invalid_request instead of letting the raised error surface as a 500.
-        @missing_param.nil? && scope_param_well_formed?
+        # Set a reason so the error_description is not translated from nil.
+        return true if scope_param_well_formed?
+
+        @invalid_request_reason = :unknown
+        false
       end
 
       def scope_param_well_formed?

--- a/lib/doorkeeper/oauth/scopes.rb
+++ b/lib/doorkeeper/oauth/scopes.rb
@@ -10,6 +10,14 @@ module Doorkeeper
 
       def self.from_string(string)
         string ||= ""
+
+        # A non-string scope (e.g. `scope[a]=b`, parsed by Rack into a Hash)
+        # has no octets to split into tokens. Reject it as a malformed request
+        # (RFC 6749 §3.3); at the token endpoint TokensController's rescue_from
+        # turns this into invalid_request. Callers that always pass a string
+        # (the model layer) never hit this.
+        raise Errors::InvalidScopeParameter, "scope must be a String" unless string.is_a?(String)
+
         new.tap do |scope|
           scope.add(*string.split)
         end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -164,6 +164,7 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
       expect { @authorizable = pre_auth.authorizable? }.not_to raise_error
       expect(@authorizable).to be false
       expect(pre_auth.error).to eq(Doorkeeper::Errors::InvalidRequest)
+      expect(pre_auth.invalid_request_reason).to eq(:unknown)
     end
 
     it "accepts scopes which are permitted for grant_type" do

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -158,6 +158,14 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
       expect(pre_auth).not_to be_authorizable
     end
 
+    it "rejects a non-string scope (e.g. scope[a]=b) with invalid_request rather than raising" do
+      attributes[:scope] = { "a" => "b" }.with_indifferent_access
+
+      expect { @authorizable = pre_auth.authorizable? }.not_to raise_error
+      expect(@authorizable).to be false
+      expect(pre_auth.error).to eq(Doorkeeper::Errors::InvalidRequest)
+    end
+
     it "accepts scopes which are permitted for grant_type" do
       allow(server).to receive(:scopes_by_grant_type).and_return(authorization_code: [:public])
       attributes[:scope] = "public"

--- a/spec/lib/oauth/scopes_spec.rb
+++ b/spec/lib/oauth/scopes_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe Doorkeeper::OAuth::Scopes do
 
     it { expect(scopes).to be_a(described_class) }
 
+    it "treats nil as an empty scope" do
+      expect(described_class.from_string(nil).all).to be_empty
+    end
+
+    it "raises InvalidScopeParameter for a non-string scope (e.g. scope[a]=b)" do
+      expect { described_class.from_string({ "a" => "b" }.with_indifferent_access) }
+        .to raise_error(Doorkeeper::Errors::InvalidScopeParameter)
+    end
+
     describe "#all" do
       it "is an array of the expected scopes" do
         scopes_array = scopes.all

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -182,6 +182,18 @@ RSpec.describe "Client Credentials Request" do
     end
   end
 
+  context "when the scope parameter is not a string (e.g. scope[a]=b)" do
+    it "responds with invalid_request instead of a 500 (RFC 6749 §3.3)" do
+      headers = authorization client.uid, client.secret
+      params  = { grant_type: "client_credentials", scope: { "a" => "b" } }
+
+      post token_endpoint_url, params: params, headers: headers
+
+      expect(response).to have_http_status(:bad_request)
+      expect(json_response).to include("error" => "invalid_request")
+    end
+  end
+
   context "when the request uses more than one client authentication method" do
     it "rejects the request per RFC 6749 §2.3" do
       headers = authorization client.uid, client.secret

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -191,6 +191,7 @@ RSpec.describe "Client Credentials Request" do
 
       expect(response).to have_http_status(:bad_request)
       expect(json_response).to include("error" => "invalid_request")
+      expect(json_response["error_description"]).to be_present
     end
   end
 


### PR DESCRIPTION
### Problem

`Scopes.from_string` assumes a string and calls `#split`. A nested `scope` parameter — `scope[a]=b`, which Rack parses into a Hash — reaches it and raises `NoMethodError`. That is not a `DoorkeeperError`, so it bypasses `TokensController`'s `rescue_from` and surfaces as an unhandled **500** rather than RFC 6749 §5.2's 400. The crash happens *before* client authentication, so it is reachable unauthenticated. (An array `scope[]=a` coincidentally survives via `Array#split`→`Array#flatten`; only the Hash shape hits this sink. Likely pre-existing.)

### Fix

`Scopes.from_string` now raises `Errors::InvalidScopeParameter` (type `invalid_request`) for a non-string argument:

- **Token endpoint:** the controller's `rescue_from Errors::DoorkeeperError` turns it into `invalid_request`, covering every grant that parses scopes (client_credentials, password, refresh_token) through the one shared sink.
- **Authorization endpoint:** `pre_auth.authorizable?` does not rescue arbitrary errors, so raising inside validation would itself be a 500. Pre-authorization instead rejects a non-string scope up front in `validate_params` (which runs before `validate_scopes` reaches `from_string`), yielding `invalid_request`.
- The model layer always passes a string, so it is unaffected.