### PR TITLE
Add built-in private_key_jwt client authentication (RFC 7523)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,25 @@ jobs:
         timeout-minutes: 10
         run: bundle exec rake spec
 
+  # The jwt gem is an optional dependency of the private_key_jwt client
+  # authentication method, and the matrix above always resolves its newest
+  # release. This job pins it to the oldest version the gemspec allows, so the
+  # declared lower bound is actually exercised.
+  jwt_lower_bound:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails_8_0_jwt_2.gemfile
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Run tests
+        timeout-minutes: 10
+        run: bundle exec rake spec
+
   rails_edge:
     runs-on: ubuntu-latest
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ User-visible changes worth mentioning.
 - [#1898] Fix: with `reuse_access_token` enabled, the `client_credentials` grant no longer reuses a token whose `resource` differs from the one requested (RFC 8707), so the audience restriction the client asked for is always applied. Follow-up to [#1886].
 - [#1899] Document the client authentication methods registry (`Doorkeeper::ClientAuthentication.register`) in the README with a walkthrough for registering a custom method, and pin it with an end-to-end request spec. Docs/test-only change, closes [#1894].
 - [#1891] Fix: an authorization request carrying a `redirect_uri` for a client registered without one (`redirect_uri` is `nil` under `allow_blank_redirect_uri`) now answers `invalid_redirect_uri` instead of crashing with an unhandled 500.
+- [#1896] Add an opt-in `private_key_jwt` client authentication method (RFC 7523 / OIDC Core §9, requires the `jwt` gem >= 2.7) that verifies assertions against the client's published public keys — `jwks` / `jwks_uri` attributes you define on your Application model, the latter fetched with an SSRF-hardened HTTP client. Part of [#1875].
 - Please add here
 
 ## 6.0.0.beta1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ User-visible changes worth mentioning.
 - [#1898] Fix: with `reuse_access_token` enabled, the `client_credentials` grant no longer reuses a token whose `resource` differs from the one requested (RFC 8707), so the audience restriction the client asked for is always applied. Follow-up to [#1886].
 - [#1899] Document the client authentication methods registry (`Doorkeeper::ClientAuthentication.register`) in the README with a walkthrough for registering a custom method, and pin it with an end-to-end request spec. Docs/test-only change, closes [#1894].
 - [#1891] Fix: an authorization request carrying a `redirect_uri` for a client registered without one (`redirect_uri` is `nil` under `allow_blank_redirect_uri`) now answers `invalid_redirect_uri` instead of crashing with an unhandled 500.
-- [#1896] Add an opt-in `private_key_jwt` client authentication method (RFC 7523 / OIDC Core §9, requires the `jwt` gem >= 2.7) that verifies assertions against the client's published public keys — `jwks` / `jwks_uri` attributes you define on your Application model, the latter fetched with an SSRF-hardened HTTP client. Part of [#1875].
+- [#1896] Add an opt-in `private_key_jwt` client authentication method (RFC 7523 / OIDC Core §9, requires the `jwt` gem >= 2.7) that verifies assertions against the client's published public keys — `jwks` / `jwks_uri` attributes you define on your Application model, the latter fetched with an SSRF-hardened HTTP client. The jti replay guard and the fetched-JWKS cache are process-local by default and can be replaced with shared stores via the `private_key_jwt_replay_guard` / `private_key_jwt_jwks_cache` config options. Part of [#1875].
 - Please add here
 
 ## 6.0.0.beta1

--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,10 @@ gem "bcrypt", "~> 3.1", require: false
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "sqlite3", "~> 2.3", platform: %i[ruby mswin mingw x64_mingw]
 
+gem "jwt", ">= 2.7"
 gem "timecop"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw]
+gem "webmock"
 
 gem "irb", "~> 1.8"
 

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -41,7 +41,9 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "factory_bot", "~> 6.0"
   gem.add_development_dependency "generator_spec", "~> 0.10.0"
   gem.add_development_dependency "grape"
+  gem.add_development_dependency "jwt", ">= 2.7"
   gem.add_development_dependency "rake", ">= 11.3.0"
   gem.add_development_dependency "rspec-rails"
   gem.add_development_dependency "timecop"
+  gem.add_development_dependency "webmock"
 end

--- a/gemfiles/rails_8_0_jwt_2.gemfile
+++ b/gemfiles/rails_8_0_jwt_2.gemfile
@@ -1,0 +1,24 @@
+# rails_8_0.gemfile, with the optional jwt dependency held at the oldest
+# version the gemspec allows so that the declared lower bound is exercised.
+
+source "https://rubygems.org"
+
+gem "rails", "~> 8.0.0"
+gem "rspec-core"
+gem "rspec-expectations"
+gem "rspec-mocks"
+gem "rspec-rails", "~> 7.1"
+gem "rspec-support"
+gem "rubocop", "~> 1.4"
+gem "rubocop-performance", require: false
+gem "rubocop-rails", require: false
+gem "rubocop-rspec", require: false
+gem "bcrypt", "~> 3.1", require: false
+gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
+gem "sprockets-rails"
+gem "sqlite3", "~> 2.3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
+gem "timecop"
+gem "jwt", "2.7.0"
+
+gemspec path: "../"

--- a/lib/doorkeeper.rb
+++ b/lib/doorkeeper.rb
@@ -8,7 +8,9 @@ require "doorkeeper/engine"
 module Doorkeeper
   autoload :Errors, "doorkeeper/errors"
   autoload :ClientAuthentication, "doorkeeper/client_authentication"
+  autoload :DocumentCache, "doorkeeper/document_cache"
   autoload :GrantFlow, "doorkeeper/grant_flow"
+  autoload :HttpFetcher, "doorkeeper/http_fetcher"
   autoload :OAuth, "doorkeeper/oauth"
   autoload :Rake, "doorkeeper/rake"
   autoload :Request, "doorkeeper/request"
@@ -69,6 +71,7 @@ module Doorkeeper
       autoload :None, "doorkeeper/oauth/client_authentication/none"
       autoload :ClientSecretBasic, "doorkeeper/oauth/client_authentication/client_secret_basic"
       autoload :ClientSecretPost, "doorkeeper/oauth/client_authentication/client_secret_post"
+      autoload :PrivateKeyJwt, "doorkeeper/oauth/client_authentication/private_key_jwt"
     end
 
     module Authorization

--- a/lib/doorkeeper/client_authentication.rb
+++ b/lib/doorkeeper/client_authentication.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "doorkeeper/client_authentication/credentials"
+require "doorkeeper/client_authentication/verified_credentials"
 require "doorkeeper/client_authentication/fallback_method"
 require "doorkeeper/client_authentication/legacy_callable"
 require "doorkeeper/client_authentication/method"
@@ -48,6 +49,14 @@ module Doorkeeper
     register(
       :client_secret_basic,
       Doorkeeper::OAuth::ClientAuthentication::ClientSecretBasic,
+    )
+
+    # Registered but not part of DEFAULT_METHODS: servers opt in through the
+    # +client_authentication+ config option. Requires the "jwt" gem at the
+    # moment an assertion is authenticated.
+    register(
+      :private_key_jwt,
+      Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt,
     )
 
     # Converts a deprecated +client_credentials+ configuration into the client

--- a/lib/doorkeeper/client_authentication/legacy_callable.rb
+++ b/lib/doorkeeper/client_authentication/legacy_callable.rb
@@ -16,6 +16,12 @@ module Doorkeeper
         @callable = callable
       end
 
+      # Legacy extractors pull a uid/secret pair out of the request, so they
+      # are treated as shared-secret methods.
+      def uses_shared_secret?
+        true
+      end
+
       def matches_request?(request)
         credentials_for(request).present?
       end

--- a/lib/doorkeeper/client_authentication/method.rb
+++ b/lib/doorkeeper/client_authentication/method.rb
@@ -18,6 +18,23 @@ module Doorkeeper
         @name = name
         @strategy = strategy
       end
+
+      # Whether this method authenticates clients with a shared symmetric
+      # secret. Callers that must refuse such methods — because no secret
+      # can have been established with the client — can ask the registry
+      # instead of keeping a hard-coded list of method names.
+      #
+      # Strategies may declare this themselves by defining
+      # +uses_shared_secret?+; for strategies that don't, the registration
+      # name is checked for "client_secret" as a conservative fallback, so an
+      # undeclared method errs on the side of being treated as secret-based.
+      def uses_shared_secret?
+        if strategy.respond_to?(:uses_shared_secret?)
+          strategy.uses_shared_secret?
+        else
+          name.to_s.include?("client_secret")
+        end
+      end
     end
   end
 end

--- a/lib/doorkeeper/client_authentication/verified_credentials.rb
+++ b/lib/doorkeeper/client_authentication/verified_credentials.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module ClientAuthentication
+    # Credentials for a client that was already fully authenticated by its
+    # authentication method (e.g. a verified private_key_jwt assertion), so
+    # the client lookup must not run a secret comparison — there is no
+    # secret, and the proof of identity has already been checked.
+    class VerifiedCredentials < Credentials
+      def initialize(uid)
+        super(uid, nil)
+      end
+
+      def pre_authenticated?
+        true
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -403,6 +403,35 @@ module Doorkeeper
     #
     option :resource_indicator_validator, default: nil
 
+    # Replay guard for `private_key_jwt` client assertions (jti single-use
+    # tracking, OIDC Core §9). The default guard remembers jti values in
+    # process-local memory, so it cannot see a replay delivered to a
+    # different server process; a multi-process deployment can supply a
+    # shared store instead — any object answering
+    # `first_use?(key, expires_at:)`, returning true when the key was never
+    # seen before and remembering it until the unix time `expires_at`.
+    #
+    # @example
+    #   private_key_jwt_replay_guard RedisReplayGuard.new
+    #
+    # @param guard [#first_use?, nil] nil uses the built-in process-local guard
+    #
+    option :private_key_jwt_replay_guard, default: nil
+
+    # Cache for JWK Sets fetched from a client's `jwks_uri` during
+    # `private_key_jwt` authentication. Defaults to a process-local
+    # Doorkeeper::DocumentCache with a 60 second TTL; supply your own
+    # instance to change the TTL, or any object answering
+    # `fetch(url) { ... }` (returning the cached document or storing and
+    # returning the block's result) to share the cache across processes.
+    #
+    # @example
+    #   private_key_jwt_jwks_cache Doorkeeper::DocumentCache.new(ttl: 300)
+    #
+    # @param cache [#fetch, nil] nil uses a built-in process-local cache
+    #
+    option :private_key_jwt_jwks_cache, default: nil
+
     # Forces the usage of the HTTPS protocol in non-native redirect uris
     # (enabled by default in non-development environments). OAuth2
     # delegates security in communication to the HTTPS protocol so it is

--- a/lib/doorkeeper/document_cache.rb
+++ b/lib/doorkeeper/document_cache.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  # A small thread-safe, fixed-TTL, in-memory memo keyed by URL. It exists
+  # so one authorization flow (authorize GET, consent POST, token exchange)
+  # does not refetch the same URL several times within a few seconds; it
+  # deliberately implements no HTTP caching semantics.
+  #
+  # Only successfully fetched and validated values may be stored — an error
+  # response or a malformed document must never be cached — which is
+  # guaranteed by callers never yielding anything but a validated value.
+  class DocumentCache
+    DEFAULT_TTL = 60
+    MAX_ENTRIES = 500
+
+    def initialize(ttl: DEFAULT_TTL)
+      @ttl = ttl
+      @mutex = Mutex.new
+      @store = {}
+    end
+
+    # Returns the cached document for the URL, or stores and returns the
+    # block's result. The block's failures (raises, nil) are not cached.
+    def fetch(url)
+      cached = read(url)
+      return cached if cached
+
+      document = yield
+      write(url, document) if document
+      document
+    end
+
+    def clear
+      @mutex.synchronize { @store.clear }
+    end
+
+    private
+
+    def read(url)
+      @mutex.synchronize do
+        entry = @store[url]
+        next nil unless entry
+
+        if entry[:expires_at] <= monotonic_now
+          @store.delete(url)
+          next nil
+        end
+
+        entry[:document]
+      end
+    end
+
+    def write(url, document)
+      @mutex.synchronize do
+        # Deleted first so a rewritten entry moves to the end of the hash's
+        # insertion order, which is the end #prune evicts from. #read
+        # already drops an entry when it finds it expired, so this only
+        # matters when two threads resolve the same URL at once.
+        @store.delete(url)
+        prune
+        @store[url] = { document: document, expires_at: monotonic_now + @ttl }
+      end
+    end
+
+    # Drop expired entries; if the store is still full, drop the oldest
+    # entries so a burst of unique URLs cannot grow the memo unbounded.
+    def prune
+      now = monotonic_now
+      @store.delete_if { |_url, entry| entry[:expires_at] <= now }
+
+      overflow = @store.size - (MAX_ENTRIES - 1)
+      return if overflow <= 0
+
+      @store.keys.first(overflow).each { |url| @store.delete(url) }
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/doorkeeper/http_fetcher.rb
+++ b/lib/doorkeeper/http_fetcher.rb
@@ -118,6 +118,11 @@ module Doorkeeper
     # @raise [FetchError] on resolution, transport or non-200 failures
     def fetch(url)
       uri = URI.parse(url)
+      # URI.parse("https:foo") yields a URI::HTTPS whose host is nil, so a
+      # caller's is_a?(URI::HTTPS) validation does not guarantee a host —
+      # and Resolv raises ArgumentError, not ResolvError, when handed nil.
+      raise FetchError, "#{url.inspect} has no host" if uri.host.blank?
+
       address = vetted_address_for(uri.host)
 
       perform_request(uri, address)

--- a/lib/doorkeeper/http_fetcher.rb
+++ b/lib/doorkeeper/http_fetcher.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+require "ipaddr"
+require "net/http"
+require "resolv"
+require "uri"
+
+module Doorkeeper
+  # Fetches a small operator-untrusted JSON document — a client's jwks_uri
+  # today — over HTTPS: redirects are never followed and any status other
+  # than 200 OK is an error.
+  #
+  # SSRF hardening: the host is resolved up front and the request is refused
+  # when any resolved address falls into an RFC 6890 special-use range
+  # (loopback, private-use, link-local, ...). The connection is then pinned
+  # to the vetted address via Net::HTTP#ipaddr= so a second, post-check DNS
+  # resolution (DNS rebinding) cannot redirect the request; TLS is still
+  # negotiated and verified against the original hostname. An exception for
+  # authorization servers themselves running on a loopback interface is
+  # intentionally not implemented. These rules follow the fetch hardening of
+  # draft-ietf-oauth-client-id-metadata-document (Sections 6.5 / 6.6), which
+  # fetches documents from the same kind of client-chosen URL.
+  #
+  # The response body is bounded and so is the total time spent reading it:
+  # a per-read timeout alone does not stop a server that dribbles bytes out
+  # indefinitely.
+  #
+  # Everything about the response is chosen by whoever hosts the document —
+  # which is whoever supplied the URL — so no failure mode here may escape
+  # as anything other than a FetchError.
+  class HttpFetcher
+    OPEN_TIMEOUT = 5
+    READ_TIMEOUT = 5
+
+    # draft-ietf-oauth-client-id-metadata-document Section 6.6 recommends a
+    # maximum response size of 5 kilobytes for a document like this.
+    MAX_RESPONSE_SIZE = 5 * 1024
+
+    # Ceiling on the whole exchange, so a body delivered one byte per
+    # READ_TIMEOUT cannot hold the connection (and the thread) for hours.
+    MAX_TOTAL_TIME = 10
+
+    # The document is served as JSON, either "application/json" or an
+    # "application/<more specific>+json" variant. A response declaring
+    # anything else plainly serves something other than the document sought
+    # and is refused without being parsed. A response declaring no media type
+    # at all is tolerated — the check is there to catch such a URL early, not
+    # as a security control, since the body still has to parse and validate
+    # in the caller.
+    JSON_MEDIA_TYPE = %r{\Aapplication/([\w.+-]+\+)?json\z}i
+
+    # RFC 6890 special-purpose IPv4/IPv6 registries, plus multicast ranges
+    # (224.0.0.0/4, ff00::/8), which are equally unfit as a document origin.
+    SPECIAL_USE_RANGES = [
+      "0.0.0.0/8",          # "this host on this network"
+      "10.0.0.0/8",         # private-use
+      "100.64.0.0/10",      # shared address space (CGN)
+      "127.0.0.0/8",        # loopback
+      "169.254.0.0/16",     # link-local
+      "172.16.0.0/12",      # private-use
+      "192.0.0.0/24",       # IETF protocol assignments
+      "192.0.2.0/24",       # documentation (TEST-NET-1)
+      "192.88.99.0/24",     # 6to4 relay anycast
+      "192.168.0.0/16",     # private-use
+      "198.18.0.0/15",      # benchmarking
+      "198.51.100.0/24",    # documentation (TEST-NET-2)
+      "203.0.113.0/24",     # documentation (TEST-NET-3)
+      "224.0.0.0/4",        # multicast
+      "240.0.0.0/4",        # reserved (includes limited broadcast)
+      "::/128",             # unspecified
+      "::1/128",            # loopback
+      # IPv4-compatible addresses (::a.b.c.d), deprecated by RFC 4291
+      # Section 2.5.5.1. Unlike the IPv4-mapped form handled in
+      # .special_use? these carry no ::ffff: marker, so they are refused
+      # wholesale rather than delegated to the embedded IPv4 address. The
+      # range also covers the two entries above.
+      "::/96",
+      "64:ff9b::/96",       # IPv4-IPv6 translation
+      "100::/64",           # discard-only
+      "2001::/23",          # IETF protocol assignments (TEREDO, ORCHID, ...)
+      "2001:db8::/32",      # documentation
+      "2002::/16",          # 6to4
+      "fc00::/7",           # unique-local
+      "fe80::/10",          # link-local
+      "ff00::/8",           # multicast
+    ].map { |cidr| IPAddr.new(cidr) }.freeze
+
+    FetchError = Class.new(StandardError)
+
+    # Everything a host can fail at while answering, so that it surfaces as
+    # a rejected client rather than an exception out of the endpoint.
+    #
+    # Net::HTTPBadResponse and Net::HTTPHeaderSyntaxError are listed
+    # explicitly because they descend straight from StandardError, *not*
+    # from Net::ProtocolError: a host answering with a mangled status line
+    # or header field raises them out of Net::HTTP.
+    TRANSPORT_ERRORS = [
+      Timeout::Error,
+      SystemCallError,
+      SocketError,
+      IOError,
+      OpenSSL::SSL::SSLError,
+      Net::ProtocolError,
+      Net::HTTPBadResponse,
+      Net::HTTPHeaderSyntaxError,
+      Resolv::ResolvError,
+      # Only reachable if a body is decompressed despite the identity
+      # Accept-Encoding requested below. Ruby can be built without zlib.
+      (Zlib::Error if defined?(::Zlib::Error)),
+    ].compact.freeze
+
+    def initialize(resolver: Resolv)
+      @resolver = resolver
+    end
+
+    # @param url [String] an already validated https:// URL
+    # @return [String] the response body
+    # @raise [FetchError] on resolution, transport or non-200 failures
+    def fetch(url)
+      uri = URI.parse(url)
+      address = vetted_address_for(uri.host)
+
+      perform_request(uri, address)
+    rescue *TRANSPORT_ERRORS => e
+      raise FetchError, "#{e.class}: #{e.message}"
+    end
+
+    def self.special_use?(address)
+      ip = address.is_a?(IPAddr) ? address : IPAddr.new(address.to_s)
+      # An IPv4-mapped IPv6 address is exactly as special-use as its
+      # embedded IPv4 address: ::ffff:127.0.0.1 must be refused while a
+      # mapped form of a public address stays reachable.
+      return special_use?(ip.native) if ip.ipv4_mapped?
+
+      SPECIAL_USE_RANGES.any? { |range| range.include?(ip) }
+    rescue IPAddr::InvalidAddressError
+      true
+    end
+
+    private
+
+    def vetted_address_for(host)
+      addresses = @resolver.getaddresses(host)
+      raise FetchError, "could not resolve #{host}" if addresses.empty?
+
+      # Every resolved address must be acceptable: pinning to one vetted
+      # address below keeps the connection off the others, but a host that
+      # mixes public and special-use records is treated as hostile.
+      if addresses.any? { |address| self.class.special_use?(address) }
+        raise FetchError, "#{host} resolves to a special-use address (RFC 6890)"
+      end
+
+      addresses.first.to_s
+    end
+
+    def perform_request(uri, address)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.ipaddr = address
+      http.open_timeout = OPEN_TIMEOUT
+      http.read_timeout = READ_TIMEOUT
+
+      request = Net::HTTP::Get.new(
+        uri.request_uri,
+        # Without an explicit Accept-Encoding, Net::HTTP negotiates gzip and
+        # inflates the body itself, which would both feed attacker-chosen
+        # bytes to zlib and turn the Content-Length check below into a check
+        # on the compressed size. A 5 kilobyte document does not need it.
+        { "Accept" => "application/json", "Accept-Encoding" => "identity" },
+      )
+      deadline = monotonic_now + MAX_TOTAL_TIME
+      body = nil
+
+      http.start do |connection|
+        # Net::HTTP never follows redirects on its own; a 3xx just fails
+        # the status check below.
+        connection.request(request) do |response|
+          raise FetchError, "expected 200 OK from #{uri.host}, got #{response.code}" unless response.is_a?(Net::HTTPOK)
+
+          verify_media_type!(response, uri.host)
+          body = bounded_body(response, uri.host, deadline)
+        end
+      end
+
+      body
+    end
+
+    def verify_media_type!(response, host)
+      declared = response["Content-Type"]
+      return if declared.blank?
+
+      media_type = declared.split(";").first.to_s.strip
+      return if JSON_MEDIA_TYPE.match?(media_type)
+
+      raise FetchError, "#{host} served #{media_type.inspect}, which is not a JSON media type"
+    end
+
+    # Reads the response in chunks so an oversized (or endlessly dribbled)
+    # body is abandoned instead of buffered in full. Raising here unwinds
+    # out of Net::HTTP#start, which closes the connection.
+    def bounded_body(response, host, deadline)
+      declared = response["Content-Length"]
+      if declared && declared.to_i > MAX_RESPONSE_SIZE
+        raise FetchError, "#{host} declares a #{declared} byte document, over the " \
+                          "#{MAX_RESPONSE_SIZE} byte limit"
+      end
+
+      body = +""
+
+      response.read_body do |chunk|
+        body << chunk
+
+        if body.bytesize > MAX_RESPONSE_SIZE
+          raise FetchError, "the document from #{host} exceeds #{MAX_RESPONSE_SIZE} bytes"
+        elsif monotonic_now > deadline
+          raise FetchError, "reading the document from #{host} took too long"
+        end
+      end
+
+      body
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/client.rb
+++ b/lib/doorkeeper/oauth/client.rb
@@ -37,6 +37,12 @@ module Doorkeeper
 
       def self.authenticate(credentials, method = Doorkeeper.config.application_model.method(:by_uid_and_secret))
         return if credentials.blank?
+
+        # Credentials that were fully authenticated by their client
+        # authentication method (e.g. a verified private_key_jwt assertion)
+        # carry no secret to compare — resolve the client by uid alone.
+        return find(credentials.uid) if credentials.respond_to?(:pre_authenticated?) && credentials.pre_authenticated?
+
         return unless (application = method.call(credentials.uid, credentials.secret))
 
         new(application)

--- a/lib/doorkeeper/oauth/client_authentication/client_secret_basic.rb
+++ b/lib/doorkeeper/oauth/client_authentication/client_secret_basic.rb
@@ -13,6 +13,10 @@ module Doorkeeper
       # decoding now would break every existing client whose credentials
       # contain URL-encodable characters.
       class ClientSecretBasic
+        def self.uses_shared_secret?
+          true
+        end
+
         # Match whenever the header decodes to a non-blank +client_id+ — i.e.
         # whenever a Basic authentication *attempt* is present. The secret may
         # be empty (public clients) or missing; those are still Basic auth

--- a/lib/doorkeeper/oauth/client_authentication/client_secret_post.rb
+++ b/lib/doorkeeper/oauth/client_authentication/client_secret_post.rb
@@ -7,6 +7,10 @@ module Doorkeeper
       # the request body. The query string is intentionally ignored so that
       # credentials must be supplied in the body as the spec requires.
       class ClientSecretPost
+        def self.uses_shared_secret?
+          true
+        end
+
         def self.matches_request?(request)
           params = request.request_parameters.with_indifferent_access
 

--- a/lib/doorkeeper/oauth/client_authentication/none.rb
+++ b/lib/doorkeeper/oauth/client_authentication/none.rb
@@ -6,6 +6,11 @@ module Doorkeeper
       # RFC 6749 §2.3 "none": a public client that authenticates with only a
       # client_id and no secret (in the request body, not the query string).
       class None
+        # The absence of client authentication involves no secret at all.
+        def self.uses_shared_secret?
+          false
+        end
+
         # Rejects a request that carries header-based client authentication (a
         # +Basic+ credential, or any non-blank Authorization header that is not
         # a bearer token): such a request must not be silently treated as an
@@ -19,13 +24,20 @@ module Doorkeeper
         # authenticating the client, so it must not suppress the +none+
         # strategy for a public client that identifies itself with a body
         # +client_id+.
+        #
+        # A request carrying a client_assertion is likewise attempting real
+        # client authentication (RFC 7521 allows a bare client_id next to the
+        # assertion), so it must not be picked up as an unauthenticated
+        # public client no matter where this method sits in the configured
+        # order.
         def self.matches_request?(request)
           params = request.request_parameters.with_indifferent_access
 
           request.post? &&
             !client_authentication_header?(request) &&
             params[:client_id].present? &&
-            params[:client_secret].blank?
+            params[:client_secret].blank? &&
+            params[:client_assertion].blank?
         end
 
         # A blank Authorization header carries no client authentication; a

--- a/lib/doorkeeper/oauth/client_authentication/private_key_jwt.rb
+++ b/lib/doorkeeper/oauth/client_authentication/private_key_jwt.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+require "uri"
+
+require "doorkeeper/oauth/client_authentication/private_key_jwt/key_resolver"
+require "doorkeeper/oauth/client_authentication/private_key_jwt/replay_guard"
+
+module Doorkeeper
+  module OAuth
+    module ClientAuthentication
+      # "private_key_jwt" client authentication (RFC 7523 / OIDC Core §9):
+      # the client authenticates with a JWT assertion signed by its private
+      # key; the server verifies it against the client's published public
+      # keys (a jwks attribute on the application model, or keys fetched
+      # from its jwks_uri). No shared secret is involved.
+      #
+      # The "jwt" gem is required only when an assertion is actually
+      # authenticated, so servers that don't enable this method don't need
+      # the dependency.
+      class PrivateKeyJwt
+        CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+        # Assertions are verified against the client's published public
+        # keys; no shared secret is involved.
+        def self.uses_shared_secret?
+          false
+        end
+
+        # Asymmetric signature algorithms only: HMAC family (and "none") are
+        # shared-secret/unauthenticated and must never verify an assertion.
+        ALLOWED_ALGORITHMS = %w[RS256 RS384 RS512 PS256 PS384 PS512 ES256 ES384 ES512].freeze
+
+        # iss/sub identify the client, aud prevents cross-server replay,
+        # exp bounds the assertion lifetime and jti makes it single-use
+        # (OIDC Core §9 requires all of these for private_key_jwt).
+        REQUIRED_CLAIMS = %w[iss sub aud exp jti].freeze
+
+        # Upper bound on how far in the future an assertion may expire. This
+        # both rejects sloppily long-lived assertions and bounds the replay
+        # guard's memory.
+        MAX_LIFETIME = 3600
+
+        def self.matches_request?(request)
+          params = request.request_parameters.with_indifferent_access
+
+          request.post? &&
+            params[:client_assertion].present? &&
+            params[:client_assertion_type] == CLIENT_ASSERTION_TYPE
+        end
+
+        def self.authenticate(request)
+          require_jwt!
+
+          params = request.request_parameters.with_indifferent_access
+          assertion = params[:client_assertion].to_s
+
+          client_id = unverified_client_id(assertion)
+          return if client_id.blank?
+          # RFC 7521 §4.2: a client_id parameter sent alongside the assertion
+          # must agree with the assertion's issuer.
+          return if params[:client_id].present? && params[:client_id] != client_id
+
+          application = OAuth::Client.find(client_id)&.application
+          return unless application
+
+          jwk_set = KeyResolver.jwk_set_for(application)
+          return unless jwk_set
+
+          claims = verified_claims(assertion, client_id, jwk_set, request)
+          return unless claims
+          return unless ReplayGuard.instance.first_use?(
+            "#{client_id}:#{claims["jti"]}",
+            expires_at: claims["exp"].to_i,
+          )
+
+          Doorkeeper::ClientAuthentication::VerifiedCredentials.new(client_id)
+        end
+
+        # The issuer read without verifying the signature — only used to
+        # locate the client (and thereby its keys); every claim is verified
+        # against those keys before the assertion authenticates anyone.
+        def self.unverified_client_id(assertion)
+          claims, = JWT.decode(assertion, nil, false)
+          # A JWT payload is any JSON value, not necessarily an object, and
+          # nothing is verified at this point — so the decoded claims are
+          # type-checked before being indexed into.
+          return unless claims.is_a?(Hash)
+
+          issuer = claims["iss"]
+
+          issuer if issuer.is_a?(String) && issuer == claims["sub"]
+        rescue JWT::DecodeError
+          nil
+        end
+        private_class_method :unverified_client_id
+
+        def self.verified_claims(assertion, client_id, jwk_set, request)
+          claims, = JWT.decode(
+            assertion,
+            nil,
+            true,
+            algorithms: ALLOWED_ALGORITHMS,
+            jwks: jwk_set,
+            required_claims: REQUIRED_CLAIMS,
+            iss: client_id,
+            verify_iss: true,
+            sub: client_id,
+            verify_sub: true,
+            aud: acceptable_audiences(request),
+            verify_aud: true,
+          )
+
+          return unless claims["exp"].to_i <= Time.now.to_i + MAX_LIFETIME
+          return unless claims["jti"].is_a?(String) && claims["jti"].present?
+
+          claims
+        rescue JWT::DecodeError, OpenSSL::OpenSSLError
+          # A published key is only parsed far enough to be usable when it is
+          # actually needed to verify a signature, so a structurally valid but
+          # mathematically nonsensical key (an EC point that is not on the
+          # curve, say) surfaces here as a bare OpenSSL error rather than a
+          # JWT one. Both mean the same thing: this assertion does not verify.
+          nil
+        end
+        private_class_method :verified_claims
+
+        # RFC 7523bis expects the issuer identifier as the audience; older
+        # deployments use the token endpoint URL. Both are accepted.
+        #
+        # OIDC Core §9 says the audience SHOULD be the token endpoint URL, and
+        # clients follow that for every endpoint they authenticate at — so the
+        # token endpoint URL is accepted at the revocation and introspection
+        # endpoints too, not just at the endpoint being called.
+        #
+        # The endpoint URLs are built from the server's own configured
+        # identity, never from the request: aud is what keeps an assertion
+        # minted for another authorization server from being replayed here, so
+        # deriving it from the client-supplied Host header would defeat its
+        # purpose on any deployment that does not filter hosts. Only a server
+        # that identifies itself nowhere falls back to the request, which is
+        # how MetadataResponse derives its issuer as well.
+        def self.acceptable_audiences(request)
+          options = server_url_options(request)
+
+          [
+            Doorkeeper.config.issuer.presence,
+            "#{base_url(options)}#{request.path}",
+            token_endpoint_url(options),
+          ].compact.uniq
+        end
+        private_class_method :acceptable_audiences
+
+        def self.server_url_options(request)
+          configured_url_options ||
+            { protocol: request.protocol, host: request.host, port: request.optional_port }
+        end
+        private_class_method :server_url_options
+
+        # An explicitly configured canonical host wins; failing that, the
+        # issuer, when it is an absolute URL (Doorkeeper allows any string).
+        def self.configured_url_options
+          default = ::Rails.application&.routes&.default_url_options || {}
+          return url_options_from(default) if default[:host].present?
+
+          issuer = URI.parse(Doorkeeper.config.issuer.to_s)
+          return unless issuer.is_a?(URI::HTTP) && issuer.host.present?
+
+          {
+            protocol: "#{issuer.scheme}://",
+            host: issuer.host,
+            port: (issuer.port unless issuer.port == issuer.default_port),
+          }
+        rescue URI::InvalidURIError
+          nil
+        end
+        private_class_method :configured_url_options
+
+        def self.url_options_from(default)
+          { protocol: default[:protocol] || "https://", host: default[:host], port: default[:port] }
+        end
+        private_class_method :url_options_from
+
+        def self.base_url(options)
+          protocol = options[:protocol].to_s
+          protocol = "#{protocol}://" unless protocol.end_with?("://")
+          host = options[:port].present? ? "#{options[:host]}:#{options[:port]}" : options[:host]
+
+          "#{protocol}#{host}"
+        end
+        private_class_method :base_url
+
+        # Built the way MetadataResponse advertises the token endpoint, so a
+        # host application that renamed the tokens controller still gets the
+        # URL its own metadata publishes.
+        def self.token_endpoint_url(url_options)
+          mapping = Doorkeeper::Rails::Routes.mapping[:tokens]
+          return unless mapping
+
+          ::Rails.application.routes.url_for(
+            { controller: "/#{mapping[:controllers]}", action: "create" }.merge(url_options),
+          )
+        rescue StandardError
+          # Routes may be skipped or unmounted; fall back to the other audiences.
+          nil
+        end
+        private_class_method :token_endpoint_url
+
+        # Enabling this method without the gem installed is a deployment
+        # mistake, not a protocol error the client could correct — so the
+        # explanation has to reach the operator rather than the client. A
+        # Doorkeeper::Errors::DoorkeeperError would be translated into an OAuth
+        # error response whose "error" value is its message (DoorkeeperError#type
+        # returns the message), handing the client a sentence where a registered
+        # error code belongs; LoadError keeps the diagnosis in the server's logs
+        # and surfaces the request as the server error it is.
+        def self.require_jwt!
+          require "jwt"
+        rescue LoadError
+          raise LoadError,
+                "private_key_jwt client authentication requires the 'jwt' gem (>= 2.7); " \
+                "add it to your Gemfile to use this method"
+        end
+        private_class_method :require_jwt!
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/client_authentication/private_key_jwt.rb
+++ b/lib/doorkeeper/oauth/client_authentication/private_key_jwt.rb
@@ -68,13 +68,21 @@ module Doorkeeper
 
           claims = verified_claims(assertion, client_id, jwk_set, request)
           return unless claims
-          return unless ReplayGuard.instance.first_use?(
+          return unless replay_guard.first_use?(
             "#{client_id}:#{claims["jti"]}",
             expires_at: claims["exp"].to_i,
           )
 
           Doorkeeper::ClientAuthentication::VerifiedCredentials.new(client_id)
         end
+
+        # The built-in guard is process-local; a multi-process deployment can
+        # supply a shared store through the private_key_jwt_replay_guard
+        # config option.
+        def self.replay_guard
+          Doorkeeper.config.private_key_jwt_replay_guard || ReplayGuard.instance
+        end
+        private_class_method :replay_guard
 
         # The issuer read without verifying the signature — only used to
         # locate the client (and thereby its keys); every claim is verified

--- a/lib/doorkeeper/oauth/client_authentication/private_key_jwt.rb
+++ b/lib/doorkeeper/oauth/client_authentication/private_key_jwt.rb
@@ -108,9 +108,19 @@ module Doorkeeper
             verify_sub: true,
             aud: acceptable_audiences(request),
             verify_aud: true,
+            # Passed explicitly so a host application that globally disabled
+            # expiration checking for its own tokens (JWT.configuration.decode)
+            # cannot silently turn off assertion expiry verification.
+            verify_expiration: true,
           )
 
-          return unless claims["exp"].to_i <= Time.now.to_i + MAX_LIFETIME
+          # RFC 7519 §4.1.4: exp is a NumericDate — a number. The jwt gem's
+          # own expiration check casts it with to_i, which would let a numeric
+          # string through (and read a non-numeric one as 0), so the type is
+          # pinned before the value is compared or handed to the replay guard.
+          exp = claims["exp"]
+          return unless exp.is_a?(Numeric) && exp.finite?
+          return unless exp <= Time.now.to_i + MAX_LIFETIME
           return unless claims["jti"].is_a?(String) && claims["jti"].present?
 
           claims

--- a/lib/doorkeeper/oauth/client_authentication/private_key_jwt.rb
+++ b/lib/doorkeeper/oauth/client_authentication/private_key_jwt.rb
@@ -16,7 +16,9 @@ module Doorkeeper
       #
       # The "jwt" gem is required only when an assertion is actually
       # authenticated, so servers that don't enable this method don't need
-      # the dependency.
+      # the dependency. Its constants are always referenced as ::JWT:
+      # doorkeeper-jwt defines Doorkeeper::JWT, which would otherwise shadow
+      # the gem everywhere inside this class.
       class PrivateKeyJwt
         CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
@@ -88,7 +90,7 @@ module Doorkeeper
         # locate the client (and thereby its keys); every claim is verified
         # against those keys before the assertion authenticates anyone.
         def self.unverified_client_id(assertion)
-          claims, = JWT.decode(assertion, nil, false)
+          claims, = ::JWT.decode(assertion, nil, false)
           # A JWT payload is any JSON value, not necessarily an object, and
           # nothing is verified at this point — so the decoded claims are
           # type-checked before being indexed into.
@@ -97,13 +99,13 @@ module Doorkeeper
           issuer = claims["iss"]
 
           issuer if issuer.is_a?(String) && issuer == claims["sub"]
-        rescue JWT::DecodeError
+        rescue ::JWT::DecodeError
           nil
         end
         private_class_method :unverified_client_id
 
         def self.verified_claims(assertion, client_id, jwk_set, request)
-          claims, = JWT.decode(
+          claims, = ::JWT.decode(
             assertion,
             nil,
             true,
@@ -132,7 +134,7 @@ module Doorkeeper
           return unless claims["jti"].is_a?(String) && claims["jti"].present?
 
           claims
-        rescue JWT::DecodeError, OpenSSL::OpenSSLError
+        rescue ::JWT::DecodeError, OpenSSL::OpenSSLError
           # A published key is only parsed far enough to be usable when it is
           # actually needed to verify a signature, so a structurally valid but
           # mathematically nonsensical key (an EC point that is not on the

--- a/lib/doorkeeper/oauth/client_authentication/private_key_jwt/key_resolver.rb
+++ b/lib/doorkeeper/oauth/client_authentication/private_key_jwt/key_resolver.rb
@@ -82,9 +82,17 @@ module Doorkeeper
           end
           private_class_method :fetch_jwks
 
+          # The built-in cache is process-local with a fixed TTL; the
+          # private_key_jwt_jwks_cache config option replaces it with any
+          # object answering fetch(url) { ... }.
           def self.jwks_cache
-            @jwks_cache ||= Doorkeeper::DocumentCache.new
+            Doorkeeper.config.private_key_jwt_jwks_cache || default_jwks_cache
           end
+
+          def self.default_jwks_cache
+            @default_jwks_cache ||= Doorkeeper::DocumentCache.new
+          end
+          private_class_method :default_jwks_cache
         end
       end
     end

--- a/lib/doorkeeper/oauth/client_authentication/private_key_jwt/key_resolver.rb
+++ b/lib/doorkeeper/oauth/client_authentication/private_key_jwt/key_resolver.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "json"
+require "uri"
+
+module Doorkeeper
+  module OAuth
+    module ClientAuthentication
+      class PrivateKeyJwt
+        # Resolves the JWK Set a client's assertion must verify against:
+        # the +jwks+ / +jwks_uri+ attributes of its application, when the
+        # application model provides them (Doorkeeper defines no such
+        # columns itself).
+        #
+        # Symmetric ("oct") keys are dropped: a symmetric key in a JWK Set is
+        # a shared secret, which this method must never verify against.
+        module KeyResolver
+          # A published JWK Set is remote, client-controlled input, so each
+          # level is type-checked before it is indexed into: a JWK Set that
+          # is not an object of objects must fail authentication, never
+          # raise out of the token endpoint.
+          def self.jwk_set_for(application)
+            raw = raw_jwks(application)
+            return unless raw.is_a?(Hash)
+
+            keys = raw["keys"] || raw[:keys]
+            return unless keys.is_a?(Array)
+
+            asymmetric = keys.grep(Hash).reject { |key| (key["kty"] || key[:kty]).to_s == "oct" }
+            return if asymmetric.empty?
+
+            JWT::JWK::Set.new({ "keys" => asymmetric })
+          rescue JWT::DecodeError, OpenSSL::OpenSSLError
+            # A hostile key can fail to parse in more ways than JWT::JWKError:
+            # a member that is not valid base64url raises JWT::Base64DecodeError
+            # (a sibling of JWT::JWKError under JWT::DecodeError, not a
+            # subclass), and an EC point that is not on its curve raises a bare
+            # OpenSSL error. None of them may escape into the token endpoint.
+            nil
+          end
+
+          def self.raw_jwks(application)
+            application_jwks(application) || fetch_jwks(application_jwks_uri(application))
+          end
+          private_class_method :raw_jwks
+
+          def self.application_jwks(application)
+            return unless application.respond_to?(:jwks)
+
+            jwks = application.jwks
+            jwks.is_a?(String) ? JSON.parse(jwks) : jwks.presence
+          rescue JSON::ParserError
+            nil
+          end
+          private_class_method :application_jwks
+
+          def self.application_jwks_uri(application)
+            application.jwks_uri if application.respond_to?(:jwks_uri)
+          end
+          private_class_method :application_jwks_uri
+
+          # The jwks_uri is fetched with a hardened HTTP client: https only,
+          # no redirects, 200 OK only, and RFC 6890 special-use addresses
+          # refused.
+          #
+          # The result is memoized, since otherwise every single authenticated
+          # request would fetch it again; a rotated key is picked up once the
+          # memo expires. Only JSON objects are stored, so a malformed
+          # response is not cached.
+          def self.fetch_jwks(jwks_uri)
+            return if jwks_uri.blank?
+
+            url = jwks_uri.to_s
+            return unless URI.parse(url).is_a?(URI::HTTPS)
+
+            jwks_cache.fetch(url) do
+              parsed = JSON.parse(Doorkeeper::HttpFetcher.new.fetch(url))
+              parsed if parsed.is_a?(Hash)
+            end
+          rescue Doorkeeper::HttpFetcher::FetchError, JSON::ParserError, URI::InvalidURIError
+            nil
+          end
+          private_class_method :fetch_jwks
+
+          def self.jwks_cache
+            @jwks_cache ||= Doorkeeper::DocumentCache.new
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/client_authentication/private_key_jwt/key_resolver.rb
+++ b/lib/doorkeeper/oauth/client_authentication/private_key_jwt/key_resolver.rb
@@ -14,6 +14,10 @@ module Doorkeeper
         #
         # Symmetric ("oct") keys are dropped: a symmetric key in a JWK Set is
         # a shared secret, which this method must never verify against.
+        #
+        # The jwt gem is always referenced as ::JWT: doorkeeper-jwt defines
+        # Doorkeeper::JWT, which would otherwise shadow the gem everywhere
+        # inside this module.
         module KeyResolver
           # A published JWK Set is remote, client-controlled input, so each
           # level is type-checked before it is indexed into: a JWK Set that
@@ -29,8 +33,8 @@ module Doorkeeper
             asymmetric = keys.grep(Hash).reject { |key| (key["kty"] || key[:kty]).to_s == "oct" }
             return if asymmetric.empty?
 
-            JWT::JWK::Set.new({ "keys" => asymmetric })
-          rescue JWT::DecodeError, OpenSSL::OpenSSLError
+            ::JWT::JWK::Set.new({ "keys" => asymmetric })
+          rescue ::JWT::DecodeError, OpenSSL::OpenSSLError
             # A hostile key can fail to parse in more ways than JWT::JWKError:
             # a member that is not valid base64url raises JWT::Base64DecodeError
             # (a sibling of JWT::JWKError under JWT::DecodeError, not a

--- a/lib/doorkeeper/oauth/client_authentication/private_key_jwt/replay_guard.rb
+++ b/lib/doorkeeper/oauth/client_authentication/private_key_jwt/replay_guard.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "singleton"
+
+module Doorkeeper
+  module OAuth
+    module ClientAuthentication
+      class PrivateKeyJwt
+        # In-memory, process-local single-use guard for assertion jti values
+        # (OIDC Core §9: an assertion may only be used once). Entries live
+        # until the assertion's own exp, which PrivateKeyJwt caps at
+        # MAX_LIFETIME, so the memory held here is bounded.
+        #
+        # Being process-local this cannot catch a replay against a different
+        # server process; a shared store is deliberately left as a follow-up
+        # for the prototype.
+        class ReplayGuard
+          include Singleton
+
+          MAX_ENTRIES = 10_000
+
+          # Expired entries are swept periodically rather than on every
+          # authentication: the sweep is O(entries) and would otherwise run on
+          # each request, walking up to MAX_ENTRIES every time. An entry that
+          # outlives its exp by up to this long only makes the guard stricter,
+          # never more permissive.
+          SWEEP_INTERVAL = 10
+
+          def initialize
+            @mutex = Mutex.new
+            @seen = {}
+            @sweep_after = 0
+          end
+
+          # @return [Boolean] true when the key was not seen before; the key
+          #   is then remembered until +expires_at+ (unix time).
+          def first_use?(key, expires_at:)
+            now = Time.now.to_i
+
+            @mutex.synchronize do
+              if now >= @sweep_after || @seen.size >= MAX_ENTRIES
+                @seen.delete_if { |_, expiry| expiry <= now }
+                @sweep_after = now + SWEEP_INTERVAL
+              end
+
+              return false if @seen.key?(key)
+
+              # When full even after expiry pruning, evict the oldest entries
+              # rather than rejecting new assertions: rejecting would let a
+              # flood of assertions lock legitimate clients out entirely,
+              # while evicting only shortens the replay window under attack.
+              @seen.shift while @seen.size >= MAX_ENTRIES
+
+              @seen[key] = expires_at
+              true
+            end
+          end
+
+          def clear
+            @mutex.synchronize do
+              @seen.clear
+              @sweep_after = 0
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/oauth/client_authentication/private_key_jwt/replay_guard.rb
+++ b/lib/doorkeeper/oauth/client_authentication/private_key_jwt/replay_guard.rb
@@ -9,14 +9,23 @@ module Doorkeeper
         # In-memory, process-local single-use guard for assertion jti values
         # (OIDC Core §9: an assertion may only be used once). Entries live
         # until the assertion's own exp, which PrivateKeyJwt caps at
-        # MAX_LIFETIME, so the memory held here is bounded.
+        # MAX_LIFETIME, so the memory held here is bounded: at most
+        # MAX_ENTRIES entries, each for at most MAX_LIFETIME seconds.
         #
-        # Being process-local this cannot catch a replay against a different
-        # server process; a shared store is deliberately left as a follow-up
-        # for the prototype.
+        # Being process-local this cannot catch a replay delivered to a
+        # different server process (separate Puma workers, separate hosts).
+        # Whether that matters depends on the deployment: the replay window
+        # is at most MAX_LIFETIME anyway, and an attacker who can capture an
+        # assertion in transit usually defeats TLS first. A deployment that
+        # wants cross-process replay protection supplies a shared store
+        # (backed by Redis or the like) through the
+        # private_key_jwt_replay_guard config option.
         class ReplayGuard
           include Singleton
 
+          # Upper bound on remembered jti values. When the guard is full even
+          # after expired entries are pruned, the oldest entries are evicted
+          # rather than new assertions rejected — see first_use?.
           MAX_ENTRIES = 10_000
 
           # Expired entries are swept periodically rather than on every

--- a/lib/doorkeeper/oauth/refresh_token_request.rb
+++ b/lib/doorkeeper/oauth/refresh_token_request.rb
@@ -28,8 +28,15 @@ module Doorkeeper
 
       private
 
+      # Resolved through +OAuth::Client+ rather than by looking the row up
+      # directly, so this grant applies the same rules the other token
+      # endpoint grants do: credentials that carry no secret because their
+      # authentication method already proved the client's identity
+      # (private_key_jwt) resolve by uid alone. The application record is
+      # what is returned, since that is what +#client+ has always exposed
+      # here.
       def load_client(credentials)
-        Doorkeeper.config.application_model.by_uid_and_secret(credentials.uid, credentials.secret)
+        Doorkeeper::OAuth::Client.authenticate(credentials)&.application
       end
 
       def before_successful_response

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -306,7 +306,19 @@ Doorkeeper.configure do
   # attributes you define on your Application model (Doorkeeper does not add
   # these columns itself). Assertions must carry iss = sub =
   # client_id, an aud of your `issuer` (or the token endpoint URL), a bounded
-  # exp, a kid header, and a single-use jti (replay is tracked per process).
+  # exp (at most 1 hour ahead), a kid header, and a single-use jti.
+  #
+  # jti replay is tracked in process-local memory by default (bounded at
+  # 10 000 entries, each held at most 1 hour), so an assertion replayed to a
+  # different server process is not caught. To share the tracking across
+  # processes, supply your own store (e.g. backed by Redis):
+  #
+  # private_key_jwt_replay_guard MyRedisReplayGuard.new
+  #
+  # JWK Sets fetched from a `jwks_uri` are cached in process-local memory
+  # for 60 seconds; to change the TTL or share the cache across processes:
+  #
+  # private_key_jwt_jwks_cache Doorkeeper::DocumentCache.new(ttl: 300)
   #
   # The accepted audiences are built from your `issuer` or from Rails'
   # `default_url_options`; set at least one of them, otherwise Doorkeeper has

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -298,6 +298,28 @@ Doorkeeper.configure do
   # The legacy `client_credentials` option is deprecated; `:from_basic` and
   # `:from_params` are automatically mapped to `:client_secret_basic` and
   # `:client_secret_post`.
+  #
+  # A `private_key_jwt` method (RFC 7523 / OIDC Core §9) is also registered
+  # but not enabled by default — add it to the list above to accept it. It
+  # requires the `jwt` gem (>= 2.7) in your bundle, and verifies assertions
+  # against the client's published public keys: `jwks` / `jwks_uri`
+  # attributes you define on your Application model (Doorkeeper does not add
+  # these columns itself). Assertions must carry iss = sub =
+  # client_id, an aud of your `issuer` (or the token endpoint URL), a bounded
+  # exp, a kid header, and a single-use jti (replay is tracked per process).
+  #
+  # The accepted audiences are built from your `issuer` or from Rails'
+  # `default_url_options`; set at least one of them, otherwise Doorkeeper has
+  # nothing but the request's Host header to identify itself with and the
+  # audience check cannot tell your server apart from another one.
+  #
+  # A client's `jwks_uri` is fetched with a hardened HTTP client (HTTPS
+  # only, no redirects, hosts resolving to RFC 6890 special-use addresses
+  # refused), so a jwks_uri on a private network or on localhost is refused
+  # even though you configured it yourself; inline `jwks` has no such
+  # restriction.
+  #
+  # client_authentication %i[client_secret_basic client_secret_post none private_key_jwt]
 
   # Change the way access token is authenticated from the request object.
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then

--- a/spec/dummy/db/migrate/20260801000000_add_jwks_to_oauth_applications.rb
+++ b/spec/dummy/db/migrate/20260801000000_add_jwks_to_oauth_applications.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# The optional jwks / jwks_uri attributes the private_key_jwt client
+# authentication method reads from the application model when a host
+# application defines them (Doorkeeper itself adds no such columns).
+class AddJwksToOauthApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :oauth_applications, :jwks, :text
+    add_column :oauth_applications, :jwks_uri, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20260730000000) do
+ActiveRecord::Schema.define(version: 20260801000000) do
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
@@ -62,6 +62,8 @@ ActiveRecord::Schema.define(version: 20260730000000) do
     t.integer "owner_id"
     t.string "owner_type"
     t.boolean "confidential", default: true, null: false
+    t.text "jwks"
+    t.string "jwks_uri"
     t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end

--- a/spec/lib/client_authentication/legacy_callable_spec.rb
+++ b/spec/lib/client_authentication/legacy_callable_spec.rb
@@ -5,6 +5,10 @@ require "spec_helper"
 RSpec.describe Doorkeeper::ClientAuthentication::LegacyCallable do
   let(:request) { double(:request, env: {}) }
 
+  it "is treated as a shared-secret method" do
+    expect(described_class.new(->(_request) {}).uses_shared_secret?).to be true
+  end
+
   describe "#matches_request?" do
     it "matches when the callable yields present credentials" do
       adapter = described_class.new(->(_request) { %w[uid secret] })

--- a/spec/lib/client_authentication/method_spec.rb
+++ b/spec/lib/client_authentication/method_spec.rb
@@ -31,4 +31,17 @@ RSpec.describe Doorkeeper::ClientAuthentication::Method do
 
     method.authenticate(example: true)
   end
+
+  describe "#uses_shared_secret?" do
+    it "trusts a strategy that declares it" do
+      declared = described_class.new(:client_secret_sounding, double(uses_shared_secret?: false))
+
+      expect(declared.uses_shared_secret?).to be false
+    end
+
+    it "falls back to the registration name when undeclared" do
+      expect(described_class.new(:my_client_secret_thing, double).uses_shared_secret?).to be true
+      expect(described_class.new(:tls_client_auth, double).uses_shared_secret?).to be false
+    end
+  end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -921,6 +921,44 @@ RSpec.describe Doorkeeper::Config do
     end
   end
 
+  describe "private_key_jwt_replay_guard" do
+    it "defaults to nil, which selects the built-in process-local guard" do
+      Doorkeeper.configure { orm DOORKEEPER_ORM }
+
+      expect(config.private_key_jwt_replay_guard).to be_nil
+    end
+
+    it "accepts a custom store" do
+      guard = double("replay guard")
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        private_key_jwt_replay_guard guard
+      end
+
+      expect(config.private_key_jwt_replay_guard).to be(guard)
+    end
+  end
+
+  describe "private_key_jwt_jwks_cache" do
+    it "defaults to nil, which selects the built-in process-local cache" do
+      Doorkeeper.configure { orm DOORKEEPER_ORM }
+
+      expect(config.private_key_jwt_jwks_cache).to be_nil
+    end
+
+    it "accepts a custom cache" do
+      cache = Doorkeeper::DocumentCache.new(ttl: 300)
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        private_key_jwt_jwks_cache cache
+      end
+
+      expect(config.private_key_jwt_jwks_cache).to be(cache)
+    end
+  end
+
   describe "issuer format validation" do
     def configure_issuer(value)
       Doorkeeper.configure do

--- a/spec/lib/document_cache_spec.rb
+++ b/spec/lib/document_cache_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# DocumentCache#fetch has no default-value argument, so the Hash#fetch cop's
+# suggested rewrite does not apply here.
+# rubocop:disable Style/RedundantFetchBlock
+RSpec.describe Doorkeeper::DocumentCache do
+  subject(:cache) { described_class.new }
+
+  let(:url) { "https://client.example.com/oauth-client" }
+
+  describe "#fetch" do
+    it "stores and returns the block result" do
+      expect(cache.fetch(url) { :document }).to eq(:document)
+    end
+
+    it "memoizes within the TTL" do
+      calls = 0
+      2.times { cache.fetch(url) { calls += 1 } }
+
+      expect(calls).to eq(1)
+    end
+
+    it "does not cache nil results" do
+      cache.fetch(url) { nil }
+      expect(cache.fetch(url) { :second }).to eq(:second)
+    end
+
+    it "does not cache raised failures" do
+      expect { cache.fetch(url) { raise "boom" } }.to raise_error("boom")
+      expect(cache.fetch(url) { :after_failure }).to eq(:after_failure)
+    end
+
+    it "expires entries after the TTL" do
+      expired = described_class.new(ttl: 0)
+      expired.fetch(url) { :first }
+
+      expect(expired.fetch(url) { :second }).to eq(:second)
+    end
+
+    it "keeps distinct URLs separate" do
+      cache.fetch(url) { :one }
+      expect(cache.fetch("#{url}-2") { :two }).to eq(:two)
+    end
+
+    it "bounds the number of stored entries" do
+      (described_class::MAX_ENTRIES + 10).times do |i|
+        cache.fetch("https://client.example.com/c#{i}") { i }
+      end
+
+      expect(cache.fetch("https://client.example.com/c0") { :refetched }).to eq(:refetched)
+    end
+  end
+
+  describe "#clear" do
+    it "drops all entries" do
+      cache.fetch(url) { :first }
+      cache.clear
+
+      expect(cache.fetch(url) { :second }).to eq(:second)
+    end
+  end
+end
+# rubocop:enable Style/RedundantFetchBlock

--- a/spec/lib/http_fetcher_spec.rb
+++ b/spec/lib/http_fetcher_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe Doorkeeper::HttpFetcher do
       expect(request_stub).not_to have_been_requested
     end
 
+    # URI.parse("https:foo") is a URI::HTTPS with a nil host, so a hostless
+    # URL can reach the fetcher despite an is_a?(URI::HTTPS) check upstream;
+    # handing that nil to Resolv would raise ArgumentError, not FetchError.
+    it "raises a FetchError without resolving when the URL has no host" do
+      expect(resolver).not_to receive(:getaddresses)
+
+      expect { fetcher.fetch("https:foo") }.to raise_error(described_class::FetchError, /no host/)
+      expect { fetcher.fetch("https://") }.to raise_error(described_class::FetchError, /no host/)
+    end
+
     it "raises without connecting when the host resolves to a special-use address" do
       allow(resolver).to receive(:getaddresses).and_return(["127.0.0.1"])
       request_stub = stub_request(:get, url)

--- a/spec/lib/http_fetcher_spec.rb
+++ b/spec/lib/http_fetcher_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Doorkeeper::HttpFetcher do
+  subject(:fetcher) { described_class.new(resolver: resolver) }
+
+  let(:url) { "https://client.example.com/oauth-client" }
+  let(:public_address) { "93.184.216.34" }
+  let(:resolver) { class_double(Resolv, getaddresses: [public_address]) }
+
+  describe "#fetch" do
+    it "returns the body of a 200 response" do
+      stub_request(:get, url).to_return(status: 200, body: '{"client_id":"x"}')
+
+      expect(fetcher.fetch(url)).to eq('{"client_id":"x"}')
+    end
+
+    it "raises on a non-200 response" do
+      stub_request(:get, url).to_return(status: 404, body: "not found")
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /404/)
+    end
+
+    it "raises on a 500 response" do
+      stub_request(:get, url).to_return(status: 500)
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /500/)
+    end
+
+    it "does not follow redirects and treats them as errors" do
+      redirect_target = "https://elsewhere.example.com/metadata"
+      stub_request(:get, url).to_return(status: 302, headers: { "Location" => redirect_target })
+      target_stub = stub_request(:get, redirect_target)
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /302/)
+      expect(target_stub).not_to have_been_requested
+    end
+
+    it "raises when the host does not resolve" do
+      allow(resolver).to receive(:getaddresses).and_return([])
+      request_stub = stub_request(:get, url)
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /resolve/)
+      expect(request_stub).not_to have_been_requested
+    end
+
+    it "raises without connecting when the host resolves to a special-use address" do
+      allow(resolver).to receive(:getaddresses).and_return(["127.0.0.1"])
+      request_stub = stub_request(:get, url)
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /special-use/)
+      expect(request_stub).not_to have_been_requested
+    end
+
+    it "raises when any of several resolved addresses is special-use" do
+      allow(resolver).to receive(:getaddresses).and_return([public_address, "10.0.0.5"])
+      request_stub = stub_request(:get, url)
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /special-use/)
+      expect(request_stub).not_to have_been_requested
+    end
+
+    it "returns a body right at the size limit" do
+      body = "x" * described_class::MAX_RESPONSE_SIZE
+      stub_request(:get, url).to_return(status: 200, body: body)
+
+      expect(fetcher.fetch(url).bytesize).to eq(described_class::MAX_RESPONSE_SIZE)
+    end
+
+    it "raises when the body exceeds the size limit" do
+      stub_request(:get, url).to_return(status: 200, body: "x" * (described_class::MAX_RESPONSE_SIZE + 1))
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /exceeds/)
+    end
+
+    it "raises without reading the body when Content-Length declares an oversized document" do
+      stub_request(:get, url).to_return(
+        status: 200,
+        body: "{}",
+        headers: { "Content-Length" => (described_class::MAX_RESPONSE_SIZE + 1).to_s },
+      )
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /over the/)
+    end
+
+    it "raises when reading the body outlives the total time budget" do
+      stub_request(:get, url).to_return(status: 200, body: "x" * 512)
+      # Every clock reading lands past the deadline computed before the read.
+      allow(Process).to receive(:clock_gettime).and_return(0, described_class::MAX_TOTAL_TIME + 1)
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /too long/)
+    end
+
+    it "requests an identity encoding so that no body is ever inflated" do
+      stub_request(:get, url).to_return(status: 200, body: "{}")
+
+      fetcher.fetch(url)
+
+      expect(
+        a_request(:get, url).with(headers: { "Accept-Encoding" => "identity" }),
+      ).to have_been_made
+    end
+
+    it "accepts a JSON media type carrying parameters" do
+      stub_request(:get, url).to_return(
+        status: 200,
+        body: "{}",
+        headers: { "Content-Type" => "application/json; charset=utf-8" },
+      )
+
+      expect(fetcher.fetch(url)).to eq("{}")
+    end
+
+    it "accepts an application/...+json media type" do
+      stub_request(:get, url).to_return(
+        status: 200,
+        body: "{}",
+        headers: { "Content-Type" => "application/jwk-set+json" },
+      )
+
+      expect(fetcher.fetch(url)).to eq("{}")
+    end
+
+    it "raises when the response declares a media type that is not JSON" do
+      stub_request(:get, url).to_return(
+        status: 200,
+        body: "{}",
+        headers: { "Content-Type" => "text/html" },
+      )
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /not a JSON media type/)
+    end
+
+    it "wraps network errors in FetchError" do
+      stub_request(:get, url).to_raise(Errno::ECONNREFUSED)
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError)
+    end
+
+    # Net::HTTPBadResponse descends from StandardError rather than from
+    # Net::ProtocolError, so a host answering with a mangled status line or
+    # header field would otherwise raise straight out of the endpoint.
+    it "wraps a mangled HTTP response in FetchError" do
+      stub_request(:get, url).to_raise(Net::HTTPBadResponse.new('wrong status line: "NOT-HTTP"'))
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /HTTPBadResponse/)
+    end
+
+    it "wraps a malformed header field in FetchError" do
+      stub_request(:get, url).to_raise(Net::HTTPHeaderSyntaxError)
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /HTTPHeaderSyntaxError/)
+    end
+
+    it "wraps a decompression failure in FetchError" do
+      stub_request(:get, url).to_raise(Zlib::DataError)
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError, /Zlib/)
+    end
+
+    it "wraps timeouts in FetchError" do
+      stub_request(:get, url).to_timeout
+
+      expect { fetcher.fetch(url) }.to raise_error(described_class::FetchError)
+    end
+  end
+
+  describe ".special_use?" do
+    blocked = %w[
+      0.0.0.1
+      10.1.2.3
+      100.64.0.1
+      127.0.0.1
+      127.8.8.8
+      169.254.10.10
+      172.16.0.1
+      172.31.255.254
+      192.0.0.10
+      192.0.2.44
+      192.88.99.1
+      192.168.1.1
+      198.18.0.1
+      198.51.100.7
+      203.0.113.9
+      224.0.0.251
+      240.0.0.1
+      255.255.255.255
+      ::
+      ::1
+      ::127.0.0.1
+      ::10.0.0.1
+      ::8.8.8.8
+      ::ffff:127.0.0.1
+      ::ffff:192.168.0.1
+      64:ff9b::1
+      100::1
+      2001:db8::1
+      2002::1
+      fc00::1
+      fdff::1
+      fe80::1
+      ff02::fb
+    ]
+
+    blocked.each do |address|
+      it "treats #{address} as special-use" do
+        expect(described_class.special_use?(address)).to be true
+      end
+    end
+
+    allowed = %w[
+      8.8.8.8
+      93.184.216.34
+      172.15.255.255
+      172.32.0.1
+      198.17.255.255
+      2606:2800:220:1:248:1893:25c8:1946
+      ::ffff:8.8.8.8
+      ::ffff:93.184.216.34
+    ]
+
+    allowed.each do |address|
+      it "treats #{address} as publicly routable" do
+        expect(described_class.special_use?(address)).to be false
+      end
+    end
+
+    it "treats unparseable addresses as special-use" do
+      expect(described_class.special_use?("not-an-ip")).to be true
+    end
+  end
+end

