### PR TITLE
Add Resource Indicators for OAuth 2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec rake spec
 
 ## Change guidance
 
+- Preserve backward compatibility.
 - Make surgical changes with specs close to the behavior you changed.
 - When changing engine behavior, check whether the impact also reaches host-app integration through `spec/dummy`.
 - When changing protocol or token behavior, look for nearby request, controller, and model specs that should move together.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ User-visible changes worth mentioning.
 - [#1887] [test] Pin that a requested non-default scope reaches the authorization grant and the exchanged token, and that the authorization strategy shares the controller's pre-authorization — the mismatch reported in [#1576] does not reproduce. Test-only change, closes [#1576].
 - [#1888] Document custom grant flow registration (`Doorkeeper::GrantFlow.register`) in the README with a SAML 2.0 bearer assertion (RFC 7522) walkthrough, and pin URN-shaped custom grant types with an end-to-end request spec. Docs/test-only change, closes [#764].
 - [#1890] [test] Pin that the authorization endpoint answers `invalid_redirect_uri` for a client registered without a redirect URI (`allow_blank_redirect_uri`), whether or not the request supplies one — the behavior required by RFC 6749 §3.1.2.3. Test-only change, closes [#1682].
+- [#1886] Add support for Resource Indicators for OAuth 2.0 (RFC 8707). Clients can include a `resource` parameter in authorization and token requests to indicate the target protected resource(s). The authorization server validates resource URIs, enforces audience restriction on tokens, and includes `aud` in introspection responses. Enable by configuring `resource_indicator_validator` with a callable. Requires new `resource` columns on access grants and tokens — run `rails generate doorkeeper:resource_indicators` to add the migration.
 - Please add here
 
 ## 6.0.0.beta1

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Supported features:
 - [OAuth 2.0 for Native Apps](https://datatracker.ietf.org/doc/html/rfc8252)
 - [Proof Key for Code Exchange by OAuth Public Clients](https://datatracker.ietf.org/doc/html/rfc7636)
 - [OAuth 2.0 Authorization Server Issuer Identification](https://datatracker.ietf.org/doc/html/rfc9207) — opt-in by setting `issuer`; adds the `iss` parameter to authorization redirects returned to the client
+- [Resource Indicators for OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc8707)
 
 ## Table of Contents
 
@@ -38,6 +39,7 @@ Supported features:
   - [Grape](#grape)
 - [ORMs](#orms)
 - [Extensions](#extensions)
+- [Resource Indicators](#resource-indicators)
 - [Custom Grant Flows](#custom-grant-flows)
 - [Example Applications](#example-applications)
 - [Sponsors](#sponsors)
@@ -107,6 +109,51 @@ Extensions that are not included by default and can be installed separately.
 | I18n translations | [doorkeeper-gem/doorkeeper-i18n](https://github.com/doorkeeper-gem/doorkeeper-i18n) |
 | CIBA - Client Initiated Backchannel Authentication Flow extension | [doorkeeper-ciba](https://github.com/autoseg/doorkeeper-ciba) |
 | Device Authorization Grant | [doorkeeper-device_authorization_grant](https://github.com/exop-group/doorkeeper-device_authorization_grant) |
+
+## Resource Indicators
+
+Doorkeeper supports [Resource Indicators for OAuth 2.0 (RFC 8707)](https://datatracker.ietf.org/doc/html/rfc8707), allowing clients to signal which protected resource(s) they intend to access. Tokens are then audience-restricted to those resources.
+
+### Setup
+
+1. Run the generator to add the required `resource` column:
+
+```bash
+rails generate doorkeeper:resource_indicators
+rails db:migrate
+```
+
+2. Configure a validator in your initializer:
+
+```ruby
+# config/initializers/doorkeeper.rb
+Doorkeeper.configure do
+  resource_indicator_validator ->(resource_indicators, client) {
+    allowed = %w[https://api.example.com/ https://calendar.example.com/]
+    resource_indicators.all? { |r| allowed.include?(r) }
+  }
+end
+```
+
+The callable receives an array of resource URIs and the OAuth client. Return `true` to accept or `false` to reject with `invalid_target`.
+
+### Behavior
+
+- Resource URIs must be absolute and must not contain a fragment component.
+- Resource indicators are stored on grants and tokens.
+- Token and refresh requests enforce subset restrictions against the original grant.
+- Token introspection responses include `aud` when resource indicators are present.
+- Grants issued with resource indicators retain their audience restriction even if the validator is later removed from configuration.
+
+### Multiple resources
+
+RFC 8707 uses repeated query parameters (`?resource=…&resource=…`) for multiple values, but Rack collapses repeated keys to the last value. Clients must use the Rails bracket syntax for multiple resource indicators:
+
+```
+?resource[]=https://api.example.com/&resource[]=https://calendar.example.com/
+```
+
+A single `resource=…` works as-is.
 
 ## Custom Grant Flows
 

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -65,7 +65,12 @@ module Doorkeeper
         pre_auth.client,
         current_resource_owner,
         pre_auth.scopes,
-      )
+      ) do |token|
+        # RFC 8707: a token for a different audience must not satisfy the match.
+        Doorkeeper.config.access_token_model.resource_indicators_match?(
+          token, pre_auth.resource_indicators&.join(" ").presence,
+        )
+      end
     end
 
     def redirect_or_render(auth)
@@ -101,11 +106,20 @@ module Doorkeeper
     end
 
     def pre_auth_params
-      params.slice(*pre_auth_param_fields).permit(*pre_auth_param_fields)
+      # RFC 8707: `resource` may appear as a single value (?resource=…) or as
+      # a Rails-style array (?resource[]=…&resource[]=…). Both scalar and array
+      # forms are permitted through strong parameters.
+      #
+      # NOTE: The RFC wire format uses repeated keys (?resource=…&resource=…),
+      # but Rack collapses those into the last value. Clients targeting this
+      # endpoint must use the resource[] bracket syntax for multiple values.
+      params
+        .slice(*pre_auth_param_fields, :resource)
+        .permit(*pre_auth_param_fields, :resource, resource: [])
     end
 
     def pre_auth_param_fields
-      custom_access_token_attributes + %i[
+      @pre_auth_param_fields ||= custom_access_token_attributes + %i[
         client_id
         code_challenge
         code_challenge_method

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -19,6 +19,18 @@
     </div>
   <% end %>
 
+  <% if Array(@pre_auth.resource_indicators).any? %>
+    <div id="oauth-resources">
+      <h3><%= t('.resources') %></h3>
+
+      <ul class="text-info">
+        <% Array(@pre_auth.resource_indicators).each do |resource| %>
+          <li><%= resource %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div class="actions">
     <%= form_tag oauth_authorization_path, method: :post do %>
       <%= hidden_field_tag :client_id, @pre_auth.client.uid, id: nil %>
@@ -31,6 +43,9 @@
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
       <% @pre_auth.custom_access_token_attributes.each do |attribute_name, attribute_value| %>
         <%= hidden_field_tag attribute_name, attribute_value, id: nil %>
+      <% end %>
+      <% Array.wrap(@pre_auth.resource_indicators).each do |resource_value| %>
+        <%= hidden_field_tag "resource[]", resource_value, id: nil %>
       <% end %>
       <%= submit_tag t('doorkeeper.authorizations.buttons.authorize'), class: "btn btn-success btn-lg btn-block" %>
     <% end %>
@@ -45,6 +60,9 @@
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
       <% @pre_auth.custom_access_token_attributes.each do |attribute_name, attribute_value| %>
         <%= hidden_field_tag attribute_name, attribute_value, id: nil %>
+      <% end %>
+      <% Array.wrap(@pre_auth.resource_indicators).each do |resource_value| %>
+        <%= hidden_field_tag "resource[]", resource_value, id: nil %>
       <% end %>
       <%= submit_tag t('doorkeeper.authorizations.buttons.deny'), class: "btn btn-danger btn-lg btn-block" %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,7 @@ en:
         title: 'Authorization required'
         prompt: 'Authorize %{client_name} to use your account?'
         able_to: 'This application will be able to:'
+        resources: 'Resources'
       show:
         title: 'Authorization code:'
       form_post:
@@ -108,6 +109,7 @@ en:
           other: 'The code_challenge_method must be one of %{challenge_methods}.'
         server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
         temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+        invalid_target: 'The requested resource is invalid, missing, unknown, or malformed.'
 
         # Configuration error messages
         credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -58,6 +58,7 @@ module Doorkeeper
     autoload :PasswordAccessTokenRequest, "doorkeeper/oauth/password_access_token_request"
     autoload :PreAuthorization, "doorkeeper/oauth/pre_authorization"
     autoload :RefreshTokenRequest, "doorkeeper/oauth/refresh_token_request"
+    autoload :ResourceIndicatorValidator, "doorkeeper/oauth/resource_indicator_validator"
     autoload :Scopes, "doorkeeper/oauth/scopes"
     autoload :Token, "doorkeeper/oauth/token"
     autoload :TokenIntrospection, "doorkeeper/oauth/token_introspection"

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -385,6 +385,24 @@ module Doorkeeper
     # (RFC 8414). When nil, the request base URL is used instead.
     option :issuer,                         default: nil
 
+    # Resource Indicators for OAuth 2.0 (RFC 8707).
+    #
+    # When set to a callable (lambda/proc), enables RFC 8707 support. The callable
+    # receives the array of resource indicator URIs and the client, and must return
+    # true if the resource(s) are acceptable, or false to reject with `invalid_target`.
+    #
+    # When nil (default), the `resource` parameter is ignored and RFC 8707 is disabled.
+    #
+    # @example
+    #   resource_indicator_validator ->(resource_indicators, client) {
+    #     resource_indicators.all? { |r| allowed_resources.include?(r) }
+    #   }
+    #
+    # @param validator [Proc, nil] A callable that validates resource indicators
+    # @see https://datatracker.ietf.org/doc/html/rfc8707
+    #
+    option :resource_indicator_validator, default: nil
+
     # Forces the usage of the HTTPS protocol in non-native redirect uris
     # (enabled by default in non-development environments). OAuth2
     # delegates security in communication to the HTTPS protocol so it is

--- a/lib/doorkeeper/errors.rb
+++ b/lib/doorkeeper/errors.rb
@@ -94,12 +94,43 @@ module Doorkeeper
     NoOrmCleaner = Class.new(DoorkeeperError)
     MissingConfigurationBuilderClass = Class.new(DoorkeeperError)
 
+    # Raised when resource_indicator_validator is configured but the required
+    # `resource` column has not been added to the database. Provides an
+    # actionable message pointing to the generator.
+    #
+    # `#type` returns `:server_error` so the token endpoint (which rescues
+    # DoorkeeperError and builds an OAuth error response from `#type`) emits a
+    # spec-compliant error code; the actionable message is retained on the
+    # exception for logs rather than being sent as the `error` value.
+    class MissingResourceColumn < DoorkeeperError
+      def initialize(table)
+        super(
+          "resource_indicator_validator is configured but the `resource` column is missing from " \
+          "the #{table} table. Run `rails generate doorkeeper:resource_indicators` and apply the migration.",
+        )
+      end
+
+      def type
+        :server_error
+      end
+    end
+
     InvalidRequest = Class.new(BaseResponseError)
     InvalidToken = Class.new(BaseResponseError)
     InvalidClient = Class.new(BaseResponseError)
     InvalidScope = Class.new(BaseResponseError)
     InvalidRedirectUri = Class.new(BaseResponseError)
     InvalidGrant = Class.new(BaseResponseError)
+    # RFC 8707 error: the requested resource is invalid, missing, unknown, or malformed.
+    # Raised bare (no arguments) as a signal inside ResourceIndicatorValidator,
+    # then rescued and surfaced through the validation framework. Also raised
+    # with a response by ErrorResponse#raise_exception! so that controller
+    # rescue handlers can extract #response for translated error descriptions.
+    class InvalidTarget < BaseResponseError
+      def initialize(response = nil)
+        super
+      end
+    end
 
     UnauthorizedClient = Class.new(BaseResponseError)
     UnsupportedResponseType = Class.new(BaseResponseError)

--- a/lib/doorkeeper/models/access_grant_mixin.rb
+++ b/lib/doorkeeper/models/access_grant_mixin.rb
@@ -100,6 +100,13 @@ module Doorkeeper
         column_names.include?("code_challenge")
       end
 
+      # RFC 8707: resource indicators are supported only when the
+      # `resource` column exists (added by the
+      # `doorkeeper:resource_indicators` generator).
+      def resource_indicators_supported?
+        column_names.include?("resource")
+      end
+
       # Replay protection for authorization codes (RFC 6749 §4.1.2, §10.5)
       # is active only when the `access_token_id` column exists (added by
       # the `doorkeeper:grant_reuse_revocation` generator): the column

--- a/lib/doorkeeper/models/access_token_mixin.rb
+++ b/lib/doorkeeper/models/access_token_mixin.rb
@@ -229,6 +229,39 @@ module Doorkeeper
         end
       end
 
+      # RFC 8707: checks whether an existing token's audience matches the
+      # requested resource indicators. Used during token reuse to prevent
+      # returning a token audience-restricted to one resource for a request
+      # targeting a different resource.
+      #
+      # The comparison runs whenever either side carries a resource, even when
+      # no validator is configured: a grant bound to resources still restricts
+      # the token's audience (see AuthorizationCodeRequest), so reuse must not
+      # silently widen it by matching an unrestricted or differently-scoped
+      # token. When both sides are blank the tokens are unrestricted and match.
+      #
+      # @param token [Doorkeeper::AccessToken] existing token
+      # @param requested_resource [String, nil] space-delimited resource URIs
+      # @return [Boolean]
+      def resource_indicators_match?(token, requested_resource)
+        token_resource = token.try(:resource)
+
+        # Both blank — neither is audience-restricted, match.
+        return true if token_resource.blank? && requested_resource.blank?
+        # One blank, the other not — mismatch.
+        return false if token_resource.blank? || requested_resource.blank?
+
+        # Both present — compare as sorted sets.
+        token_resource.split.sort == requested_resource.split.sort
+      end
+
+      # RFC 8707: resource indicators are supported only when the
+      # `resource` column exists (added by the
+      # `doorkeeper:resource_indicators` generator).
+      def resource_indicators_supported?
+        column_names.include?("resource")
+      end
+
       # Looking for not expired AccessToken record with a matching set of
       # scopes that belongs to specific Application and Resource Owner.
       # If it doesn't exists - then creates it.
@@ -261,9 +294,17 @@ module Doorkeeper
           # matching token may carry the wrong refresh token presence (e.g. it
           # was issued through a grant with a different `use_refresh_token`)
           # while an older token satisfies the request and can still be reused.
+          #
+          # RFC 8707: resource indicators must also match so that a token
+          # audience-restricted to one resource is never reused for another.
+          requested_resource = token_attributes[:resource]
+
           access_token = matching_token_for(
             application, resource_owner, scopes, custom_attributes: custom_attributes, include_expired: false,
-          ) { |token| refresh_token_matches?(token, token_attributes) }
+          ) do |token|
+            refresh_token_matches?(token, token_attributes) &&
+              resource_indicators_match?(token, requested_resource)
+          end
 
           return access_token if access_token&.reusable?
         end

--- a/lib/doorkeeper/oauth/authorization/code.rb
+++ b/lib/doorkeeper/oauth/authorization/code.rb
@@ -47,6 +47,16 @@ module Doorkeeper
             attributes[:resource_owner_id] = resource_owner.id
           end
 
+          # RFC 8707: persist resource indicators so they can be enforced at
+          # the token endpoint (subset validation) and carried to the token.
+          if pre_auth.respond_to?(:resource_indicators) && pre_auth.resource_indicators.present?
+            unless Doorkeeper.config.access_grant_model.resource_indicators_supported?
+              raise Doorkeeper::Errors::MissingResourceColumn, "oauth_access_grants"
+            end
+
+            attributes[:resource] = pre_auth.resource_indicators.join(" ")
+          end
+
           pkce_attributes.merge(attributes).merge(custom_attributes)
         end
 

--- a/lib/doorkeeper/oauth/authorization/token.rb
+++ b/lib/doorkeeper/oauth/authorization/token.rb
@@ -59,13 +59,24 @@ module Doorkeeper
             resource_owner,
           )
 
-          @token = Doorkeeper.config.access_token_model.find_or_create_for(
+          token_attributes = {
             application: application,
             resource_owner: resource_owner,
             scopes: pre_auth.scopes,
             expires_in: self.class.access_token_expires_in(Doorkeeper.config, context),
             use_refresh_token: false,
-          )
+          }
+
+          # RFC 8707: carry resource indicators to the access token
+          if pre_auth.respond_to?(:resource_indicators) && pre_auth.resource_indicators.present?
+            unless Doorkeeper.config.access_token_model.resource_indicators_supported?
+              raise Doorkeeper::Errors::MissingResourceColumn, "oauth_access_tokens"
+            end
+
+            token_attributes[:resource] = pre_auth.resource_indicators.join(" ")
+          end
+
+          @token = Doorkeeper.config.access_token_model.find_or_create_for(**token_attributes)
         end
 
         def application

--- a/lib/doorkeeper/oauth/authorization_code_request.rb
+++ b/lib/doorkeeper/oauth/authorization_code_request.rb
@@ -12,6 +12,7 @@ module Doorkeeper
       # Runs last, so the single-use enforcement it performs only acts once
       # the caller has proven possession of the code (redirect_uri + PKCE).
       validate :grant_accessible, error: Errors::InvalidGrant
+      validate :resource_indicators, error: Errors::InvalidTarget
 
       attr_reader :grant, :client, :redirect_uri, :access_token, :code_verifier,
                   :invalid_request_reason, :missing_param
@@ -27,6 +28,7 @@ module Doorkeeper
         @grant_type = Doorkeeper::OAuth::AUTHORIZATION_CODE
         @redirect_uri = parameters[:redirect_uri]
         @code_verifier = parameters[:code_verifier]
+        @raw_resource_indicators = parameters[:resource]
       end
 
       private
@@ -42,11 +44,26 @@ module Doorkeeper
 
           grant.revoke
 
+          token_attributes = custom_token_attributes_with_data
+          # RFC 8707 §2.2: audience-restrict the access token to the resources
+          # bound to the grant. When the token request specifies a (valid)
+          # subset, use that subset; when it omits `resource`, inherit the
+          # grant's full resource set so the token is never issued without an
+          # audience restriction.
+          effective_resources = resolved_resource_indicators.presence || grant_resource_indicators
+          if effective_resources.present?
+            unless Doorkeeper.config.access_token_model.resource_indicators_supported?
+              raise Errors::MissingResourceColumn, "oauth_access_tokens"
+            end
+
+            token_attributes[:resource] = effective_resources.join(" ")
+          end
+
           find_or_create_access_token(
             client,
             resource_owner,
             grant.scopes,
-            custom_token_attributes_with_data,
+            token_attributes,
             server,
           )
 
@@ -139,6 +156,44 @@ module Doorkeeper
           .with_indifferent_access
           .slice(*Doorkeeper.config.custom_access_token_attributes)
           .symbolize_keys
+      end
+
+      # RFC 8707: validate resource indicators on the token request.
+      # If the grant carries resource indicators, the token request's resource
+      # parameter must be a subset. If no grant resource is present, the
+      # validator checks the request resource against server policy.
+      #
+      # Subset and syntax enforcement run even when no validator is configured
+      # as long as the grant is already audience-restricted: a grant bound to
+      # resources must never be exchanged for a token whose audience widens
+      # beyond it. Only when the feature is disabled AND the grant has no
+      # stored resources is the `resource` parameter ignored entirely.
+      def validate_resource_indicators
+        @grant_resource_indicators = grant&.try(:resource)&.split
+
+        validator = Doorkeeper.config.resource_indicator_validator
+
+        # Feature effectively off: no validator and nothing already bound to
+        # enforce against. Ignore the `resource` parameter.
+        return true if validator.nil? && @grant_resource_indicators.blank?
+
+        @resolved_resource_indicators = ResourceIndicatorValidator.validate!(
+          @raw_resource_indicators,
+          config_validator: validator,
+          client: client,
+          grant_resource_indicators: @grant_resource_indicators,
+        )
+        true
+      rescue Errors::InvalidTarget
+        false
+      end
+
+      def resolved_resource_indicators
+        @resolved_resource_indicators || []
+      end
+
+      def grant_resource_indicators
+        @grant_resource_indicators || []
       end
 
       def revoke_previous_tokens(application, resource_owner)

--- a/lib/doorkeeper/oauth/client_credentials_request.rb
+++ b/lib/doorkeeper/oauth/client_credentials_request.rb
@@ -7,19 +7,23 @@ module Doorkeeper
 
       alias error_response response
 
-      delegate :error, to: :issuer
-
       def initialize(server, client, parameters = {})
+        super()
         @client = client
         @server = server
         @response = nil
         @grant_type = Doorkeeper::OAuth::CLIENT_CREDENTIALS
         @original_scopes = parameters[:scope]
-        @parameters = parameters.except(:scope)
+        @raw_resource_indicators = parameters[:resource]
+        @parameters = parameters.except(:scope, :resource)
       end
 
       def access_token
         issuer.token
+      end
+
+      def error
+        @resource_indicator_error || issuer.error
       end
 
       def issuer
@@ -32,14 +36,41 @@ module Doorkeeper
       private
 
       def valid?
-        issuer.create(client, scopes, custom_token_attributes_with_data)
+        validate_resource_indicators && issuer.create(client, scopes, custom_token_attributes_with_data)
+      end
+
+      def validate_resource_indicators
+        validator = Doorkeeper.config.resource_indicator_validator
+        return true unless validator
+        return true if @raw_resource_indicators.blank?
+
+        @resolved_resource_indicators = ResourceIndicatorValidator.validate!(
+          @raw_resource_indicators,
+          config_validator: validator,
+          client: client,
+        )
+        true
+      rescue Errors::InvalidTarget
+        @resource_indicator_error = Errors::InvalidTarget
+        false
       end
 
       def custom_token_attributes_with_data
-        parameters
+        attrs = parameters
           .with_indifferent_access
           .slice(*Doorkeeper.config.custom_access_token_attributes)
           .symbolize_keys
+
+        # RFC 8707: attach validated resource indicators to token attributes
+        if @resolved_resource_indicators.present?
+          unless Doorkeeper.config.access_token_model.resource_indicators_supported?
+            raise Errors::MissingResourceColumn, "oauth_access_tokens"
+          end
+
+          attrs[:resource] = @resolved_resource_indicators.join(" ")
+        end
+
+        attrs
       end
     end
   end

--- a/lib/doorkeeper/oauth/metadata_response.rb
+++ b/lib/doorkeeper/oauth/metadata_response.rb
@@ -35,6 +35,8 @@ module Doorkeeper
             # condition under which the iss parameter is emitted. false survives
             # the compaction below, so it is advertised explicitly.
             authorization_response_iss_parameter_supported: config.issuer.present?,
+            # RFC 8707: advertise resource indicator support when configured.
+            resource_indicators_supported: resource_indicators_supported?,
           }
           data.compact!
 
@@ -151,6 +153,12 @@ module Doorkeeper
 
       def code_challenge_methods_supported
         config.pkce_code_challenge_methods_supported
+      end
+
+      def resource_indicators_supported?
+        config.resource_indicator_validator.present? &&
+          Doorkeeper.config.access_grant_model.resource_indicators_supported? &&
+          Doorkeeper.config.access_token_model.resource_indicators_supported?
       end
     end
   end

--- a/lib/doorkeeper/oauth/password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/password_access_token_request.rb
@@ -9,10 +9,12 @@ module Doorkeeper
       validate :client_supports_grant_flow, error: Errors::UnauthorizedClient
       validate :resource_owner, error: Errors::InvalidGrant
       validate :scopes, error: Errors::InvalidScope
+      validate :resource_indicators, error: Errors::InvalidTarget
 
       attr_reader :client, :credentials, :resource_owner, :parameters, :access_token
 
       def initialize(server, client, credentials, resource_owner, parameters = {})
+        super()
         @server          = server
         @resource_owner  = resource_owner
         @client          = client
@@ -20,12 +22,21 @@ module Doorkeeper
         @parameters      = parameters
         @original_scopes = parameters[:scope]
         @grant_type      = Doorkeeper::OAuth::PASSWORD
+        @raw_resource_indicators = parameters[:resource]
       end
 
       private
 
       def before_successful_response
-        find_or_create_access_token(client, resource_owner, scopes, {}, server)
+        token_attributes = {}
+        if @resolved_resource_indicators.present?
+          unless Doorkeeper.config.access_token_model.resource_indicators_supported?
+            raise Errors::MissingResourceColumn, "oauth_access_tokens"
+          end
+
+          token_attributes[:resource] = @resolved_resource_indicators.join(" ")
+        end
+        find_or_create_access_token(client, resource_owner, scopes, token_attributes, server)
         super
       end
 
@@ -69,6 +80,21 @@ module Doorkeeper
 
       def validate_client_supports_grant_flow
         Doorkeeper.config.allow_grant_flow_for_client?(grant_type, client&.application)
+      end
+
+      # RFC 8707: validate resource indicators against server policy.
+      def validate_resource_indicators
+        validator = Doorkeeper.config.resource_indicator_validator
+        return true unless validator
+
+        @resolved_resource_indicators = ResourceIndicatorValidator.validate!(
+          @raw_resource_indicators,
+          config_validator: validator,
+          client: client,
+        )
+        true
+      rescue Errors::InvalidTarget
+        false
       end
     end
   end

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -16,11 +16,12 @@ module Doorkeeper
       validate :scopes, error: Errors::InvalidScope
       validate :code_challenge, error: Errors::InvalidRequest
       validate :code_challenge_method, error: Errors::InvalidCodeChallengeMethod
+      validate :resource_indicators, error: Errors::InvalidTarget
 
       attr_reader :client, :code_challenge, :code_challenge_method, :missing_param,
                   :redirect_uri, :resource_owner, :response_type, :state,
                   :authorization_response_flow, :response_mode, :custom_access_token_attributes,
-                  :invalid_request_reason
+                  :invalid_request_reason, :resource_indicators
 
       def initialize(server, parameters = {}, resource_owner = nil)
         @server = server
@@ -34,6 +35,7 @@ module Doorkeeper
         @code_challenge_method = parameters[:code_challenge_method]
         @resource_owner = resource_owner
         @custom_access_token_attributes = parameters.slice(*Doorkeeper.config.custom_access_token_attributes).to_h
+        @raw_resource_indicators = parameters[:resource]
       end
 
       def authorizable?
@@ -180,6 +182,21 @@ module Doorkeeper
 
         code_challenge.blank? ||
           (code_challenge_method.present? && Doorkeeper.config.pkce_code_challenge_methods_supported.include?(code_challenge_method))
+      end
+
+      def validate_resource_indicators
+        validator = Doorkeeper.config.resource_indicator_validator
+        # When no validator is configured, resource indicators are ignored (feature disabled)
+        return true unless validator
+
+        @resource_indicators = ResourceIndicatorValidator.validate!(
+          @raw_resource_indicators,
+          config_validator: validator,
+          client: client,
+        )
+        true
+      rescue Errors::InvalidTarget
+        false
       end
 
       def response_on_fragment?

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -10,6 +10,7 @@ module Doorkeeper
       validate :client,       error: Errors::InvalidClient
       validate :client_match, error: Errors::InvalidGrant
       validate :scope,        error: Errors::InvalidScope
+      validate :resource_indicators, error: Errors::InvalidTarget
 
       attr_reader :access_token, :client, :credentials, :refresh_token
       attr_reader :missing_param
@@ -21,6 +22,7 @@ module Doorkeeper
         @grant_type = Doorkeeper::OAuth::REFRESH_TOKEN
         @original_scopes = parameters[:scope] || parameters[:scopes]
         @refresh_token_parameter = parameters[:refresh_token]
+        @raw_resource_indicators = parameters[:resource]
         @client = load_client(credentials) if credentials
       end
 
@@ -72,6 +74,19 @@ module Doorkeeper
 
         if refresh_token_revoked_on_use?
           attributes[:previous_refresh_token] = refresh_token.refresh_token
+        end
+
+        # RFC 8707: carry resource indicators to the new access token.
+        # If the refresh request specified a (subset of) resource(s), use those;
+        # otherwise inherit from the refresh token itself.
+        if @resolved_resource_indicators.present?
+          unless Doorkeeper.config.access_token_model.resource_indicators_supported?
+            raise Errors::MissingResourceColumn, "oauth_access_tokens"
+          end
+
+          attributes[:resource] = @resolved_resource_indicators.join(" ")
+        elsif refresh_token.try(:resource).present?
+          attributes[:resource] = refresh_token.resource
         end
 
         # RFC6749
@@ -130,6 +145,34 @@ module Doorkeeper
         else
           true
         end
+      end
+
+      # RFC 8707: resource indicators on refresh must be a subset of those
+      # bound to the original refresh token (which inherited from the grant).
+      #
+      # Subset and syntax enforcement run even when no validator is configured
+      # as long as the original token is already audience-restricted: a refresh
+      # must never widen the audience beyond what the original token carried.
+      # Only when the feature is disabled AND the original token has no stored
+      # resources is the `resource` parameter ignored entirely.
+      def validate_resource_indicators
+        original_resources = refresh_token.try(:resource)&.split
+
+        validator = Doorkeeper.config.resource_indicator_validator
+
+        # Feature effectively off: no validator and nothing already bound to
+        # enforce against. Ignore the `resource` parameter.
+        return true if validator.nil? && original_resources.blank?
+
+        @resolved_resource_indicators = ResourceIndicatorValidator.validate!(
+          @raw_resource_indicators,
+          config_validator: validator,
+          client: client,
+          grant_resource_indicators: original_resources,
+        )
+        true
+      rescue Errors::InvalidTarget
+        false
       end
 
       def custom_token_attributes_with_data

--- a/lib/doorkeeper/oauth/resource_indicator_validator.rb
+++ b/lib/doorkeeper/oauth/resource_indicator_validator.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module Doorkeeper
+  module OAuth
+    # Validates the `resource` parameter per RFC 8707.
+    #
+    # The `resource` value MUST be an absolute URI without a fragment component.
+    # Multiple `resource` parameters MAY be present.
+    #
+    # @see https://datatracker.ietf.org/doc/html/rfc8707#section-2
+    module ResourceIndicatorValidator
+      module_function
+
+      # Validates and normalizes an array of resource indicator values.
+      #
+      # @param resource_indicators [Array<String>, String, nil] One or more resource URIs
+      # @param config_validator [Proc, nil] Custom validator from configuration
+      # @param client [Doorkeeper::OAuth::Client, nil] The requesting client
+      # @param grant_resource_indicators [Array<String>, nil] Resource indicators from the
+      #   original authorization grant (for subset enforcement on token requests)
+      #
+      # @return [Array<String>] Validated resource indicator URIs
+      # @raise [Doorkeeper::Errors::InvalidTarget] When validation fails
+      def validate!(resource_indicators, config_validator: nil, client: nil, grant_resource_indicators: nil)
+        return [] if resource_indicators.blank?
+
+        indicators = Array.wrap(resource_indicators).reject(&:blank?).uniq
+        return [] if indicators.empty?
+
+        indicators.each { |uri| validate_uri!(uri) }
+
+        # If the token request specifies resources, they must be a subset of those
+        # originally granted (RFC 8707 §2.2).
+        raise Errors::InvalidTarget if grant_resource_indicators.present? && (indicators - grant_resource_indicators).any?
+
+        # Custom server policy validation
+        raise Errors::InvalidTarget if config_validator && !config_validator.call(indicators, client)
+
+        indicators
+      end
+
+      # @return [Boolean] true when the values are syntactically valid
+      def valid?(resource_indicators)
+        return true if resource_indicators.blank?
+
+        Array(resource_indicators).reject(&:blank?).all? { |uri| valid_uri?(uri) }
+      end
+
+      def valid_uri?(uri)
+        return false unless uri.is_a?(String)
+
+        parsed = URI.parse(uri)
+        # MUST be absolute URI
+        return false unless parsed.absolute?
+        # MUST NOT include a fragment
+        return false if parsed.fragment
+
+        true
+      rescue URI::InvalidURIError, TypeError
+        false
+      end
+
+      def validate_uri!(uri)
+        raise Errors::InvalidTarget unless valid_uri?(uri)
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/token_introspection.rb
+++ b/lib/doorkeeper/oauth/token_introspection.rb
@@ -113,6 +113,12 @@ module Doorkeeper
           iat: @token.created_at.to_i,
         }
 
+        # RFC 8707: include audience restriction when resource indicators are present
+        if @token.try(:resource).present?
+          aud = @token.resource.split
+          response[:aud] = aud.length == 1 ? aud.first : aud
+        end
+
         # `token_type` (RFC 6749 §7.1) and `exp` describe the access token:
         # a refresh token is not a Bearer credential and has no expiry of its
         # own, so both are omitted (they are OPTIONAL per RFC 7662 §2.2) when

--- a/lib/generators/doorkeeper/resource_indicators_generator.rb
+++ b/lib/generators/doorkeeper/resource_indicators_generator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Doorkeeper
+  # Generates migration with the `resource` column for access grants and
+  # access tokens, required for RFC 8707 Resource Indicators support.
+  #
+  class ResourceIndicatorsGenerator < ::Rails::Generators::Base
+    include ::Rails::Generators::Migration
+    source_root File.expand_path("templates", __dir__)
+    desc "Add resource indicators support (RFC 8707) to Doorkeeper tables."
+
+    def resource_indicators
+      migration_template(
+        "enable_resource_indicators_migration.rb.erb",
+        "db/migrate/enable_resource_indicators.rb",
+        migration_version: migration_version,
+      )
+    end
+
+    def self.next_migration_number(dirname)
+      ActiveRecord::Generators::Base.next_migration_number(dirname)
+    end
+
+    private
+
+    def migration_version
+      "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]"
+    end
+  end
+end

--- a/lib/generators/doorkeeper/templates/enable_resource_indicators_migration.rb.erb
+++ b/lib/generators/doorkeeper/templates/enable_resource_indicators_migration.rb.erb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class EnableResourceIndicators < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_column :oauth_access_grants, :resource, :text, null: true
+    add_column :oauth_access_tokens, :resource, :text, null: true
+  end
+end

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -604,4 +604,32 @@ Doorkeeper.configure do
   # custom_metadata(
   #   userinfo_endpoint: "https://auth.example.com/oauth/userinfo",
   # )
+
+  # Resource Indicators for OAuth 2.0 (RFC 8707)
+  #
+  # When configured with a callable, enables RFC 8707 support. The callable
+  # receives an array of resource indicator URIs and the OAuth client, and must
+  # return true if the resources are acceptable, or false to reject with
+  # `invalid_target`.
+  #
+  # Clients may then include one or more `resource` parameters in authorization
+  # and token requests to signal which protected resource(s) they intend to
+  # access. The authorization server will:
+  #   - Validate resource URIs (must be absolute, no fragment)
+  #   - Store resource indicators on grants and tokens
+  #   - Enforce subset restrictions on token/refresh requests
+  #   - Include `aud` in token introspection responses
+  #
+  # NOTE: RFC 8707 specifies repeated query parameters (?resource=…&resource=…)
+  # for multiple values, but Rack collapses repeated keys to the last value.
+  # Clients must use the Rails bracket syntax (resource[]=…&resource[]=…) to
+  # send multiple resource indicators. A single resource=… works as-is.
+  #
+  # To use this feature, first run `rails generate doorkeeper:resource_indicators`
+  # to add the required `resource` column to the access grants and tokens tables.
+  #
+  # resource_indicator_validator ->(resource_indicators, client) {
+  #   allowed = %w[https://api.example.com/ https://calendar.example.com/]
+  #   resource_indicators.all? { |r| allowed.include?(r) }
+  # }
 end

--- a/spec/dummy/db/migrate/20260730000000_enable_resource_indicators.rb
+++ b/spec/dummy/db/migrate/20260730000000_enable_resource_indicators.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class EnableResourceIndicators < ActiveRecord::Migration[5.0]
+  def change
+    add_column :oauth_access_grants, :resource, :text, null: true
+    add_column :oauth_access_tokens, :resource, :text, null: true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20260716000000) do
+ActiveRecord::Schema.define(version: 20260730000000) do
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20260716000000) do
     t.datetime "created_at", null: false
     t.datetime "revoked_at"
     t.string "scopes"
+    t.text "resource"
     t.string "tenant_name"
     t.bigint "access_token_id"
     unless ENV["WITHOUT_PKCE"]
@@ -42,6 +43,7 @@ ActiveRecord::Schema.define(version: 20260716000000) do
     t.datetime "revoked_at"
     t.datetime "created_at", null: false
     t.string "scopes"
+    t.text "resource"
     t.string "previous_refresh_token", default: "", null: false
     t.string "tenant_name"
     t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true

--- a/spec/generators/resource_indicators_generator_spec.rb
+++ b/spec/generators/resource_indicators_generator_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "generators/doorkeeper/resource_indicators_generator"
+
+RSpec.describe Doorkeeper::ResourceIndicatorsGenerator do
+  include GeneratorSpec::TestCase
+
+  tests described_class
+  destination ::File.expand_path("tmp/dummy", __dir__)
+
+  describe "after running the generator" do
+    before do
+      prepare_destination
+    end
+
+    it "creates a migration with a version specifier" do
+      stub_const("ActiveRecord::VERSION::MAJOR", 7)
+      stub_const("ActiveRecord::VERSION::MINOR", 1)
+
+      run_generator
+
+      assert_migration "db/migrate/enable_resource_indicators.rb" do |migration|
+        assert migration.include?("ActiveRecord::Migration[7.1]\n")
+        assert migration.include?("add_column :oauth_access_grants, :resource, :text")
+        assert migration.include?("add_column :oauth_access_tokens, :resource, :text")
+      end
+    end
+  end
+end

--- a/spec/lib/oauth/password_access_token_request_spec.rb
+++ b/spec/lib/oauth/password_access_token_request_spec.rb
@@ -175,6 +175,102 @@ RSpec.describe Doorkeeper::OAuth::PasswordAccessTokenRequest do
     end
   end
 
+  describe "with resource indicators (RFC 8707)" do
+    let(:resource_uri) { "https://api.example.com/" }
+
+    context "when resource_indicator_validator is configured" do
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          resource_indicator_validator ->(_indicators, _client) { true }
+        end
+      end
+
+      context "with a valid resource indicator" do
+        subject(:request) do
+          described_class.new(server, client, credentials, owner, resource: [resource_uri])
+        end
+
+        it "issues a token with the resource persisted" do
+          expect { request.authorize }.to change { Doorkeeper::AccessToken.count }.by(1)
+
+          token = Doorkeeper::AccessToken.last
+          expect(token.resource).to eq(resource_uri)
+        end
+      end
+
+      context "with multiple valid resource indicators" do
+        subject(:request) do
+          described_class.new(server, client, credentials, owner, resource: [resource_uri, second_resource_uri])
+        end
+
+        let(:second_resource_uri) { "https://calendar.example.com/" }
+
+        it "persists all resource indicators space-separated" do
+          expect { request.authorize }.to change { Doorkeeper::AccessToken.count }.by(1)
+
+          token = Doorkeeper::AccessToken.last
+          expect(token.resource).to eq("#{resource_uri} #{second_resource_uri}")
+        end
+      end
+
+      context "without resource indicator" do
+        subject(:request) do
+          described_class.new(server, client, credentials, owner)
+        end
+
+        it "issues a token without resource constraint" do
+          expect { request.authorize }.to change { Doorkeeper::AccessToken.count }.by(1)
+
+          token = Doorkeeper::AccessToken.last
+          expect(token.resource).to be_nil
+        end
+      end
+    end
+
+    context "when resource_indicator_validator rejects the resource" do
+      subject(:request) do
+        described_class.new(server, client, credentials, owner, resource: [resource_uri])
+      end
+
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          resource_indicator_validator ->(_indicators, _client) { false }
+        end
+      end
+
+      it "rejects the request with invalid_target" do
+        response = request.authorize
+        expect(response).to be_a(Doorkeeper::OAuth::ErrorResponse)
+        expect(response.body[:error]).to eq(:invalid_target)
+      end
+
+      it "does not issue a token" do
+        expect { request.authorize }.not_to(change { Doorkeeper::AccessToken.count })
+      end
+    end
+
+    context "when resource_indicator_validator is not configured" do
+      subject(:request) do
+        described_class.new(server, client, credentials, owner, resource: [resource_uri])
+      end
+
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+        end
+      end
+
+      it "ignores resource indicators and issues a token without resource" do
+        expect { request.authorize }.to change { Doorkeeper::AccessToken.count }.by(1)
+
+        token = Doorkeeper::AccessToken.last
+        expect(token.resource).to be_nil
+      end
+    end
+  end
+
   describe "with custom expiry" do
     let(:server) do
       double(

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
       scopes
       code_challenge
       code_challenge_method
+      resource_indicators
     ])
   end
 

--- a/spec/lib/oauth/resource_indicator_validator_spec.rb
+++ b/spec/lib/oauth/resource_indicator_validator_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::OAuth::ResourceIndicatorValidator do
+  describe ".validate!" do
+    it "returns empty array when resource_indicators is nil" do
+      expect(described_class.validate!(nil)).to eq([])
+    end
+
+    it "returns empty array when resource_indicators is blank" do
+      expect(described_class.validate!("")).to eq([])
+      expect(described_class.validate!([])).to eq([])
+    end
+
+    it "returns validated URIs for valid absolute URIs" do
+      result = described_class.validate!(["https://api.example.com/"])
+      expect(result).to eq(["https://api.example.com/"])
+    end
+
+    it "accepts multiple resource URIs" do
+      uris = ["https://api.example.com/", "https://calendar.example.com/"]
+      result = described_class.validate!(uris)
+      expect(result).to eq(uris)
+    end
+
+    it "accepts a single string (wrapped into array)" do
+      result = described_class.validate!("https://api.example.com/")
+      expect(result).to eq(["https://api.example.com/"])
+    end
+
+    it "raises InvalidTarget for relative URIs" do
+      expect do
+        described_class.validate!(["/relative/path"])
+      end.to raise_error(Doorkeeper::Errors::InvalidTarget)
+    end
+
+    it "raises InvalidTarget for URIs with fragments" do
+      expect do
+        described_class.validate!(["https://api.example.com/#fragment"])
+      end.to raise_error(Doorkeeper::Errors::InvalidTarget)
+    end
+
+    it "raises InvalidTarget for invalid URIs" do
+      expect do
+        described_class.validate!(["not a uri at all %%%"])
+      end.to raise_error(Doorkeeper::Errors::InvalidTarget)
+    end
+
+    it "raises InvalidTarget for non-String values (e.g. Hash from malformed params)" do
+      expect do
+        described_class.validate!([{ "foo" => "bar" }])
+      end.to raise_error(Doorkeeper::Errors::InvalidTarget)
+    end
+
+    it "raises InvalidTarget for Integer values" do
+      expect do
+        described_class.validate!([123])
+      end.to raise_error(Doorkeeper::Errors::InvalidTarget)
+    end
+
+    it "allows URIs with query components (per RFC 8707 §2)" do
+      result = described_class.validate!(["https://api.example.com/app?tenant=foo"])
+      expect(result).to eq(["https://api.example.com/app?tenant=foo"])
+    end
+
+    context "with a config_validator" do
+      it "calls the validator with indicators and client" do
+        validator = ->(indicators, _client) { indicators.all? { |r| r.start_with?("https://allowed.com/") } }
+        client = double(:client)
+
+        result = described_class.validate!(
+          ["https://allowed.com/api"],
+          config_validator: validator,
+          client: client,
+        )
+        expect(result).to eq(["https://allowed.com/api"])
+      end
+
+      it "raises InvalidTarget when validator returns false" do
+        validator = ->(_indicators, _client) { false }
+
+        expect do
+          described_class.validate!(["https://api.example.com/"], config_validator: validator)
+        end.to raise_error(Doorkeeper::Errors::InvalidTarget)
+      end
+    end
+
+    context "with grant_resource_indicators (subset enforcement)" do
+      let(:grant_resources) { ["https://api.example.com/", "https://calendar.example.com/"] }
+
+      it "allows a subset of the grant resources" do
+        result = described_class.validate!(
+          ["https://api.example.com/"],
+          grant_resource_indicators: grant_resources,
+        )
+        expect(result).to eq(["https://api.example.com/"])
+      end
+
+      it "allows exact match of the grant resources" do
+        result = described_class.validate!(
+          grant_resources,
+          grant_resource_indicators: grant_resources,
+        )
+        expect(result).to eq(grant_resources)
+      end
+
+      it "raises InvalidTarget when requesting resources not in the grant" do
+        expect do
+          described_class.validate!(
+            ["https://other.example.com/"],
+            grant_resource_indicators: grant_resources,
+          )
+        end.to raise_error(Doorkeeper::Errors::InvalidTarget)
+      end
+    end
+  end
+
+  describe ".valid?" do
+    it "returns true for nil" do
+      expect(described_class.valid?(nil)).to be true
+    end
+
+    it "returns true for blank array" do
+      expect(described_class.valid?([])).to be true
+    end
+
+    it "returns true for valid absolute URIs" do
+      expect(described_class.valid?(["https://api.example.com/"])).to be true
+    end
+
+    it "returns false for URIs with fragments" do
+      expect(described_class.valid?(["https://api.example.com/#frag"])).to be false
+    end
+
+    it "returns false for relative URIs" do
+      expect(described_class.valid?(["/path"])).to be false
+    end
+  end
+end

--- a/spec/lib/oauth/resource_indicators_spec.rb
+++ b/spec/lib/oauth/resource_indicators_spec.rb
@@ -1,0 +1,793 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Resource Indicators (RFC 8707)" do
+  let(:application) { FactoryBot.create(:application) }
+  let(:resource_owner) { FactoryBot.create(:resource_owner) }
+  let(:resource_uri) { "https://api.example.com/" }
+  let(:second_resource_uri) { "https://calendar.example.com/" }
+
+  before do
+    Doorkeeper.configure do
+      orm DOORKEEPER_ORM
+      resource_indicator_validator ->(_indicators, _client) { true }
+    end
+  end
+
+  describe "PreAuthorization" do
+    subject(:pre_auth) { Doorkeeper::OAuth::PreAuthorization.new(server, parameters, resource_owner) }
+
+    let(:server) do
+      double(
+        :server,
+        default_scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+        scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+        authorization_response_flows: Doorkeeper.config.authorization_response_flows,
+        refresh_token_enabled?: false,
+      )
+    end
+
+    let(:parameters) do
+      {
+        client_id: application.uid,
+        response_type: "code",
+        redirect_uri: application.redirect_uri,
+        scope: "public",
+        resource: [resource_uri],
+      }
+    end
+
+    it "is authorizable with valid resource indicators" do
+      expect(pre_auth).to be_authorizable
+      expect(pre_auth.resource_indicators).to eq([resource_uri])
+    end
+
+    it "is authorizable with multiple resource indicators" do
+      parameters[:resource] = [resource_uri, second_resource_uri]
+      expect(pre_auth).to be_authorizable
+      expect(pre_auth.resource_indicators).to eq([resource_uri, second_resource_uri])
+    end
+
+    it "deduplicates repeated resource indicators" do
+      parameters[:resource] = [resource_uri, resource_uri]
+      expect(pre_auth).to be_authorizable
+      expect(pre_auth.resource_indicators).to eq([resource_uri])
+    end
+
+    it "is authorizable without resource indicators (optional parameter)" do
+      parameters.delete(:resource)
+      expect(pre_auth).to be_authorizable
+      expect(pre_auth.resource_indicators).to eq([])
+    end
+
+    context "when resource indicator is invalid" do
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          resource_indicator_validator ->(_indicators, _client) { false }
+        end
+      end
+
+      it "is not authorizable" do
+        expect(pre_auth).not_to be_authorizable
+        expect(pre_auth.error).to eq(Doorkeeper::Errors::InvalidTarget)
+      end
+    end
+
+    context "when resource URI has a fragment" do
+      before { parameters[:resource] = ["https://api.example.com/#frag"] }
+
+      it "is not authorizable" do
+        expect(pre_auth).not_to be_authorizable
+        expect(pre_auth.error).to eq(Doorkeeper::Errors::InvalidTarget)
+      end
+    end
+
+    context "when resource URI is relative" do
+      before { parameters[:resource] = ["/path"] }
+
+      it "is not authorizable" do
+        expect(pre_auth).not_to be_authorizable
+        expect(pre_auth.error).to eq(Doorkeeper::Errors::InvalidTarget)
+      end
+    end
+
+    context "when resource_indicator_validator is nil (feature disabled)" do
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+        end
+      end
+
+      it "is authorizable regardless of resource parameter" do
+        parameters[:resource] = ["/invalid"]
+        expect(pre_auth).to be_authorizable
+      end
+    end
+  end
+
+  describe "Authorization Code Grant" do
+    let(:access_grant) do
+      FactoryBot.create(
+        :access_grant,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+        resource: "#{resource_uri} #{second_resource_uri}",
+      )
+    end
+
+    context "with token request specifying resource subset" do
+      let(:request) do
+        Doorkeeper::OAuth::AuthorizationCodeRequest.new(
+          Doorkeeper.config,
+          access_grant,
+          application,
+          redirect_uri: access_grant.redirect_uri,
+          code_verifier: nil,
+          resource: [resource_uri],
+        )
+      end
+
+      it "issues a token with the requested resource subset" do
+        request.authorize
+        token = Doorkeeper::AccessToken.last
+        expect(token.resource).to eq(resource_uri)
+      end
+    end
+
+    context "with token request specifying resource not in grant" do
+      let(:request) do
+        Doorkeeper::OAuth::AuthorizationCodeRequest.new(
+          Doorkeeper.config,
+          access_grant,
+          application,
+          redirect_uri: access_grant.redirect_uri,
+          code_verifier: nil,
+          resource: ["https://other.example.com/"],
+        )
+      end
+
+      it "rejects the request with invalid_target" do
+        response = request.authorize
+        expect(response).to be_a(Doorkeeper::OAuth::ErrorResponse)
+        expect(response.body[:error]).to eq(:invalid_target)
+      end
+    end
+
+    context "without resource parameter on token request" do
+      let(:request) do
+        Doorkeeper::OAuth::AuthorizationCodeRequest.new(
+          Doorkeeper.config,
+          access_grant,
+          application,
+          redirect_uri: access_grant.redirect_uri,
+          code_verifier: nil,
+        )
+      end
+
+      it "issues a token bound to the grant's resource set" do
+        request.authorize
+        token = Doorkeeper::AccessToken.last
+        expect(token.resource).to eq("#{resource_uri} #{second_resource_uri}")
+      end
+    end
+
+    context "when validator is disabled but grant has stored resources" do
+      before do
+        # Simulate the validator being removed after the grant was issued
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          default_scopes :public
+        end
+      end
+
+      let(:request) do
+        Doorkeeper::OAuth::AuthorizationCodeRequest.new(
+          Doorkeeper.config,
+          access_grant,
+          application,
+          redirect_uri: access_grant.redirect_uri,
+          code_verifier: nil,
+        )
+      end
+
+      it "still carries the grant's resource indicators to the token" do
+        request.authorize
+        token = Doorkeeper::AccessToken.last
+        expect(token.resource).to eq("#{resource_uri} #{second_resource_uri}")
+      end
+    end
+
+    # Regression: when the validator is not configured, an explicit
+    # `resource` parameter on the token request was previously silently
+    # ignored and subset enforcement was skipped, allowing a request for
+    # an audience outside the grant to succeed.  These tests verify the
+    # fix: subset and syntax enforcement run even without a validator
+    # when the grant is already audience-restricted.
+    context "when validator is not configured (regression coverage)" do
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          default_scopes :public
+        end
+      end
+
+      context "with token request specifying resource not in grant" do
+        let(:request) do
+          Doorkeeper::OAuth::AuthorizationCodeRequest.new(
+            Doorkeeper.config,
+            access_grant,
+            application,
+            redirect_uri: access_grant.redirect_uri,
+            code_verifier: nil,
+            resource: ["https://other.example.com/"],
+          )
+        end
+
+        it "rejects a resource not in the grant even when the validator is not configured" do
+          response = request.authorize
+          expect(response).to be_a(Doorkeeper::OAuth::ErrorResponse)
+          expect(response.body[:error]).to eq(:invalid_target)
+        end
+      end
+
+      context "with token request specifying a valid resource subset" do
+        let(:request) do
+          Doorkeeper::OAuth::AuthorizationCodeRequest.new(
+            Doorkeeper.config,
+            access_grant,
+            application,
+            redirect_uri: access_grant.redirect_uri,
+            code_verifier: nil,
+            resource: [resource_uri],
+          )
+        end
+
+        it "honors a valid resource subset even when the validator is not configured" do
+          request.authorize
+          token = Doorkeeper::AccessToken.last
+          expect(token.resource).to eq(resource_uri)
+        end
+      end
+
+      context "without resource parameter on token request" do
+        let(:request) do
+          Doorkeeper::OAuth::AuthorizationCodeRequest.new(
+            Doorkeeper.config,
+            access_grant,
+            application,
+            redirect_uri: access_grant.redirect_uri,
+            code_verifier: nil,
+          )
+        end
+
+        it "inherits the grant's full resource set when resource is omitted and the validator is not configured" do
+          request.authorize
+          token = Doorkeeper::AccessToken.last
+          expect(token.resource).to eq("#{resource_uri} #{second_resource_uri}")
+        end
+      end
+    end
+  end
+
+  describe "Client Credentials Grant" do
+    let(:client) { Doorkeeper::OAuth::Client.new(application) }
+
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        default_scopes :public
+        resource_indicator_validator ->(_indicators, _client) { true }
+      end
+    end
+
+    context "with valid resource indicator" do
+      let(:request) do
+        Doorkeeper::OAuth::ClientCredentialsRequest.new(
+          Doorkeeper.config,
+          client,
+          scope: "public",
+          resource: [resource_uri],
+        )
+      end
+
+      it "issues a token with the resource indicator" do
+        response = request.authorize
+        expect(response).to be_a(Doorkeeper::OAuth::TokenResponse)
+        token = Doorkeeper::AccessToken.last
+        expect(token.resource).to eq(resource_uri)
+      end
+    end
+
+    context "with invalid resource indicator" do
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          resource_indicator_validator ->(_indicators, _client) { false }
+        end
+      end
+
+      let(:request) do
+        Doorkeeper::OAuth::ClientCredentialsRequest.new(
+          Doorkeeper.config,
+          client,
+          scope: "public",
+          resource: [resource_uri],
+        )
+      end
+
+      it "rejects the request with invalid_target" do
+        response = request.authorize
+        expect(response).to be_a(Doorkeeper::OAuth::ErrorResponse)
+        expect(response.body[:error]).to eq(:invalid_target)
+      end
+    end
+
+    context "without resource indicator" do
+      let(:request) do
+        Doorkeeper::OAuth::ClientCredentialsRequest.new(
+          Doorkeeper.config,
+          client,
+          scope: "public",
+        )
+      end
+
+      it "issues a token without resource constraint" do
+        response = request.authorize
+        expect(response).to be_a(Doorkeeper::OAuth::TokenResponse)
+        token = Doorkeeper::AccessToken.last
+        expect(token.resource).to be_nil
+      end
+    end
+  end
+
+  describe "Refresh Token Grant" do
+    let(:access_token) do
+      FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+        use_refresh_token: true,
+        resource: "#{resource_uri} #{second_resource_uri}",
+      )
+    end
+    let(:credentials) do
+      Doorkeeper::OAuth::Client::Credentials.new(application.uid, application.secret)
+    end
+    let(:client) { Doorkeeper.config.application_model.by_uid_and_secret(credentials.uid, credentials.secret) }
+
+    context "with resource subset" do
+      let(:request) do
+        Doorkeeper::OAuth::RefreshTokenRequest.new(
+          Doorkeeper.config,
+          access_token,
+          credentials,
+          refresh_token: access_token.refresh_token,
+          resource: [resource_uri],
+        )
+      end
+
+      it "issues a new token with the requested resource subset" do
+        request.authorize
+        new_token = Doorkeeper::AccessToken.order(:created_at).last
+        expect(new_token.id).not_to eq(access_token.id)
+        expect(new_token.resource).to eq(resource_uri)
+      end
+    end
+
+    context "with resource not in original token" do
+      let(:request) do
+        Doorkeeper::OAuth::RefreshTokenRequest.new(
+          Doorkeeper.config,
+          access_token,
+          credentials,
+          refresh_token: access_token.refresh_token,
+          resource: ["https://other.example.com/"],
+        )
+      end
+
+      it "rejects with invalid_target" do
+        response = request.authorize
+        expect(response).to be_a(Doorkeeper::OAuth::ErrorResponse)
+        expect(response.body[:error]).to eq(:invalid_target)
+      end
+    end
+
+    context "without resource parameter" do
+      let(:request) do
+        Doorkeeper::OAuth::RefreshTokenRequest.new(
+          Doorkeeper.config,
+          access_token,
+          credentials,
+          refresh_token: access_token.refresh_token,
+        )
+      end
+
+      it "inherits resource from the original token" do
+        request.authorize
+        new_token = Doorkeeper::AccessToken.order(:created_at).last
+        expect(new_token.id).not_to eq(access_token.id)
+        expect(new_token.resource).to eq("#{resource_uri} #{second_resource_uri}")
+      end
+    end
+
+    context "when validator is not configured" do
+      before do
+        Doorkeeper.configure do
+          orm DOORKEEPER_ORM
+          default_scopes :public
+        end
+      end
+
+      context "with resource not in original token" do
+        let(:request) do
+          Doorkeeper::OAuth::RefreshTokenRequest.new(
+            Doorkeeper.config,
+            access_token,
+            credentials,
+            refresh_token: access_token.refresh_token,
+            resource: ["https://other.example.com/"],
+          )
+        end
+
+        it "rejects a resource not in the original token even when the validator is not configured" do
+          response = request.authorize
+          expect(response).to be_a(Doorkeeper::OAuth::ErrorResponse)
+          expect(response.body[:error]).to eq(:invalid_target)
+        end
+      end
+
+      context "with a valid resource subset" do
+        let(:request) do
+          Doorkeeper::OAuth::RefreshTokenRequest.new(
+            Doorkeeper.config,
+            access_token,
+            credentials,
+            refresh_token: access_token.refresh_token,
+            resource: [resource_uri],
+          )
+        end
+
+        it "honors a valid resource subset even when the validator is not configured" do
+          request.authorize
+          new_token = Doorkeeper::AccessToken.order(:created_at).last
+          expect(new_token.id).not_to eq(access_token.id)
+          expect(new_token.resource).to eq(resource_uri)
+        end
+      end
+
+      context "without resource parameter" do
+        let(:request) do
+          Doorkeeper::OAuth::RefreshTokenRequest.new(
+            Doorkeeper.config,
+            access_token,
+            credentials,
+            refresh_token: access_token.refresh_token,
+          )
+        end
+
+        it "inherits the original token's resource when resource is omitted and the validator is not configured" do
+          request.authorize
+          new_token = Doorkeeper::AccessToken.order(:created_at).last
+          expect(new_token.id).not_to eq(access_token.id)
+          expect(new_token.resource).to eq("#{resource_uri} #{second_resource_uri}")
+        end
+      end
+    end
+  end
+
+  describe "Token Introspection" do
+    let(:token_with_resource) do
+      FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+        resource: resource_uri,
+      )
+    end
+
+    let(:token_with_multiple_resources) do
+      FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+        resource: "#{resource_uri} #{second_resource_uri}",
+      )
+    end
+
+    let(:token_without_resource) do
+      FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+      )
+    end
+
+    let(:server) do
+      double(
+        :server,
+        credentials: nil,
+        context: double(:context, request: double(:request, authorization: "Bearer #{auth_token.token}")),
+      )
+    end
+
+    let(:auth_token) do
+      FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+      )
+    end
+
+    before do
+      allow(Doorkeeper).to receive(:authenticate).and_return(auth_token)
+    end
+
+    it "includes aud as string for single resource" do
+      introspection = Doorkeeper::OAuth::TokenIntrospection.new(server, token_with_resource)
+      allow(introspection).to receive(:authorized?).and_return(true)
+
+      json = introspection.to_json
+      expect(json[:aud]).to eq(resource_uri)
+    end
+
+    it "includes aud as array for multiple resources" do
+      introspection = Doorkeeper::OAuth::TokenIntrospection.new(server, token_with_multiple_resources)
+      allow(introspection).to receive(:authorized?).and_return(true)
+
+      json = introspection.to_json
+      expect(json[:aud]).to eq([resource_uri, second_resource_uri])
+    end
+
+    it "does not include aud when no resource is set" do
+      introspection = Doorkeeper::OAuth::TokenIntrospection.new(server, token_without_resource)
+      allow(introspection).to receive(:authorized?).and_return(true)
+
+      json = introspection.to_json
+      expect(json).not_to have_key(:aud)
+    end
+  end
+
+  describe "Metadata Response" do
+    it "advertises resource_indicators_supported as true when configured" do
+      response = Doorkeeper::OAuth::MetadataResponse.new(
+        "https://auth.example.com",
+        ->(**_args) { "https://auth.example.com/oauth/authorize" },
+      )
+      expect(response.body[:resource_indicators_supported]).to be true
+    end
+
+    it "advertises resource_indicators_supported as false when not configured" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+      end
+
+      response = Doorkeeper::OAuth::MetadataResponse.new(
+        "https://auth.example.com",
+        ->(**_args) { "https://auth.example.com/oauth/authorize" },
+      )
+      expect(response.body[:resource_indicators_supported]).to be false
+    end
+  end
+
+  describe "Token Reuse with Resource Indicators" do
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        default_scopes :public
+        reuse_access_token
+        resource_indicator_validator ->(_indicators, _client) { true }
+      end
+    end
+
+    it "does not reuse a token with a different resource" do
+      # Existing token audience-restricted to api
+      existing_token = FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+        resource: resource_uri,
+      )
+
+      # Request a token for a different resource
+      new_token = Doorkeeper.config.access_token_model.find_or_create_for(
+        application: application,
+        resource_owner: resource_owner,
+        scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+        expires_in: 7200,
+        use_refresh_token: false,
+        resource: second_resource_uri,
+      )
+
+      expect(new_token.id).not_to eq(existing_token.id)
+      expect(new_token.resource).to eq(second_resource_uri)
+    end
+
+    it "reuses a token with the same resource" do
+      existing_token = FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+        resource: resource_uri,
+      )
+
+      reused_token = Doorkeeper.config.access_token_model.find_or_create_for(
+        application: application,
+        resource_owner: resource_owner,
+        scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+        expires_in: 7200,
+        use_refresh_token: false,
+        resource: resource_uri,
+      )
+
+      expect(reused_token.id).to eq(existing_token.id)
+    end
+
+    it "does not reuse an unrestricted token when resource is requested" do
+      existing_token = FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+        resource: nil,
+      )
+
+      new_token = Doorkeeper.config.access_token_model.find_or_create_for(
+        application: application,
+        resource_owner: resource_owner,
+        scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+        expires_in: 7200,
+        use_refresh_token: false,
+        resource: resource_uri,
+      )
+
+      expect(new_token.id).not_to eq(existing_token.id)
+      expect(new_token.resource).to eq(resource_uri)
+    end
+  end
+
+  describe "Token Reuse with Resource Indicators and no validator configured" do
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        default_scopes :public
+        reuse_access_token
+        # deliberately omit resource_indicator_validator
+      end
+    end
+
+    it "does not reuse a token with a different resource when the validator is not configured" do
+      existing_token = FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+        resource: resource_uri,
+      )
+
+      new_token = Doorkeeper.config.access_token_model.find_or_create_for(
+        application: application,
+        resource_owner: resource_owner,
+        scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+        expires_in: 7200,
+        use_refresh_token: false,
+        resource: second_resource_uri,
+      )
+
+      expect(new_token.id).not_to eq(existing_token.id)
+      expect(new_token.resource).to eq(second_resource_uri)
+    end
+
+    it "does not reuse an unrestricted token when a resource is requested and the validator is not configured" do
+      existing_token = FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+        resource: nil,
+      )
+
+      new_token = Doorkeeper.config.access_token_model.find_or_create_for(
+        application: application,
+        resource_owner: resource_owner,
+        scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+        expires_in: 7200,
+        use_refresh_token: false,
+        resource: resource_uri,
+      )
+
+      expect(new_token.id).not_to eq(existing_token.id)
+      expect(new_token.resource).to eq(resource_uri)
+    end
+
+    it "reuses a token with the same resource when the validator is not configured" do
+      existing_token = FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+        resource: resource_uri,
+      )
+
+      reused_token = Doorkeeper.config.access_token_model.find_or_create_for(
+        application: application,
+        resource_owner: resource_owner,
+        scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+        expires_in: 7200,
+        use_refresh_token: false,
+        resource: resource_uri,
+      )
+
+      expect(reused_token.id).to eq(existing_token.id)
+    end
+
+    it "reuses an unrestricted token when no resource is requested and the validator is not configured" do
+      existing_token = FactoryBot.create(
+        :access_token,
+        application: application,
+        resource_owner_id: resource_owner.id,
+        resource_owner_type: resource_owner.class.name,
+        scopes: "public",
+        resource: nil,
+      )
+
+      reused_token = Doorkeeper.config.access_token_model.find_or_create_for(
+        application: application,
+        resource_owner: resource_owner,
+        scopes: Doorkeeper::OAuth::Scopes.from_string("public"),
+        expires_in: 7200,
+        use_refresh_token: false,
+      )
+
+      expect(reused_token.id).to eq(existing_token.id)
+    end
+  end
+
+  describe "parameter permitting" do
+    # Verifies that both the scalar (?resource=uri) and array (?resource[]=uri)
+    # wire formats survive strong parameters and reach PreAuthorization.
+    # RFC 8707 §2 uses the scalar form; Rails array form is also common.
+    it "passes a scalar resource parameter through to PreAuthorization" do
+      params = ActionController::Parameters.new(
+        client_id: "uid",
+        response_type: "code",
+        resource: "https://api.example.com/",
+      )
+
+      permitted = params.permit(:client_id, :response_type, :resource, resource: [])
+      expect(permitted[:resource]).to eq("https://api.example.com/")
+    end
+
+    it "passes an array resource parameter through to PreAuthorization" do
+      params = ActionController::Parameters.new(
+        client_id: "uid",
+        response_type: "code",
+        resource: ["https://api.example.com/", "https://cal.example.com/"],
+      )
+
+      permitted = params.permit(:client_id, :response_type, :resource, resource: [])
+      expect(permitted[:resource]).to eq(["https://api.example.com/", "https://cal.example.com/"])
+    end
+  end
+end

