### PR TITLE
[test] Pin `invalid_redirect_uri` for clients registered without a redirect URI, closes #1682

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ User-visible changes worth mentioning.
 - [#1885] Index `oauth_access_grants.access_token_id` in the migration templates: since [#1879] the code-replay revocation filters access grants by that column, the "never used to filter queries" premise behind `index: false` no longer holds.
 - [#1887] [test] Pin that a requested non-default scope reaches the authorization grant and the exchanged token, and that the authorization strategy shares the controller's pre-authorization — the mismatch reported in [#1576] does not reproduce. Test-only change, closes [#1576].
 - [#1888] Document custom grant flow registration (`Doorkeeper::GrantFlow.register`) in the README with a SAML 2.0 bearer assertion (RFC 7522) walkthrough, and pin URN-shaped custom grant types with an end-to-end request spec. Docs/test-only change, closes [#764].
+- [#1890] [test] Pin that the authorization endpoint answers `invalid_redirect_uri` for a client registered without a redirect URI (`allow_blank_redirect_uri`), whether or not the request supplies one — the behavior required by RFC 6749 §3.1.2.3. Test-only change, closes [#1682].
 - Please add here
 
 ## 6.0.0.beta1

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -333,6 +333,9 @@ Doorkeeper.configure do
   # types, but you **need** to manually drop `NOT NULL` constraint from `redirect_uri`
   # column for `oauth_applications` database table.
   #
+  # You almost certainly do not want to change this. There are very, very few cases
+  # where you want to change this configuration value.
+  #
   # You can completely disable this feature with:
   #
   # allow_blank_redirect_uri false

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -257,6 +257,32 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
     expect(pre_auth).not_to be_authorizable
   end
 
+  context "when the application has no registered redirect_uri" do
+    before do
+      allow(Doorkeeper.config).to receive(:allow_blank_redirect_uri?).and_return(true)
+    end
+
+    let(:application) { FactoryBot.create(:application, redirect_uri: "") }
+
+    # RFC 6749 §3.1.2.3: when no redirection URI has been registered, the
+    # client MUST include one in the authorization request, and a provided
+    # value must still match a registered URI — so an application registered
+    # without a redirect_uri cannot use redirect-based flows at all.
+    it "is not authorizable when the request omits the redirect_uri" do
+      attributes[:redirect_uri] = nil
+
+      expect(pre_auth).not_to be_authorizable
+      expect(pre_auth.error).to eq(Doorkeeper::Errors::InvalidRedirectUri)
+    end
+
+    it "is not authorizable when the request provides a redirect_uri" do
+      attributes[:redirect_uri] = "https://app.com/callback"
+
+      expect(pre_auth).not_to be_authorizable
+      expect(pre_auth.error).to eq(Doorkeeper::Errors::InvalidRedirectUri)
+    end
+  end
+
   context "when resource_owner cannot access client application" do
     before { allow(Doorkeeper.configuration).to receive(:authorize_resource_owner_for_client).and_return(->(*_) { false }) }
 

--- a/spec/requests/flows/authorization_code_errors_spec.rb
+++ b/spec/requests/flows/authorization_code_errors_spec.rb
@@ -69,6 +69,32 @@ feature "Authorization Code Flow Errors" do
       url_should_not_have_param "iss"
     end
   end
+
+  # RFC 6749 §3.1.2.3: when no redirection URI has been registered, the client
+  # MUST include one in the authorization request, and a provided value must
+  # still match a registered URI. `allow_blank_redirect_uri` only lifts the
+  # registration-time validation for URI-less grant flows; it does not make the
+  # authorization endpoint usable without a registered redirect URI.
+  context "when the client has no registered redirect URI" do
+    background do
+      config_is_set(:allow_blank_redirect_uri, true)
+      @client.update!(redirect_uri: "")
+    end
+
+    scenario "displays invalid_redirect_uri error when redirect_uri is missing" do
+      visit authorization_endpoint_url(client: @client)
+
+      i_should_not_see "Authorize"
+      i_should_see_translated_error_message :invalid_redirect_uri
+    end
+
+    scenario "displays invalid_redirect_uri error when redirect_uri is provided" do
+      visit authorization_endpoint_url(client: @client, redirect_uri: "https://app.example.com/callback")
+
+      i_should_not_see "Authorize"
+      i_should_see_translated_error_message :invalid_redirect_uri
+    end
+  end
 end
 
 RSpec.describe "Authorization Code Flow Errors after authorization" do


### PR DESCRIPTION
## Summary

Test-only change. Pins the authorization endpoint's rejection of clients that were registered without a `redirect_uri` (possible when `allow_blank_redirect_uri` permits it), so #1682 can be closed with the behavior locked in rather than just discussed.

Two altitudes:

- **`PreAuthorization` unit spec** — a client with a blank registered `redirect_uri` is not authorizable, whether the request omits `redirect_uri` or supplies one, and the error is `Errors::InvalidRedirectUri`.
- **Authorization endpoint feature spec** — both request shapes render the translated `invalid_redirect_uri` error and never reach the consent form (the existing `after` hook also asserts no grant is created).

## Why close #1682

The issue reports two things; neither marks a bug:

1. **The rejection is required by RFC 6749 §3.1.2.3** — "if no redirection URI has been registered, the client MUST include a redirection URI with the authorization request", and a provided value "MUST" be compared and matched against a registered redirection URI. A client with nothing registered therefore has no request shape the server may accept, exactly as @ThisIsMissEm concluded in the thread. `allow_blank_redirect_uri` lifts the registration-time validation for URI-less grant flows (its default already refuses blank registrations while `authorization_code` or `implicit` is enabled); it does not make redirect-based flows usable without a registered URI.

2. **"In 5.6.6 and before an authorization code was returned" does not match any release.** The permissive variant (8a2f3d60, for #1518) was reverted (aca6b47b) before ever shipping — both commits first appear in v5.5.3 — and `validate_redirect_uri` is byte-identical from v5.5.3 through current `main`. What did change shortly before the report is 5.6.7's #1676, which made the authorization endpoint honor `handle_auth_errors :raise`: for apps configured to raise, the same rejection started surfacing as a `Doorkeeper::Errors::InvalidRedirectUri` exception instead of the rendered error page. A visibility change, not an authorization-outcome change.

## Scope note

This deliberately does **not** touch the neighboring question in #1678 — whether a client that *did* register exactly one URI may omit the parameter (RFC 6749 §3.1.2.3 only mandates the parameter when registration is absent, partial, or ambiguous). That relaxation stays tracked there; these specs only pin the nothing-registered case, which must fail under any resolution of #1678.