--- a/spec/lib/oauth/client_authentication/client_secret_basic_spec.rb
+++ b/spec/lib/oauth/client_authentication/client_secret_basic_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Doorkeeper::OAuth::ClientAuthentication::ClientSecretBasic do
+  it "declares that it uses a shared secret" do
+    expect(described_class.uses_shared_secret?).to be true
+  end
+
   describe ".matches_request?" do
     it "matches if the request has basic authorization" do
       request = mock_request(

--- a/spec/lib/oauth/client_authentication/client_secret_post_spec.rb
+++ b/spec/lib/oauth/client_authentication/client_secret_post_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Doorkeeper::OAuth::ClientAuthentication::ClientSecretPost do
+  it "declares that it uses a shared secret" do
+    expect(described_class.uses_shared_secret?).to be true
+  end
+
   describe ".matches_request?" do
     it "matches if the request body has the client credentials" do
       request = mock_request(request_parameters: { client_id: "1234", client_secret: "5678" })

--- a/spec/lib/oauth/client_authentication/none_spec.rb
+++ b/spec/lib/oauth/client_authentication/none_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Doorkeeper::OAuth::ClientAuthentication::None do
+  it "declares that it uses no shared secret" do
+    expect(described_class.uses_shared_secret?).to be false
+  end
+
   describe ".matches_request?" do
     it "matches if the request body has a client_id but no client_secret" do
       request = mock_request(request_parameters: { client_id: "1234" })
@@ -83,6 +87,18 @@ RSpec.describe Doorkeeper::OAuth::ClientAuthentication::None do
       request = mock_request(
         request_parameters: { client_id: "1234" },
         authorization: "Digest username=\"a\"",
+      )
+
+      expect(described_class.matches_request?(request)).not_to be true
+    end
+
+    it "doesn't match if the request carries a client_assertion (RFC 7521 §4.2)" do
+      request = mock_request(
+        request_parameters: {
+          client_id: "1234",
+          client_assertion: "some.jwt.assertion",
+          client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        },
       )
 
       expect(described_class.matches_request?(request)).not_to be true

--- a/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
+++ b/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
@@ -328,6 +328,30 @@ RSpec.describe Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt do
       expect(described_class.authenticate(request_with(assertion))).to be_nil
     end
 
+    it "tracks jti replay through a configured custom replay guard" do
+      guard = double("replay guard")
+      expect(guard).to receive(:first_use?)
+        .with(a_string_starting_with("#{client_id}:"), expires_at: kind_of(Integer))
+        .twice
+        .and_return(true, false)
+      config_is_set(:private_key_jwt_replay_guard, guard)
+
+      assertion = build_assertion
+
+      expect(described_class.authenticate(request_with(assertion))).not_to be_nil
+      expect(described_class.authenticate(request_with(assertion))).to be_nil
+    end
+
+    it "resolves a jwks_uri through a configured custom jwks cache" do
+      jwks_uri = "https://client.example.com/jwks.json"
+      allow(application).to receive_messages(jwks: nil, jwks_uri: jwks_uri)
+      cache = double("jwks cache")
+      allow(cache).to receive(:fetch).with(jwks_uri).and_return(jwks)
+      config_is_set(:private_key_jwt_jwks_cache, cache)
+
+      expect(described_class.authenticate(request_with(build_assertion))).not_to be_nil
+    end
+
     it "rejects garbage assertions" do
       expect(described_class.authenticate(request_with("not.a.jwt"))).to be_nil
     end

--- a/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
+++ b/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
@@ -100,6 +100,26 @@ RSpec.describe Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt do
       expect(credentials).to be_pre_authenticated
     end
 
+    # doorkeeper-jwt defines Doorkeeper::JWT, which shadows the jwt gem for
+    # any bare JWT reference made inside the Doorkeeper module — every gem
+    # reference in this class must be written ::JWT to survive that.
+    context "when doorkeeper-jwt's Doorkeeper::JWT module is defined" do
+      before do
+        stub_const("Doorkeeper::JWT", Module.new)
+      end
+
+      it "still authenticates a valid assertion" do
+        credentials = described_class.authenticate(request_with(build_assertion))
+
+        expect(credentials).to be_a(Doorkeeper::ClientAuthentication::VerifiedCredentials)
+        expect(credentials.uid).to eq(client_id)
+      end
+
+      it "still rejects a malformed assertion without raising" do
+        expect(described_class.authenticate(request_with("not-a-jwt"))).to be_nil
+      end
+    end
+
     # A missing dependency is the operator's problem, not the client's, so it
     # must not travel back as an OAuth error: raising outside the
     # Doorkeeper::Errors::DoorkeeperError hierarchy the endpoints translate into

--- a/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
+++ b/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
@@ -239,6 +239,70 @@ RSpec.describe Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt do
       expect(credentials).to be_nil
     end
 
+    # RFC 7519 §4.1.4 defines exp as a NumericDate — a number. The jwt gem
+    # validates the type when encoding but not when decoding, where its
+    # expiration check casts with to_i — so without an explicit type check a
+    # string exp would authenticate. Signed by hand because JWT.encode
+    # refuses to mint such an assertion.
+    it "rejects a validly signed assertion whose exp is a numeric string" do
+      claims = {
+        "iss" => client_id, "sub" => client_id, "aud" => issuer,
+        "exp" => (Time.now.to_i + 300).to_s, "jti" => "string-exp",
+      }
+      segments = [{ "alg" => "RS256", "kid" => kid }.to_json, claims.to_json].map do |segment|
+        Base64.urlsafe_encode64(segment).delete("=")
+      end
+      signing_input = segments.join(".")
+      signature = rsa_key.sign(OpenSSL::Digest.new("SHA256"), signing_input)
+      assertion = "#{signing_input}.#{Base64.urlsafe_encode64(signature).delete("=")}"
+
+      expect(described_class.authenticate(request_with(assertion))).to be_nil
+    end
+
+    it "rejects an assertion whose exp is an absurdly large integer" do
+      credentials = described_class.authenticate(request_with(build_assertion(claims: { "exp" => 10**100 })))
+
+      expect(credentials).to be_nil
+    end
+
+    # Infinity is not valid JSON, so such a payload already fails to decode —
+    # pinned here so a laxer JSON parser in a future jwt gem cannot let it
+    # reach the arithmetic on exp.
+    it "rejects an assertion whose payload smuggles exp: Infinity" do
+      payload = %({"iss":"#{client_id}","sub":"#{client_id}","aud":"#{issuer}","exp":Infinity,"jti":"x"})
+      segments = [{ "alg" => "RS256", "kid" => kid }.to_json, payload, "signature"]
+      assertion = segments.map { |segment| Base64.urlsafe_encode64(segment).delete("=") }.join(".")
+
+      expect { expect(described_class.authenticate(request_with(assertion))).to be_nil }
+        .not_to raise_error
+    end
+
+    it "accepts an assertion whose exp is a finite float NumericDate" do
+      credentials = described_class.authenticate(
+        request_with(build_assertion(claims: { "exp" => Time.now.to_f.floor + 300.5 })),
+      )
+
+      expect(credentials).not_to be_nil
+    end
+
+    context "when the host application globally disabled expiration checking" do
+      around do |example|
+        original = JWT.configuration.decode.verify_expiration
+        JWT.configuration.decode.verify_expiration = false
+        example.run
+      ensure
+        JWT.configuration.decode.verify_expiration = original
+      end
+
+      it "still rejects an expired assertion" do
+        credentials = described_class.authenticate(
+          request_with(build_assertion(claims: { "exp" => Time.now.to_i - 10 })),
+        )
+
+        expect(credentials).to be_nil
+      end
+    end
+
     it "rejects an assertion without an audience" do
       credentials = described_class.authenticate(request_with(build_assertion(claims: { "aud" => nil })))
 

--- a/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
+++ b/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
@@ -376,6 +376,16 @@ RSpec.describe Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt do
       expect(described_class.authenticate(request_with("not.a.jwt"))).to be_nil
     end
 
+    # URI.parse("https:foo") is a URI::HTTPS with a nil host: it passes the
+    # scheme check yet must fail authentication, not raise an ArgumentError
+    # out of the token endpoint when the nil host reaches the resolver.
+    it "rejects the assertion when the jwks_uri has no host" do
+      allow(application).to receive_messages(jwks: nil, jwks_uri: "https:foo")
+
+      expect { expect(described_class.authenticate(request_with(build_assertion))).to be_nil }
+        .not_to raise_error
+    end
+
     # A JWT payload is any JSON value, and the issuer is read before anything
     # is verified — so a payload that is not an object must fail
     # authentication rather than raise out of the token endpoint.

--- a/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
+++ b/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
@@ -1,0 +1,325 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "jwt"
+
+RSpec.describe Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt do
+  let(:client_id) { "registered-client-uid" }
+  let(:issuer) { "https://as.example.com" }
+  let(:rsa_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:kid) { "test-key" }
+  let(:jwk) { JWT::JWK.new(rsa_key.public_key, { kid: kid }) }
+  let(:jwks) { { "keys" => [jwk.export] } }
+  let(:application) { double("application", jwks: jwks, jwks_uri: nil) }
+  let(:client) { instance_double(Doorkeeper::OAuth::Client, application: application) }
+
+  before do
+    config_is_set(:issuer, issuer)
+    allow(Doorkeeper::OAuth::Client).to receive(:find).and_return(nil)
+    allow(Doorkeeper::OAuth::Client).to receive(:find).with(client_id).and_return(client)
+    described_class::ReplayGuard.instance.clear
+    # The jwks memo outlives a single example and is keyed by URL only, so a
+    # jwks_uri reused across examples would otherwise serve stale keys.
+    described_class::KeyResolver.jwks_cache.clear
+  end
+
+  def build_assertion(claims: {}, key: rsa_key, alg: "RS256", header_kid: kid)
+    claims = {
+      "iss" => client_id,
+      "sub" => client_id,
+      "aud" => issuer,
+      "exp" => Time.now.to_i + 300,
+      "jti" => SecureRandom.hex(8),
+    }.merge(claims).compact
+
+    headers = header_kid ? { "kid" => header_kid } : {}
+    JWT.encode(claims, key, alg, headers)
+  end
+
+  def request_with(assertion, extra_params = {})
+    mock_request(
+      request_parameters: {
+        client_assertion: assertion,
+        client_assertion_type: described_class::CLIENT_ASSERTION_TYPE,
+      }.merge(extra_params),
+    )
+  end
+
+  it "declares that it uses no shared secret" do
+    expect(described_class.uses_shared_secret?).to be false
+  end
+
+  describe ".matches_request?" do
+    it "matches a POST with an assertion and the jwt-bearer assertion type" do
+      expect(described_class.matches_request?(request_with(build_assertion))).to be true
+    end
+
+    it "does not match without a client_assertion" do
+      request = mock_request(request_parameters: { client_assertion_type: described_class::CLIENT_ASSERTION_TYPE })
+
+      expect(described_class.matches_request?(request)).to be false
+    end
+
+    it "does not match another assertion type" do
+      request = mock_request(
+        request_parameters: {
+          client_assertion: build_assertion,
+          client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:saml2-bearer",
+        },
+      )
+
+      expect(described_class.matches_request?(request)).to be false
+    end
+
+    it "does not match without an assertion type" do
+      request = mock_request(request_parameters: { client_assertion: build_assertion })
+
+      expect(described_class.matches_request?(request)).to be false
+    end
+
+    it "does not match GET requests" do
+      request = mock_request(
+        request_method: "GET",
+        request_parameters: {
+          client_assertion: build_assertion,
+          client_assertion_type: described_class::CLIENT_ASSERTION_TYPE,
+        },
+      )
+
+      expect(described_class.matches_request?(request)).to be false
+    end
+  end
+
+  describe ".authenticate" do
+    it "returns pre-authenticated credentials for a valid assertion" do
+      credentials = described_class.authenticate(request_with(build_assertion))
+
+      expect(credentials).to be_a(Doorkeeper::ClientAuthentication::VerifiedCredentials)
+      expect(credentials.uid).to eq(client_id)
+      expect(credentials.secret).to be_nil
+      expect(credentials).to be_pre_authenticated
+    end
+
+    # A missing dependency is the operator's problem, not the client's, so it
+    # must not travel back as an OAuth error: raising outside the
+    # Doorkeeper::Errors::DoorkeeperError hierarchy the endpoints translate into
+    # error responses is what keeps the message out of the token response body.
+    it "raises outside the error hierarchy rendered to clients without the jwt gem" do
+      allow(described_class).to receive(:require).with("jwt").and_raise(LoadError)
+
+      expect { described_class.authenticate(request_with(build_assertion)) }
+        .to raise_error(LoadError, /requires the 'jwt' gem/)
+    end
+
+    it "accepts the token endpoint URL as audience" do
+      credentials = described_class.authenticate(
+        request_with(build_assertion(claims: { "aud" => "#{issuer}/oauth/token" })),
+      )
+
+      expect(credentials).not_to be_nil
+    end
+
+    it "accepts the called endpoint's URL as audience" do
+      request = request_with(build_assertion)
+
+      credentials = described_class.authenticate(
+        request_with(build_assertion(claims: { "aud" => "#{issuer}#{request.path}" })),
+      )
+
+      expect(credentials).not_to be_nil
+    end
+
+    # The audience is what stops an assertion minted for another authorization
+    # server from being accepted here, so it must not be derived from a header
+    # the caller controls.
+    it "rejects an audience built from the request's Host header" do
+      request = request_with(build_assertion)
+      audience = request.base_url + request.path
+
+      credentials = described_class.authenticate(request_with(build_assertion(claims: { "aud" => audience })))
+
+      expect(credentials).to be_nil
+    end
+
+    context "when the server identifies itself nowhere" do
+      before { config_is_set(:issuer, nil) }
+
+      it "falls back to the request URL as audience" do
+        request = request_with(build_assertion)
+        audience = request.base_url + request.path
+
+        credentials = described_class.authenticate(request_with(build_assertion(claims: { "aud" => audience })))
+
+        expect(credentials).not_to be_nil
+      end
+    end
+
+    it "accepts a matching client_id parameter next to the assertion" do
+      credentials = described_class.authenticate(request_with(build_assertion, client_id: client_id))
+
+      expect(credentials).not_to be_nil
+    end
+
+    it "rejects a client_id parameter that contradicts the assertion issuer" do
+      credentials = described_class.authenticate(request_with(build_assertion, client_id: "someone-else"))
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects an assertion whose iss and sub differ" do
+      credentials = described_class.authenticate(request_with(build_assertion(claims: { "sub" => "someone-else" })))
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects an assertion for an unknown client" do
+      credentials = described_class.authenticate(request_with(build_assertion(claims: { "iss" => "ghost", "sub" => "ghost" })))
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects an assertion signed with the wrong key" do
+      other_key = OpenSSL::PKey::RSA.generate(2048)
+
+      credentials = described_class.authenticate(request_with(build_assertion(key: other_key)))
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects HMAC-signed assertions even when the jwks carries an oct key" do
+      allow(application).to receive(:jwks).and_return(
+        "keys" => [jwk.export, { "kty" => "oct", "kid" => "hmac", "k" => Base64.urlsafe_encode64("secret") }],
+      )
+
+      credentials = described_class.authenticate(
+        request_with(build_assertion(key: "secret", alg: "HS256", header_kid: "hmac")),
+      )
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects unsigned assertions" do
+      credentials = described_class.authenticate(
+        request_with(build_assertion(key: nil, alg: "none", header_kid: nil)),
+      )
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects an assertion referencing an unknown kid" do
+      credentials = described_class.authenticate(request_with(build_assertion(header_kid: "other-kid")))
+
+      expect(credentials).to be_nil
+    end
+
+    # The kid requirement is enforced by the jwt gem's JWKS key finder; this
+    # example pins it so a change of that gem default cannot silently void
+    # the documented requirement.
+    it "rejects a validly signed assertion without a kid header" do
+      expect(described_class.authenticate(request_with(build_assertion(header_kid: nil)))).to be_nil
+    end
+
+    it "rejects an expired assertion" do
+      credentials = described_class.authenticate(request_with(build_assertion(claims: { "exp" => Time.now.to_i - 10 })))
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects an assertion without exp" do
+      credentials = described_class.authenticate(request_with(build_assertion(claims: { "exp" => nil })))
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects an assertion that lives longer than MAX_LIFETIME" do
+      too_late = Time.now.to_i + described_class::MAX_LIFETIME + 60
+
+      credentials = described_class.authenticate(request_with(build_assertion(claims: { "exp" => too_late })))
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects an assertion without an audience" do
+      credentials = described_class.authenticate(request_with(build_assertion(claims: { "aud" => nil })))
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects an assertion for another audience" do
+      credentials = described_class.authenticate(request_with(build_assertion(claims: { "aud" => "https://other.example.com" })))
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects an assertion without a jti" do
+      credentials = described_class.authenticate(request_with(build_assertion(claims: { "jti" => nil })))
+
+      expect(credentials).to be_nil
+    end
+
+    it "rejects a replayed assertion" do
+      assertion = build_assertion
+
+      expect(described_class.authenticate(request_with(assertion))).not_to be_nil
+      expect(described_class.authenticate(request_with(assertion))).to be_nil
+    end
+
+    it "rejects garbage assertions" do
+      expect(described_class.authenticate(request_with("not.a.jwt"))).to be_nil
+    end
+
+    # A JWT payload is any JSON value, and the issuer is read before anything
+    # is verified — so a payload that is not an object must fail
+    # authentication rather than raise out of the token endpoint.
+    ["[1, 2]", "42", %("a string")].each do |payload|
+      it "rejects an assertion whose payload is #{payload}" do
+        segments = [{ "alg" => "RS256" }.to_json, payload, "signature"]
+        assertion = segments.map { |segment| Base64.urlsafe_encode64(segment).delete("=") }.join(".")
+
+        expect { expect(described_class.authenticate(request_with(assertion))).to be_nil }
+          .not_to raise_error
+      end
+    end
+
+    it "returns nil when the client publishes no keys" do
+      keyless = double("application")
+      allow(client).to receive(:application).and_return(keyless)
+
+      expect(described_class.authenticate(request_with(build_assertion))).to be_nil
+    end
+
+    it "reads a JSON string jwks attribute" do
+      allow(application).to receive(:jwks).and_return({ "keys" => [jwk.export] }.to_json)
+
+      expect(described_class.authenticate(request_with(build_assertion))).not_to be_nil
+    end
+
+    # A malformed JWK Set must fail authentication rather than raise a
+    # TypeError out of the token endpoint. The last four are keys that only
+    # blow up once they are parsed for real: a member that is not valid
+    # base64url, and an EC point that is not on its curve — the latter is
+    # parsed lazily when a kid is present, so it escapes through the decode
+    # path rather than through the JWK Set constructor.
+    [
+      ["an array", [{ "kty" => "RSA" }]],
+      ["a number", 42],
+      ["an object whose keys is not an array", { "keys" => { "kid" => "x" } }],
+      ["an object whose keys holds non-objects", { "keys" => ["not-a-key"] }],
+      ["an object whose keys mixes objects and non-objects", { "keys" => ["junk", { "kty" => "oct", "k" => "x" }] }],
+      ["a key with a malformed base64url member", { "keys" => [{ "kty" => "RSA", "n" => "!!!", "e" => "AQAB" }] }],
+      ["a kid-bearing key with a malformed base64url member",
+       { "keys" => [{ "kty" => "RSA", "kid" => "test-key", "n" => "!!!", "e" => "AQAB" }] },],
+      ["an EC point that is not on the curve",
+       { "keys" => [{ "kty" => "EC", "crv" => "P-256", "x" => "AA", "y" => "AA" }] },],
+      ["a kid-bearing EC point that is not on the curve",
+       { "keys" => [{ "kty" => "EC", "crv" => "P-256", "kid" => "test-key", "x" => "AA", "y" => "AA" }] },],
+    ].each do |description, value|
+      it "returns nil when the application's jwks is #{description}" do
+        allow(application).to receive(:jwks).and_return(value)
+
+        expect { expect(described_class.authenticate(request_with(build_assertion))).to be_nil }
+          .not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/lib/oauth/refresh_token_request_spec.rb
+++ b/spec/lib/oauth/refresh_token_request_spec.rb
@@ -113,6 +113,17 @@ RSpec.describe Doorkeeper::OAuth::RefreshTokenRequest do
     expect(request.error).to eq(Doorkeeper::Errors::InvalidGrant)
   end
 
+  context "with credentials already authenticated by their client authentication method" do
+    let(:credentials) { Doorkeeper::ClientAuthentication::VerifiedCredentials.new(client.uid) }
+
+    it "resolves the client by uid alone" do
+      expect(client).to be_confidential
+
+      expect { request.authorize }.to change { client.reload.access_tokens.count }.by(1)
+      expect(request.error).to be_nil
+    end
+  end
+
   it "rejects revoked tokens" do
     refresh_token.revoke
     request.validate

--- a/spec/requests/endpoints/metadata_spec.rb
+++ b/spec/requests/endpoints/metadata_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe "Authorization Server Metadata endpoint" do
 
   context "with an unregistered client_authentication method configured" do
     before do
-      config_is_set(:client_authentication, %i[client_secret_basic private_key_jwt])
+      config_is_set(:client_authentication, %i[client_secret_basic tls_client_auth])
     end
 
     it "does not advertise the method the resolver ignores" do
@@ -304,16 +304,16 @@ RSpec.describe "Authorization Server Metadata endpoint" do
   context "with a custom client_authentication method registered by an extension" do
     before do
       Doorkeeper::ClientAuthentication.register(
-        :private_key_jwt,
+        :tls_client_auth,
         double(matches_request?: false, authenticate: nil),
       )
-      config_is_set(:client_authentication, %i[client_secret_basic private_key_jwt])
+      config_is_set(:client_authentication, %i[client_secret_basic tls_client_auth])
     end
 
     after do
       # The example only adds this one method, so removing it restores the
       # registry in-place without replacing the Hash other code may hold.
-      Doorkeeper::ClientAuthentication::Registry.registered_methods.delete(:private_key_jwt)
+      Doorkeeper::ClientAuthentication::Registry.registered_methods.delete(:tls_client_auth)
     end
 
     it "advertises the custom method alongside the built-ins" do
@@ -321,7 +321,7 @@ RSpec.describe "Authorization Server Metadata endpoint" do
 
       response_status_should_be(200)
       expect(json_response["token_endpoint_auth_methods_supported"])
-        .to eq(%w[client_secret_basic private_key_jwt])
+        .to eq(%w[client_secret_basic tls_client_auth])
     end
   end
 

--- a/spec/requests/flows/private_key_jwt_spec.rb
+++ b/spec/requests/flows/private_key_jwt_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "jwt"
+
+feature "private_key_jwt client authentication" do
+  let(:redirect_uri) { "https://app.example.com/callback" }
+  let(:rsa_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:kid) { "sig-key" }
+  let(:jwk) { JWT::JWK.new(rsa_key.public_key, { kid: kid }) }
+  let(:jwks) { { "keys" => [jwk.export] } }
+  let(:token_endpoint_audience) { "http://www.example.com/oauth/token" }
+
+  background do
+    config_is_set(:client_authentication, %i[client_secret_basic client_secret_post none private_key_jwt])
+    default_scopes_exist :default
+    config_is_set(:authenticate_resource_owner) { User.first || redirect_to("/sign_in") }
+    create_resource_owner
+    sign_in
+
+    client_exists(
+      name: "Confidential Example App",
+      redirect_uri: redirect_uri,
+      confidential: true,
+      jwks: jwks.to_json,
+    )
+
+    Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::KeyResolver.jwks_cache.clear
+    Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::ReplayGuard.instance.clear
+    allow(Resolv).to receive(:getaddresses).and_return(["93.184.216.34"])
+  end
+
+  def client_assertion(key: rsa_key, header_kid: kid, claims: {})
+    JWT.encode(
+      {
+        "iss" => @client.uid,
+        "sub" => @client.uid,
+        "aud" => token_endpoint_audience,
+        "exp" => Time.now.to_i + 60,
+        "jti" => SecureRandom.hex(8),
+      }.merge(claims),
+      key,
+      "RS256",
+      { "kid" => header_kid },
+    )
+  end
+
+  # When a matching token already exists (e.g. a second run within one
+  # scenario) the authorization endpoint skips the consent screen and
+  # redirects straight back with a fresh code.
+  def authorize_and_return_code
+    visit authorization_endpoint_url(client_id: @client.uid, redirect_uri: redirect_uri)
+    click_on "Authorize" if current_params["code"].blank?
+    current_params["code"]
+  end
+
+  def post_token(code, extra_params = {})
+    page.driver.post token_endpoint_url, {
+      grant_type: "authorization_code",
+      code: code,
+      redirect_uri: redirect_uri,
+      client_id: @client.uid,
+    }.merge(extra_params)
+  end
+
+  scenario "a confidential client authenticates the token request with a signed assertion" do
+    code = authorize_and_return_code
+
+    post_token(
+      code,
+      client_assertion: client_assertion,
+      client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+    )
+
+    expect(page.driver.response.status).to eq(200)
+    expect(json_response).to include("access_token" => Doorkeeper::AccessToken.first.token)
+    expect(Doorkeeper::AccessToken.first.application.uid).to eq(@client.uid)
+  end
+
+  context "when the refresh token grant is enabled" do
+    background do
+      config_is_set(:refresh_token_enabled, true)
+      config_is_set(:grant_flows, %w[authorization_code refresh_token])
+    end
+
+    scenario "a confidential client refreshes with a signed assertion" do
+      post_token(
+        authorize_and_return_code,
+        client_assertion: client_assertion,
+        client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+      )
+      expect(page.driver.response.status).to eq(200)
+      refresh_token = json_response["refresh_token"]
+      expect(refresh_token).to be_present
+
+      page.driver.post token_endpoint_url, {
+        grant_type: "refresh_token",
+        refresh_token: refresh_token,
+        client_id: @client.uid,
+        client_assertion: client_assertion,
+        client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+      }
+
+      expect(page.driver.response.status).to eq(200)
+      expect(json_response).to have_key("access_token")
+      expect(json_response["refresh_token"]).not_to eq(refresh_token)
+    end
+  end
+
+  scenario "keys can also be fetched from the application's jwks_uri" do
+    jwks_uri = "https://client.example.com/jwks.json"
+    @client.update!(jwks: nil, jwks_uri: jwks_uri)
+    stub_request(:get, jwks_uri).to_return(status: 200, body: jwks.to_json)
+
+    code = authorize_and_return_code
+    post_token(
+      code,
+      client_assertion: client_assertion,
+      client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+    )
+
+    expect(page.driver.response.status).to eq(200)
+    expect(json_response).to have_key("access_token")
+  end
+
+  # The jwks_uri names a host the client controls, so its answers get the
+  # same treatment as any other client-published input: a rejected client,
+  # never an exception out of the token endpoint.
+  scenario "a jwks_uri host that does not speak HTTP is rejected, not raised" do
+    jwks_uri = "https://client.example.com/jwks.json"
+    @client.update!(jwks: nil, jwks_uri: jwks_uri)
+    stub_request(:get, jwks_uri).to_raise(Net::HTTPBadResponse.new('wrong status line: "NOT-HTTP"'))
+
+    code = authorize_and_return_code
+    post_token(
+      code,
+      client_assertion: client_assertion,
+      client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+    )
+
+    expect(page.driver.response.status).to eq(401)
+    expect(json_response["error"]).to eq("invalid_client")
+  end
+
+  scenario "a confidential client cannot exchange the code without authentication" do
+    code = authorize_and_return_code
+
+    post_token(code)
+
+    expect(page.driver.response.status).to eq(401)
+    expect(json_response["error"]).to eq("invalid_client")
+  end
+
+  scenario "an assertion signed with a key outside the published jwks is rejected" do
+    code = authorize_and_return_code
+
+    post_token(
+      code,
+      client_assertion: client_assertion(key: OpenSSL::PKey::RSA.generate(2048)),
+      client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+    )
+
+    expect(page.driver.response.status).to eq(401)
+    expect(json_response["error"]).to eq("invalid_client")
+  end
+
+  scenario "a replayed assertion is rejected" do
+    assertion = client_assertion
+
+    first_code = authorize_and_return_code
+    post_token(
+      first_code,
+      client_assertion: assertion,
+      client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+    )
+    expect(page.driver.response.status).to eq(200)
+
+    second_code = authorize_and_return_code
+    post_token(
+      second_code,
+      client_assertion: assertion,
+      client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+    )
+
+    expect(page.driver.response.status).to eq(401)
+    expect(json_response["error"]).to eq("invalid_client")
+  end
+
+  scenario "private_key_jwt is advertised in the authorization server metadata" do
+    page.driver.get "/.well-known/oauth-authorization-server"
+
+    expect(json_response["token_endpoint_auth_methods_supported"]).to include("private_key_jwt")
+  end
+
+  # OIDC Core §9 says the audience SHOULD be the token endpoint URL, so a
+  # compliant client sends that value when authenticating at the revocation
+  # and introspection endpoints too.
+  scenario "the token endpoint audience is accepted at the revocation endpoint" do
+    code = authorize_and_return_code
+    post_token(
+      code,
+      client_assertion: client_assertion,
+      client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+    )
+    expect(page.driver.response.status).to eq(200)
+
+    token = Doorkeeper::AccessToken.last
+    page.driver.post "/oauth/revoke", {
+      token: token.token,
+      client_id: @client.uid,
+      client_assertion: client_assertion,
+      client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+    }
+
+    expect(page.driver.response.status).to eq(200)
+    expect(token.reload).to be_revoked
+  end
+
+  scenario "the endpoint's own URL is still accepted as audience" do
+    code = authorize_and_return_code
+    post_token(
+      code,
+      client_assertion: client_assertion,
+      client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+    )
+    expect(page.driver.response.status).to eq(200)
+
+    token = Doorkeeper::AccessToken.last
+    revocation_audience = "http://www.example.com/oauth/revoke"
+    page.driver.post "/oauth/revoke", {
+      token: token.token,
+      client_id: @client.uid,
+      client_assertion: client_assertion(claims: { "aud" => revocation_audience }),
+      client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+    }
+
+    expect(page.driver.response.status).to eq(200)
+    expect(token.reload).to be_revoked
+  end
+
+  scenario "an assertion for an unrelated audience is rejected" do
+    code = authorize_and_return_code
+
+    post_token(
+      code,
+      client_assertion: client_assertion(claims: { "aud" => "https://someone-else.example.com/token" }),
+      client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+    )
+
+    expect(page.driver.response.status).to eq(401)
+    expect(json_response["error"]).to eq("invalid_client")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,10 @@ require "rspec/rails"
 require "capybara/rspec"
 require "database_cleaner"
 require "generator_spec/test_case"
+require "webmock/rspec"
+
+# Coveralls posts its results over HTTP from an at_exit hook in CI.
+WebMock.disable_net_connect!(allow: "coveralls.io")
 
 # Load JRuby SQLite3 if in that platform
 if defined? JRUBY_VERSION


### PR DESCRIPTION
Part of #1875 — the first of two stacked PRs split out of #1880, as discussed there (`private_key_jwt` lands first, Client ID Metadata Documents stack on top).

Registers a `private_key_jwt` method (RFC 7523 §2.2 / OIDC Core §9) in the client authentication registry (#1840). It is **not** part of `DEFAULT_METHODS` — servers opt in through the `client_authentication` config option — and the `jwt` gem (>= 2.7) is required only when an assertion is actually verified, so it stays an optional dependency.

## What's in here

- **Assertion verification**, deliberately strict: asymmetric algorithms only (HMAC / `none` can never verify, symmetric `oct` JWKs are dropped from the key set), `iss` = `sub` = `client_id` with an optional `client_id` parameter cross-check (RFC 7521 §4.2), `aud` = configured issuer or token endpoint URL (derived from the server's own configuration — only a server that configures neither an `issuer` nor `default_url_options` falls back to the request, matching `MetadataResponse`), bounded `exp`, single-use `jti` (process-local replay guard). Malformed input — a JWT payload that isn't an object, a JWK member that isn't valid base64url, an EC point off its curve — fails authentication instead of raising out of the token endpoint.
- **Key resolution** from `jwks` / `jwks_uri` attributes you define on your Application model (Doorkeeper adds no columns itself; the dummy app defines them as the reference setup).
- **`Doorkeeper::HttpFetcher`** — an SSRF-hardened HTTP client used to fetch `jwks_uri`: HTTPS only, no redirects, 200 OK only, RFC 6890 special-use addresses refused with the connection pinned to the vetted IP (DNS-rebinding-proof), 5 KB response cap and a wall-clock deadline on the exchange. Results are memoized in **`Doorkeeper::DocumentCache`** (small fixed-TTL memo). Both are top-level classes because the stacked CIMD PR fetches metadata documents through the same client.
- **A `uses_shared_secret?` registry contract**: strategies declare whether they authenticate with a shared symmetric secret (`client_secret_basic`/`_post` and legacy callables: `true`; `none` / `private_key_jwt`: `false`), with a conservative name-based fallback for strategies that don't declare it. Callers that must refuse secret-based methods can ask the registry instead of hard-coding method names.
- The `none` method no longer matches a request carrying a `client_assertion`, so an assertion can never be downgraded to an unauthenticated public client; the refresh token grant now resolves its client through `OAuth::Client` like every other grant, which is what lets secret-less credentials work there.
- A dedicated CI job (`gemfiles/rails_8_0_jwt_2.gemfile`) exercises the jwt gem's declared lower bound, which the regular matrix never resolves.

>[!NOTE]
> 
> - This PR is intended to double as the worked example for #1894 (documenting how to add a custom client authentication method): `PrivateKeyJwt` shows the full surface — `matches_request?`, `authenticate`, `uses_shared_secret?`, registry registration and the opt-in config.
> - Full suite green (1771 examples). Every behavior above has a spec, including the negative space (oct-key downgrade attempts, replayed assertions, Host-header audiences, hostile JWK sets, transport failures at the `jwks_uri`).
> 
> The second PR in the stack adds Client ID Metadata Documents on top: URL `client_id`s, document validation and materialization, and document-based key resolution wired into this method's `KeyResolver`.