### PR TITLE
Index `oauth_access_grants.access_token_id`, which #1879 began filtering by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ User-visible changes worth mentioning.
 - [#1881] Fix: `Doorkeeper::ApplicationsController` no longer 500s on `create`/`update`/`destroy` in `api_only` mode, where `ActionController::API` provides no `flash`. Confining `flash` to the HTML path is not sufficient on its own, because a client that does not name JSON explicitly still negotiates its way into that path — an absent `Accept` header and a browser-like list such as `application/json, text/plain, */*` both resolve to `text/html`, and a bare `*/*` resolves to the first registered format — so `api_only` mode now pins the response format to JSON.
 - [#1883] Internal: merge `CHANGELOG.md` with git's `union` driver, so two pull requests that each add an entry no longer conflict on the line above "Please add here".
 - [#1884] Fix: `/oauth/introspect` and `/oauth/revoke` extend the token lookup across both token types when the lookup by `token_type_hint` finds nothing (RFC 7662 §2.1 / RFC 7009 §2.1), so a wrong hint no longer hides a token the server knows about ([#1882])
+- [#1885] Index `oauth_access_grants.access_token_id` in the migration templates: since [#1879] the code-replay revocation filters access grants by that column, the "never used to filter queries" premise behind `index: false` no longer holds.
 - Please add here
 
 ## 6.0.0.beta1

--- a/lib/generators/doorkeeper/templates/add_access_token_to_access_grants.rb.erb
+++ b/lib/generators/doorkeeper/templates/add_access_token_to_access_grants.rb.erb
@@ -2,8 +2,9 @@
 
 class AddAccessTokenToAccessGrants < ActiveRecord::Migration<%= migration_version %>
   def change
-    # No index: the column is only read back from an already-loaded grant,
-    # never used to filter queries.
-    add_reference :oauth_access_grants, :access_token, index: false
+    # Indexed: when a code is replayed, the revocation checks whether the
+    # issued token is still referenced by another grant, which filters
+    # oauth_access_grants by access_token_id.
+    add_reference :oauth_access_grants, :access_token, index: true
   end
 end

--- a/lib/generators/doorkeeper/templates/migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/migration.rb.erb
@@ -37,9 +37,10 @@ class CreateDoorkeeperTables < ActiveRecord::Migration<%= migration_version %>
       # Comment out this line if you don't want a reused authorization code
       # to revoke the tokens already issued for it.
       #
-      # No index: the column is only read back from an already-loaded grant,
-      # never used to filter queries.
-      t.references :access_token,    index: false
+      # Indexed: when a code is replayed, the revocation checks whether the
+      # issued token is still referenced by another grant, which filters
+      # this table by access_token_id.
+      t.references :access_token,    index: true
     end
 
     add_index :oauth_access_grants, :token, unique: true

--- a/spec/dummy/db/migrate/20260716000000_add_access_token_to_access_grants.rb
+++ b/spec/dummy/db/migrate/20260716000000_add_access_token_to_access_grants.rb
@@ -2,6 +2,6 @@
 
 class AddAccessTokenToAccessGrants < ActiveRecord::Migration[6.1]
   def change
-    add_reference :oauth_access_grants, :access_token, index: false
+    add_reference :oauth_access_grants, :access_token, index: true
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20260716000000) do
       t.string   "code_challenge"
       t.string   "code_challenge_method"
     end
+    t.index ["access_token_id"], name: "index_oauth_access_grants_on_access_token_id"
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 


### PR DESCRIPTION
When #1865 added the `access_token` reference to `oauth_access_grants`, the column was only written at code exchange and read back from an already-loaded grant, so the migration template opted out of the reference's default index — and said so: *"No index: the column is only read back from an already-loaded grant, never used to filter queries."* That was accurate at the time; I wrote it.

#1879 quietly invalidated that premise, and I missed it while reviewing my own follow-up. The shared-token guard it introduced (`token_shared_with_other_grant?`) asks, on a code replay, whether the issued token is still referenced by another grant — an `exists?` that filters `oauth_access_grants` by `access_token_id`. In the common case (no other grant references the token) the predicate matches nothing, which without an index means a scan of the whole table, and the lookup deliberately runs under `with_primary_role`, so the scan always lands on the primary. Code replays are not exotic: an interrupted network round-trip or a double submit re-sends a consumed code in ordinary operation, and grants accumulate one row per authorization on installs that don't run `doorkeeper:db:cleanup`, so the cost grows quietly with table age.

With the premise gone, the column should follow the same convention as every other reference in the schema, all of which are indexed. This PR:

- drops `index: false` from both migration templates (`add_reference`/`t.references` index by default) and replaces the stale comment with the actual access pattern,
- updates the dummy app's migration and schema so the test schema matches what the template generates.

The timing is the point of doing this now rather than later: 6.0.0.beta1 predates the column, so no released migration has created it yet and this stays a template-only change. Once 6.0.0 final ships the column unindexed, correcting it would take an additional migration plus generator support for existing installs.