### PR TITLE
Answer `invalid_redirect_uri` instead of 500 when the client registered no redirect URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ User-visible changes worth mentioning.
 - [#1890] [test] Pin that the authorization endpoint answers `invalid_redirect_uri` for a client registered without a redirect URI (`allow_blank_redirect_uri`), whether or not the request supplies one — the behavior required by RFC 6749 §3.1.2.3. Test-only change, closes [#1682].
 - [#1898] Fix: with `reuse_access_token` enabled, the `client_credentials` grant no longer reuses a token whose `resource` differs from the one requested (RFC 8707), so the audience restriction the client asked for is always applied. Follow-up to [#1886].
 - [#1899] Document the client authentication methods registry (`Doorkeeper::ClientAuthentication.register`) in the README with a walkthrough for registering a custom method, and pin it with an end-to-end request spec. Docs/test-only change, closes [#1894].
+- [#1891] Fix: an authorization request carrying a `redirect_uri` for a client registered without one (`redirect_uri` is `nil` under `allow_blank_redirect_uri`) now answers `invalid_redirect_uri` instead of crashing with an unhandled 500.
 - Please add here
 
 ## 6.0.0.beta1

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -60,7 +60,10 @@ module Doorkeeper
         end
 
         def self.valid_for_authorization?(url, client_url)
-          valid?(url) && client_url.split.any? { |other_url| matches?(url, other_url) }
+          # client_url is nil when the application was registered without a
+          # redirect URI (allow_blank_redirect_uri) — no possible match, not
+          # an error.
+          valid?(url) && client_url.to_s.split.any? { |other_url| matches?(url, other_url) }
         end
 
         def self.as_uri(url)

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -61,8 +61,8 @@ module Doorkeeper
 
         def self.valid_for_authorization?(url, client_url)
           # client_url is blank when the application was registered without a
-          # redirect URI (allow_blank_redirect_uri) — no possible match, not
-          # an error.
+          # redirect URI (allow_blank_redirect_uri) — no possible match for
+          # redirection based OAuth flows, not an error.
           return false if client_url.blank?
 
           valid?(url) && client_url.split.any? { |other_url| matches?(url, other_url) }

--- a/lib/doorkeeper/oauth/helpers/uri_checker.rb
+++ b/lib/doorkeeper/oauth/helpers/uri_checker.rb
@@ -60,10 +60,12 @@ module Doorkeeper
         end
 
         def self.valid_for_authorization?(url, client_url)
-          # client_url is nil when the application was registered without a
+          # client_url is blank when the application was registered without a
           # redirect URI (allow_blank_redirect_uri) — no possible match, not
           # an error.
-          valid?(url) && client_url.to_s.split.any? { |other_url| matches?(url, other_url) }
+          return false if client_url.blank?
+
+          valid?(url) && client_url.split.any? { |other_url| matches?(url, other_url) }
         end
 
         def self.as_uri(url)

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -1039,6 +1039,33 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
         expect(Doorkeeper::AccessToken.count).to eq 0
       end
     end
+
+    # The registered redirect_uri is nil (not "") when the application was
+    # created outside the HTML form, e.g. over console or API, under
+    # allow_blank_redirect_uri.
+    context "when a redirect_uri is provided but the client registered none" do
+      before do
+        allow(Doorkeeper.config).to receive(:allow_blank_redirect_uri?).and_return(true)
+        client.update!(redirect_uri: nil)
+
+        get :new, params: {
+          client_id: client.uid,
+          response_type: "token",
+          redirect_uri: "https://app.example.com/callback",
+        }
+      end
+
+      it "answers invalid_redirect_uri" do
+        expect(response).not_to be_redirect
+        expect(response).to have_http_status(:bad_request)
+        expect(response.body).to include(ERB::Util.html_escape(translated_error_message(:invalid_redirect_uri)))
+      end
+
+      it "does not issue any token" do
+        expect(Doorkeeper::AccessGrant.count).to eq 0
+        expect(Doorkeeper::AccessToken.count).to eq 0
+      end
+    end
   end
 
   describe "GET #new in API mode with errors" do

--- a/spec/lib/oauth/helpers/uri_checker_spec.rb
+++ b/spec/lib/oauth/helpers/uri_checker_spec.rb
@@ -287,6 +287,13 @@ describe Doorkeeper::OAuth::Helpers::URIChecker do
       expect(described_class).not_to be_valid_for_authorization(uri, client_uri)
     end
 
+    it "is false if the client has no registered redirect uri" do
+      uri = "http://app.co/aaa"
+
+      expect(described_class.valid_for_authorization?(uri, nil)).to be false
+      expect(described_class.valid_for_authorization?(uri, "")).to be false
+    end
+
     it "is false if queries does not match" do
       uri = "http://app.co/aaa?pankcakes=abc"
       client_uri = "http://app.co/aaa?waffles=abc"


### PR DESCRIPTION
## Summary

`URIChecker.valid_for_authorization?` calls `client_url.split`, so a `nil` registered `redirect_uri` raises `NoMethodError` — an unhandled 500. One-line fix: coerce with `to_s`, so a `nil` registration behaves exactly like the empty string (nothing registered → no provided value can match → `invalid_redirect_uri`, per RFC 6749 §3.1.2.3's requirement that a provided value match a registered one).

## How the `nil` is reachable

- `allow_blank_redirect_uri` permits registering an application with a blank `redirect_uri`. The HTML form submits `""` (which already worked), but an application created over the console or an API can carry `redirect_uri = nil`.
- Any authorization request for such a client that **supplies** a `redirect_uri` parameter then crashes before client authentication — an unauthenticated 500. A request that omits the parameter is unaffected (rejected earlier by the `redirect_uri.blank?` guard).

Discovered while pinning the neighboring no-registered-URI behavior for #1682 (PR #1890); this PR is independent of that one and touches none of the same files.

## Other call site

`AuthorizationCodeRequest#validate_redirect_uri` passes `grant.redirect_uri`, which cannot be `nil` through the normal flow (pre-authorization requires a `redirect_uri` before a grant is created). For out-of-spec data the failure mode moves from a 500 to `invalid_grant` — also strictly an improvement.