### PR TITLE
Document custom grant flow registration in the README, closes #764

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ User-visible changes worth mentioning.
 - [#1884] Fix: `/oauth/introspect` and `/oauth/revoke` extend the token lookup across both token types when the lookup by `token_type_hint` finds nothing (RFC 7662 §2.1 / RFC 7009 §2.1), so a wrong hint no longer hides a token the server knows about ([#1882])
 - [#1885] Index `oauth_access_grants.access_token_id` in the migration templates: since [#1879] the code-replay revocation filters access grants by that column, the "never used to filter queries" premise behind `index: false` no longer holds.
 - [#1887] [test] Pin that a requested non-default scope reaches the authorization grant and the exchanged token, and that the authorization strategy shares the controller's pre-authorization — the mismatch reported in [#1576] does not reproduce. Test-only change, closes [#1576].
+- [#1888] Document custom grant flow registration (`Doorkeeper::GrantFlow.register`) in the README with a SAML 2.0 bearer assertion (RFC 7522) walkthrough, and pin URN-shaped custom grant types with an end-to-end request spec. Docs/test-only change, closes [#764].
 - Please add here
 
 ## 6.0.0.beta1

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Supported features:
   - [Grape](#grape)
 - [ORMs](#orms)
 - [Extensions](#extensions)
+- [Custom Grant Flows](#custom-grant-flows)
 - [Example Applications](#example-applications)
 - [Sponsors](#sponsors)
 - [Development](#development)
@@ -106,6 +107,111 @@ Extensions that are not included by default and can be installed separately.
 | I18n translations | [doorkeeper-gem/doorkeeper-i18n](https://github.com/doorkeeper-gem/doorkeeper-i18n) |
 | CIBA - Client Initiated Backchannel Authentication Flow extension | [doorkeeper-ciba](https://github.com/autoseg/doorkeeper-ciba) |
 | Device Authorization Grant | [doorkeeper-device_authorization_grant](https://github.com/exop-group/doorkeeper-device_authorization_grant) |
+
+## Custom Grant Flows
+
+Besides the built-in OAuth 2 flows, Doorkeeper can recognize and process any custom grant type through its grant flow registry — including grant types whose names are URNs or URIs, such as the SAML 2.0 bearer assertion grant defined by [RFC 7522](https://www.rfc-editor.org/rfc/rfc7522).
+
+A grant flow bundles a matcher for the `grant_type` parameter with a strategy class that processes the token request. Register it before `Doorkeeper.configure` and enable it by adding its registered name to `grant_flows`:
+
+```ruby
+# config/initializers/doorkeeper.rb
+Doorkeeper::GrantFlow.register(
+  :saml2_bearer,
+  grant_type_matches: "urn:ietf:params:oauth:grant-type:saml2-bearer",
+  grant_type_strategy: SamlBearer::Strategy,
+)
+
+Doorkeeper.configure do
+  grant_flows %w[authorization_code saml2_bearer]
+  # ...
+end
+```
+
+Note that `grant_flows` lists the *registered flow name* (`saml2_bearer`), while `grant_type_matches` — a `String` or a `Regexp` — is what the request's `grant_type` parameter is matched against.
+
+The strategy class receives the authorization server as `server` and builds the request object handling the grant:
+
+```ruby
+module SamlBearer
+  class Strategy < Doorkeeper::Request::Strategy
+    delegate :client, :parameters, to: :server
+
+    def request
+      @request ||= TokenRequest.new(Doorkeeper.config, client, parameters)
+    end
+  end
+end
+```
+
+The request object validates the grant and issues the token. Subclassing `Doorkeeper::OAuth::BaseRequest` provides the response handling, scope calculation and token creation, so only the grant-specific parts remain (per RFC 7522 §2.1 the `assertion` parameter carries a single SAML assertion, base64url-encoded without padding):
+
+```ruby
+module SamlBearer
+  class TokenRequest < Doorkeeper::OAuth::BaseRequest
+    validate :client, error: Doorkeeper::Errors::InvalidClient
+    validate :client_supports_grant_flow, error: Doorkeeper::Errors::UnauthorizedClient
+    validate :assertion, error: Doorkeeper::Errors::InvalidGrant
+    validate :scopes, error: Doorkeeper::Errors::InvalidScope
+
+    attr_reader :client, :parameters, :access_token
+
+    def initialize(server, client, parameters = {})
+      @server          = server
+      @client          = client
+      @parameters      = parameters
+      @original_scopes = parameters[:scope]
+      @grant_type      = "urn:ietf:params:oauth:grant-type:saml2-bearer"
+    end
+
+    private
+
+    def before_successful_response
+      find_or_create_access_token(client, resource_owner, scopes, {}, server)
+      super
+    end
+
+    def assertion
+      # Decode and verify the SAML assertion — signature, audience, validity
+      # window, etc. — e.g. with the ruby-saml gem. Skipping verification
+      # turns the endpoint into a token vending machine for anyone.
+      @assertion ||= decode_and_verify_saml(parameters[:assertion])
+    end
+
+    def resource_owner
+      # Map the assertion's subject to a resource owner.
+      @resource_owner ||= User.find_by(email: assertion.name_id)
+    end
+
+    def validate_client
+      client.present?
+    end
+
+    def validate_client_supports_grant_flow
+      Doorkeeper.config.allow_grant_flow_for_client?(grant_type, client&.application)
+    end
+
+    def validate_assertion
+      assertion.present? && resource_owner.present?
+    end
+
+    def validate_scopes
+      return true if scopes.blank?
+
+      Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
+        scope_str: scopes.to_s,
+        server_scopes: server.scopes,
+        app_scopes: client&.scopes,
+        grant_type: grant_type,
+      )
+    end
+  end
+end
+```
+
+The `client_supports_grant_flow` validation keeps the custom grant subject to the `allow_grant_flow_for_client` configuration option (per-client grant restrictions), just like the built-in flows.
+
+Flows can also handle custom `response_type` values on the authorization endpoint via the `response_type_matches` / `response_type_strategy` options — see the built-in registrations in [`lib/doorkeeper/grant_flow.rb`](lib/doorkeeper/grant_flow.rb) for reference. An extension can also group several flows under one configuration name with `Doorkeeper::GrantFlow.register_alias` (e.g. the OpenID Connect extension registers `implicit_oidc` to expand to multiple response types).
 
 ## Example Applications
 

--- a/spec/requests/flows/custom_grant_flow_spec.rb
+++ b/spec/requests/flows/custom_grant_flow_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+# End-to-end coverage for the custom grant flow registry [#1418] with a
+# URN-shaped grant type, mirroring the README "Custom Grant Flows" example.
+
+require "spec_helper"
+
+module SamlBearerExample
+  Assertion = Struct.new(:name_id)
+
+  class TokenRequest < Doorkeeper::OAuth::BaseRequest
+    validate :client, error: Doorkeeper::Errors::InvalidClient
+    validate :client_supports_grant_flow, error: Doorkeeper::Errors::UnauthorizedClient
+    validate :assertion, error: Doorkeeper::Errors::InvalidGrant
+    validate :scopes, error: Doorkeeper::Errors::InvalidScope
+
+    attr_reader :client, :parameters, :access_token
+
+    def initialize(server, client, parameters = {})
+      @server          = server
+      @client          = client
+      @parameters      = parameters
+      @original_scopes = parameters[:scope]
+      @grant_type      = "urn:ietf:params:oauth:grant-type:saml2-bearer"
+    end
+
+    private
+
+    def before_successful_response
+      find_or_create_access_token(client, resource_owner, scopes, {}, server)
+      super
+    end
+
+    def assertion
+      @assertion ||= decode_and_verify_saml(parameters[:assertion])
+    end
+
+    # Stands in for real SAML verification (ruby-saml etc.)
+    def decode_and_verify_saml(raw)
+      Assertion.new("Joe") if raw == "valid-saml-assertion"
+    end
+
+    def resource_owner
+      @resource_owner ||= User.find_by(name: assertion.name_id)
+    end
+
+    def validate_client
+      client.present?
+    end
+
+    def validate_client_supports_grant_flow
+      Doorkeeper.config.allow_grant_flow_for_client?(grant_type, client&.application)
+    end
+
+    def validate_assertion
+      assertion.present? && resource_owner.present?
+    end
+
+    def validate_scopes
+      return true if scopes.blank?
+
+      Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
+        scope_str: scopes.to_s,
+        server_scopes: server.scopes,
+        app_scopes: client&.scopes,
+        grant_type: grant_type,
+      )
+    end
+  end
+
+  class Strategy < Doorkeeper::Request::Strategy
+    delegate :client, :parameters, to: :server
+
+    def request
+      @request ||= TokenRequest.new(Doorkeeper.config, client, parameters)
+    end
+  end
+end
+
+RSpec.describe "Custom SAML bearer grant flow (README example)" do
+  let(:client) { FactoryBot.create :application }
+  let!(:user) { FactoryBot.create :resource_owner, name: "Joe" }
+
+  before do
+    Doorkeeper::GrantFlow.register(
+      :saml2_bearer,
+      grant_type_matches: "urn:ietf:params:oauth:grant-type:saml2-bearer",
+      grant_type_strategy: SamlBearerExample::Strategy,
+    )
+
+    Doorkeeper.configure do
+      orm DOORKEEPER_ORM
+      grant_flows %w[authorization_code saml2_bearer]
+    end
+  end
+
+  after do
+    Doorkeeper::GrantFlow.flows.delete(:saml2_bearer)
+  end
+
+  def authorization(username, password)
+    credentials = ActionController::HttpAuthentication::Basic.encode_credentials username, password
+    { "HTTP_AUTHORIZATION" => credentials }
+  end
+
+  it "issues a token for a valid assertion" do
+    headers = authorization client.uid, client.secret
+    params = {
+      grant_type: "urn:ietf:params:oauth:grant-type:saml2-bearer",
+      assertion: "valid-saml-assertion",
+    }
+
+    post token_endpoint_url, params: params, headers: headers
+
+    expect(response.status).to eq(200)
+    token = Doorkeeper::AccessToken.first
+    expect(token.resource_owner_id).to eq(user.id)
+    expect(json_response).to include("access_token" => token.token)
+  end
+
+  it "rejects an unverifiable assertion with invalid_grant" do
+    headers = authorization client.uid, client.secret
+    params = {
+      grant_type: "urn:ietf:params:oauth:grant-type:saml2-bearer",
+      assertion: "garbage",
+    }
+
+    post token_endpoint_url, params: params, headers: headers
+
+    expect(response.status).to eq(400)
+    expect(json_response).to include("error" => "invalid_grant")
+  end
+
+  it "rejects clients barred from the flow with unauthorized_client" do
+    Doorkeeper.configure do
+      orm DOORKEEPER_ORM
+      grant_flows %w[authorization_code saml2_bearer]
+      allow_grant_flow_for_client do |grant_flow, _application|
+        grant_flow != "urn:ietf:params:oauth:grant-type:saml2-bearer"
+      end
+    end
+
+    headers = authorization client.uid, client.secret
+    params = {
+      grant_type: "urn:ietf:params:oauth:grant-type:saml2-bearer",
+      assertion: "valid-saml-assertion",
+    }
+
+    post token_endpoint_url, params: params, headers: headers
+
+    expect(response.status).to eq(400)
+    expect(json_response).to include("error" => "unauthorized_client")
+  end
+
+  it "still rejects unregistered grant types" do
+    headers = authorization client.uid, client.secret
+    params = { grant_type: "urn:example:unknown" }
+
+    post token_endpoint_url, params: params, headers: headers
+
+    expect(response.status).to eq(400)
+    expect(json_response).to include("error" => "unsupported_grant_type")
+  end
+end

--- a/spec/requests/flows/custom_grant_flow_spec.rb
+++ b/spec/requests/flows/custom_grant_flow_spec.rb
@@ -6,6 +6,10 @@
 require "spec_helper"
 
 module SamlBearerExample
+  # `name_id` mirrors the SAML assertion's subject <NameID>. The dummy app's
+  # User model only has a `name` column, so `resource_owner` below maps the
+  # NameID onto it; the README example maps it onto `email`, as a real
+  # application typically would.
   Assertion = Struct.new(:name_id)
 
   class TokenRequest < Doorkeeper::OAuth::BaseRequest


### PR DESCRIPTION
## Summary

Closes #764.

The technical ask of #764 — support grant types whose names are URNs/URIs, such as the SAML 2.0 bearer assertion grant (`urn:ietf:params:oauth:grant-type:saml2-bearer`, [RFC 7522 §2.1]) — was resolved back in 5.5.0 by the grant flow registry (#1418): grant types are mapped to strategy classes through explicit registration (`grant_type_matches` accepts any `String` or `Regexp`) instead of the old camelize/constantize resolution the issue complained about.

What never happened is documentation: the issue's opening question was literally *"Is there any documentation for creating custom grant types?"*, and to this day the registry appears in neither the README nor the wiki — only in the CHANGELOG and the source. This PR closes that gap:

- **README**: new "Custom Grant Flows" section walking through `Doorkeeper::GrantFlow.register` with a SAML 2.0 bearer assertion (RFC 7522) example — flow registration, `grant_flows` configuration, the `Doorkeeper::Request::Strategy` subclass, and a `Doorkeeper::OAuth::BaseRequest` subclass with grant-specific validations. Also points at `response_type_matches`/`response_type_strategy` and `register_alias` for authorization-endpoint flows and extension aliases.
- **Spec**: an end-to-end request spec mirroring the README example, pinning URN-shaped grant types at the `/oauth/token` level (token issuance for a valid assertion, `invalid_grant` for an unverifiable one, `unsupported_grant_type` for unregistered types). The registry so far had unit specs only.

The README example is verified by the added spec. One subtlety it documents: `BaseRequest#authorize` reads `access_token` but doesn't define the reader, so subclasses must declare `attr_reader :access_token` themselves (as `PasswordAccessTokenRequest` does).

Docs/test-only change — no behavior changes.

[RFC 7522 §2.1]: https://www.rfc-editor.org/rfc/rfc7522#section-2.1