### PR TITLE
Document custom client authentication methods in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ User-visible changes worth mentioning.
 - [#1888] Document custom grant flow registration (`Doorkeeper::GrantFlow.register`) in the README with a SAML 2.0 bearer assertion (RFC 7522) walkthrough, and pin URN-shaped custom grant types with an end-to-end request spec. Docs/test-only change, closes [#764].
 - [#1890] [test] Pin that the authorization endpoint answers `invalid_redirect_uri` for a client registered without a redirect URI (`allow_blank_redirect_uri`), whether or not the request supplies one — the behavior required by RFC 6749 §3.1.2.3. Test-only change, closes [#1682].
 - [#1898] Fix: with `reuse_access_token` enabled, the `client_credentials` grant no longer reuses a token whose `resource` differs from the one requested (RFC 8707), so the audience restriction the client asked for is always applied. Follow-up to [#1886].
+- [#1899] Document the client authentication methods registry (`Doorkeeper::ClientAuthentication.register`) in the README with a walkthrough for registering a custom method, and pin it with an end-to-end request spec. Docs/test-only change, closes [#1894].
 - Please add here
 
 ## 6.0.0.beta1

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Supported features:
 - [Extensions](#extensions)
 - [Resource Indicators](#resource-indicators)
 - [Custom Grant Flows](#custom-grant-flows)
+- [Custom Client Authentication Methods](#custom-client-authentication-methods)
 - [Example Applications](#example-applications)
 - [Sponsors](#sponsors)
 - [Development](#development)
@@ -259,6 +260,55 @@ end
 The `client_supports_grant_flow` validation keeps the custom grant subject to the `allow_grant_flow_for_client` configuration option (per-client grant restrictions), just like the built-in flows.
 
 Flows can also handle custom `response_type` values on the authorization endpoint via the `response_type_matches` / `response_type_strategy` options — see the built-in registrations in [`lib/doorkeeper/grant_flow.rb`](lib/doorkeeper/grant_flow.rb) for reference. An extension can also group several flows under one configuration name with `Doorkeeper::GrantFlow.register_alias` (e.g. the OpenID Connect extension registers `implicit_oidc` to expand to multiple response types).
+
+## Custom Client Authentication Methods
+
+Doorkeeper authenticates clients (RFC 6749 §2.3) through a registry of named methods. `client_secret_basic`, `client_secret_post` and `none` are built in, and an application or extension can register additional ones — for instance to keep accepting credentials that a partner integration sends in its own headers.
+
+A method is any object that responds to `matches_request?` and `authenticate`. Register it before `Doorkeeper.configure` and enable it by listing its registered name in `client_authentication`:
+
+```ruby
+# config/initializers/doorkeeper.rb
+Doorkeeper::ClientAuthentication.register(
+  :partner_headers,
+  PartnerHeaders::Authentication,
+)
+
+Doorkeeper.configure do
+  client_authentication %i[client_secret_basic client_secret_post partner_headers none]
+  # ...
+end
+```
+
+The order of `client_authentication` is the order the methods are tried in: the first one whose `matches_request?` returns true handles the request.
+
+`matches_request?` decides whether the request carries this method's credentials, and `authenticate` extracts them into a `Doorkeeper::ClientAuthentication::Credentials` pair (or `nil`):
+
+```ruby
+module PartnerHeaders
+  class Authentication
+    def self.matches_request?(request)
+      request.get_header("HTTP_X_CLIENT_ID").present? &&
+        request.get_header("HTTP_X_CLIENT_SECRET").present?
+    end
+
+    def self.authenticate(request)
+      Doorkeeper::ClientAuthentication::Credentials.new(
+        request.get_header("HTTP_X_CLIENT_ID"),
+        request.get_header("HTTP_X_CLIENT_SECRET"),
+      )
+    end
+  end
+end
+```
+
+Two things are worth keeping in mind when writing one.
+
+**Keep `matches_request?` as narrow as possible.** RFC 6749 §2.3 forbids a client from using more than one authentication method in a single request, and Doorkeeper enforces that across the whole registry rather than only the enabled methods. A method that matches too broadly therefore collides with a built-in one and the request is answered with `invalid_request`.
+
+**The returned credentials are resolved with `by_uid_and_secret`.** A blank secret resolves only a public (non-confidential) client — that is what the built-in `none` method relies on — while a confidential client is resolved only when the secret matches the registered one. A method that establishes the client's identity by some other proof, such as a client certificate or a signed assertion, therefore still has to produce the registered secret for a confidential client.
+
+Enabled methods are advertised in the authorization server metadata, so a registered method appears in `token_endpoint_auth_methods_supported` at `/.well-known/oauth-authorization-server` once `client_authentication` lists it.
 
 ## Example Applications
 

--- a/spec/requests/flows/custom_client_authentication_spec.rb
+++ b/spec/requests/flows/custom_client_authentication_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# End-to-end coverage for the client authentication registry [#1840],
+# mirroring the README "Custom Client Authentication Methods" example.
+
+require "spec_helper"
+
+module PartnerHeadersExample
+  # Reads the client credentials a partner integration sends in its own
+  # headers instead of the transports RFC 6749 §2.3 defines.
+  class Authentication
+    def self.matches_request?(request)
+      request.get_header("HTTP_X_CLIENT_ID").present? &&
+        request.get_header("HTTP_X_CLIENT_SECRET").present?
+    end
+
+    def self.authenticate(request)
+      Doorkeeper::ClientAuthentication::Credentials.new(
+        request.get_header("HTTP_X_CLIENT_ID"),
+        request.get_header("HTTP_X_CLIENT_SECRET"),
+      )
+    end
+  end
+end
+
+RSpec.describe "Custom client authentication method (README example)" do
+  let(:client) { FactoryBot.create :application }
+
+  before do
+    Doorkeeper::ClientAuthentication.register(
+      :partner_headers,
+      PartnerHeadersExample::Authentication,
+    )
+
+    Doorkeeper.configure do
+      orm DOORKEEPER_ORM
+      grant_flows %w[client_credentials]
+      client_authentication %i[client_secret_basic client_secret_post partner_headers none]
+    end
+  end
+
+  after do
+    Doorkeeper::ClientAuthentication.registered_methods.delete(:partner_headers)
+  end
+
+  def partner_headers(uid, secret)
+    { "HTTP_X_CLIENT_ID" => uid, "HTTP_X_CLIENT_SECRET" => secret }
+  end
+
+  def basic_auth(uid, secret)
+    credentials = ActionController::HttpAuthentication::Basic.encode_credentials(uid, secret)
+    { "HTTP_AUTHORIZATION" => credentials }
+  end
+
+  it "authenticates a client whose credentials arrive in the custom headers" do
+    post token_endpoint_url,
+         params: { grant_type: "client_credentials" },
+         headers: partner_headers(client.uid, client.secret)
+
+    expect(response.status).to eq(200)
+    expect(json_response).to include("access_token" => Doorkeeper::AccessToken.first.token)
+  end
+
+  it "rejects a wrong secret with invalid_client" do
+    post token_endpoint_url,
+         params: { grant_type: "client_credentials" },
+         headers: partner_headers(client.uid, "wrong-secret")
+
+    expect(response.status).to eq(401)
+    expect(json_response).to include("error" => "invalid_client")
+  end
+
+  it "leaves the built-in methods working" do
+    post token_endpoint_url,
+         params: { grant_type: "client_credentials" },
+         headers: basic_auth(client.uid, client.secret)
+
+    expect(response.status).to eq(200)
+  end
+
+  # RFC 6749 §2.3: a client must not use more than one authentication method in
+  # a single request. The check runs across the whole registry, so it fires for
+  # a method that is registered but not enabled too — `client_secret_basic` is
+  # deliberately left out of `client_authentication` here, which is what makes
+  # this example fail if the check were ever narrowed to the enabled methods.
+  it "rejects a request that also carries a registered but disabled method's credentials" do
+    Doorkeeper.configure do
+      orm DOORKEEPER_ORM
+      grant_flows %w[client_credentials]
+      client_authentication %i[partner_headers none]
+    end
+
+    post token_endpoint_url,
+         params: { grant_type: "client_credentials" },
+         headers: partner_headers(client.uid, client.secret)
+           .merge(basic_auth(client.uid, client.secret))
+
+    expect(response.status).to eq(400)
+    expect(json_response).to include("error" => "invalid_request")
+  end
+
+  it "advertises the registered method in the server metadata" do
+    get "/.well-known/oauth-authorization-server"
+
+    expect(json_response["token_endpoint_auth_methods_supported"]).to include("partner_headers")
+  end
+end


### PR DESCRIPTION
Closes #1894.

Same shape as #1888: a README section plus an end-to-end request spec that mirrors the example, so the documented walkthrough is actually exercised rather than just written down.

The example registers a method that reads credentials a partner integration sends in its own headers. I deliberately kept it independent of #1896, so it reads as a "registering a custom method" walkthrough on its own and doesn't need that PR to land first.

Alongside the `matches_request?` / `authenticate` contract and the fact that `client_authentication` is ordered, the section calls out two things that seemed easy to get wrong while writing it:

- `matches_request?` is evaluated across the **whole registry** for the RFC 6749 §2.3 "no more than one method" rule, not just the enabled methods — so a matcher that is too broad collides with a built-in method and the request comes back `invalid_request`.
- The returned credentials are resolved with `by_uid_and_secret`, so a blank secret only ever resolves a public client. A method that proves identity some other way still has to produce the registered secret for a confidential client. (Verified: confidential + blank secret resolves to `nil`.)

The spec covers the happy path, a wrong secret, the built-in methods still working alongside it, the §2.3 collision, and the method showing up in `token_endpoint_auth_methods_supported`.

Happy to swap the example for something else if you'd prefer a different one — a standard method like mTLS felt misleading given the `by_uid_and_secret` constraint above.