--- a/spec/requests/flows/client_credentials_spec.rb
+++ b/spec/requests/flows/client_credentials_spec.rb
@@ -257,6 +257,25 @@ RSpec.describe "Client Credentials Request" do
     end
   end
 
+  context "when resource column is missing from the access token table" do
+    before do
+      config_is_set(:resource_indicator_validator, ->(_indicators, _client) { true })
+      allow(Doorkeeper.config.access_token_model).to receive(:resource_indicators_supported?).and_return(false)
+    end
+
+    it "returns a spec-compliant server_error instead of the exception message" do
+      headers = authorization client.uid, client.secret
+      params  = { grant_type: "client_credentials", resource: "https://api.example.com/" }
+
+      post token_endpoint_url, params: params, headers: headers
+
+      expect(response.status).to eq(400)
+      expect(json_response["error"]).to eq("server_error")
+      expect(json_response["error_description"]).to eq(translated_error_message(:server_error))
+      expect(json_response["error"]).not_to include("resource_indicator_validator")
+    end
+  end
+
   def authorization(username, password)
     credentials = ActionController::HttpAuthentication::Basic.encode_credentials username, password
     { "HTTP_AUTHORIZATION" => credentials }

--- a/spec/requests/flows/password_spec.rb
+++ b/spec/requests/flows/password_spec.rb
@@ -467,5 +467,78 @@ RSpec.describe "Resource Owner Password Credentials Flow" do
         end.not_to(change { Doorkeeper::AccessToken.count })
       end
     end
+
+    context "with resource indicators (RFC 8707)" do
+      context "when resource_indicator_validator accepts the resource" do
+        before do
+          config_is_set(:resource_indicator_validator, ->(_indicators, _client) { true })
+        end
+
+        it "issues a token with the resource persisted" do
+          expect do
+            post token_endpoint_url, params: password_token_endpoint_params(
+              client: @client,
+              resource_owner: @resource_owner,
+            ).merge("resource" => ["https://api.example.com/"])
+          end.to change { Doorkeeper::AccessToken.count }.by(1)
+
+          token = Doorkeeper::AccessToken.last
+          expect(token.resource).to eq("https://api.example.com/")
+          expect(json_response).to include("access_token" => token.token)
+        end
+
+        it "persists multiple resource indicators space-separated" do
+          expect do
+            post token_endpoint_url, params: password_token_endpoint_params(
+              client: @client,
+              resource_owner: @resource_owner,
+            ).merge("resource" => ["https://api.example.com/", "https://calendar.example.com/"])
+          end.to change { Doorkeeper::AccessToken.count }.by(1)
+
+          token = Doorkeeper::AccessToken.last
+          expect(token.resource).to eq("https://api.example.com/ https://calendar.example.com/")
+        end
+
+        it "issues a token without resource when resource is not provided" do
+          expect do
+            post token_endpoint_url, params: password_token_endpoint_params(
+              client: @client,
+              resource_owner: @resource_owner,
+            )
+          end.to change { Doorkeeper::AccessToken.count }.by(1)
+
+          token = Doorkeeper::AccessToken.last
+          expect(token.resource).to be_nil
+        end
+      end
+
+      context "when resource_indicator_validator rejects the resource" do
+        before do
+          config_is_set(:resource_indicator_validator, ->(_indicators, _client) { false })
+        end
+
+        it "does not issue a token" do
+          expect do
+            post token_endpoint_url, params: password_token_endpoint_params(
+              client: @client,
+              resource_owner: @resource_owner,
+            ).merge("resource" => ["https://api.example.com/"])
+          end.not_to(change { Doorkeeper::AccessToken.count })
+        end
+
+        it "returns invalid_target error" do
+          post token_endpoint_url, params: password_token_endpoint_params(
+            client: @client,
+            resource_owner: @resource_owner,
+          ).merge("resource" => ["https://api.example.com/"])
+
+          expect(response.status).to eq(400)
+          expect(json_response).to match(
+            "error" => "invalid_target",
+            "error_description" => an_instance_of(String),
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/requests/flows/resource_indicators_spec.rb
+++ b/spec/requests/flows/resource_indicators_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+feature "Resource Indicators (RFC 8707) Flow" do
+  let(:resource_uri) { "https://api.example.com/" }
+
+  background do
+    default_scopes_exist :default
+    config_is_set(:authenticate_resource_owner) { User.first || redirect_to("/sign_in") }
+    config_is_set(
+      :resource_indicator_validator,
+      lambda { |indicators, _client|
+        indicators.all? { |r| r.start_with?("https://") }
+      },
+    )
+    client_exists
+    create_resource_owner
+    sign_in
+  end
+
+  scenario "authorization code flow with resource indicator audience-restricts the token" do
+    # 1. Authorization request with resource parameter
+    params = {
+      client_id: @client.uid,
+      redirect_uri: @client.redirect_uri,
+      response_type: "code",
+      scope: "default",
+      resource: resource_uri,
+    }
+    visit "/oauth/authorize?#{Rack::Utils.build_query(params)}"
+
+    # Verify the page rendered the authorize form (not an error)
+    expect(page).to have_button("Authorize")
+    click_on "Authorize"
+
+    # 2. Grant is created with the resource indicator persisted
+    grant = Doorkeeper::AccessGrant.first
+    expect(grant).to be_present
+    expect(grant.resource).to eq(resource_uri)
+
+    # 3. Exchange the code for a token, requesting the same resource
+    page.driver.post token_endpoint_url, {
+      grant_type: "authorization_code",
+      code: grant.token,
+      client_id: @client.uid,
+      client_secret: @client.secret,
+      redirect_uri: @client.redirect_uri,
+      resource: resource_uri,
+    }
+
+    expect(page.driver.response.status).to eq(200)
+    token_response = JSON.parse(page.driver.response.body)
+    expect(token_response["access_token"]).to be_present
+
+    # 4. The issued access token is audience-restricted
+    access_token = Doorkeeper::AccessToken.find_by(token: token_response["access_token"])
+    expect(access_token.resource).to eq(resource_uri)
+  end
+end


### PR DESCRIPTION
Add support for Resource Indicators for OAuth 2.0 (RFC 8707). 

Clients can include a `resource` parameter in authorization and token requests to indicate the target protected resource(s). The authorization server validates resource URIs, enforces audience restriction on tokens, and includes `aud` in introspection responses. Enable by configuring `resource_indicator_validator` with a callable. Requires new `resource` columns on access grants and tokens — run `rails generate doorkeeper:resource_indicators` to add the migration.

Enable by configuring `resource_indicator_validator` with a callable. Requires new `resource` columns on access grants and tokens — run `rails generate doorkeeper:resource_indicators` to add the migration.

https://datatracker.ietf.org/doc/html/rfc8707

Closes #1413 
Reviewed version of https://github.com/doorkeeper-gem/doorkeeper/pull/1559/