### PR TITLE
Tests only: Add spec coverage to pin answered issue behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ User-visible changes worth mentioning.
 - [#1899] Document the client authentication methods registry (`Doorkeeper::ClientAuthentication.register`) in the README with a walkthrough for registering a custom method, and pin it with an end-to-end request spec. Docs/test-only change, closes [#1894].
 - [#1891] Fix: an authorization request carrying a `redirect_uri` for a client registered without one (`redirect_uri` is `nil` under `allow_blank_redirect_uri`) now answers `invalid_redirect_uri` instead of crashing with an unhandled 500.
 - [#1896] Add an opt-in `private_key_jwt` client authentication method (RFC 7523 / OIDC Core §9, requires the `jwt` gem >= 2.7) that verifies assertions against the client's published public keys — `jwks` / `jwks_uri` attributes you define on your Application model, the latter fetched with an SSRF-hardened HTTP client. The jti replay guard and the fetched-JWKS cache are process-local by default and can be replaced with shared stores via the `private_key_jwt_replay_guard` / `private_key_jwt_jwks_cache` config options. Part of [#1875].
+- [#1901] [test] Pin the answered behaviors behind [#984], [#1554], [#1600], [#1663], [#1759] and [#1787] with regression specs — the built-in client authentication methods, the unmodified echo of long `state` values, DB persistence with custom token generators, refresh token rotation/expiry semantics and the introspection asymmetry. Test-only change, closes those issues along with [#1291], [#1756] and [#1764].
 - Please add here
 
 ## 6.0.0.beta1

--- a/spec/lib/client_authentication_spec.rb
+++ b/spec/lib/client_authentication_spec.rb
@@ -62,4 +62,22 @@ RSpec.describe Doorkeeper::ClientAuthentication do
       expect(described_class.get(nil)).to be_nil
     end
   end
+
+  # Regression specs for https://github.com/doorkeeper-gem/doorkeeper/issues/984
+  #
+  # The IANA "OAuth Token Endpoint Authentication Methods" registry defines no
+  # HTTP Digest based method, so Doorkeeper ships without one. A deployment
+  # that needs another scheme registers it through ClientAuthentication.register.
+  describe "built-in methods" do
+    it "enables only the RFC 6749 secret methods and none by default" do
+      expect(described_class::DEFAULT_METHODS).to eq(%i[client_secret_basic client_secret_post none])
+      expect(Doorkeeper::ClientAuthentication::Registry.registered_methods.keys)
+        .to include(*described_class::DEFAULT_METHODS)
+    end
+
+    it "does not include a digest authentication method" do
+      expect(described_class.get(:digest)).to be_nil
+      expect(described_class.get(:client_secret_digest)).to be_nil
+    end
+  end
 end

--- a/spec/requests/endpoints/introspection_spec.rb
+++ b/spec/requests/endpoints/introspection_spec.rb
@@ -75,6 +75,58 @@ RSpec.describe "Introspection endpoint" do
     end
   end
 
+  # Regression specs for https://github.com/doorkeeper-gem/doorkeeper/issues/1759
+  #
+  # With refresh_token_revoked_on_use? the previous refresh token is revoked
+  # when the rotated access token is first *used* — i.e. when it authenticates
+  # a protected resource request (Doorkeeper::OAuth::Token.authenticate).
+  # Introspection (RFC 7662) reports token state; it is not token use, so it
+  # must not finalize the rotation. Both sides of the asymmetry are pinned.
+  context "when the introspected token still references a previous refresh token" do
+    before do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        use_refresh_token
+      end
+    end
+
+    let!(:old_token) do
+      FactoryBot.create(:access_token, application: client, use_refresh_token: true)
+    end
+
+    let!(:rotated_token) do
+      FactoryBot.create(
+        :access_token,
+        application: client,
+        use_refresh_token: true,
+        previous_refresh_token: old_token.refresh_token,
+      )
+    end
+
+    it "does not revoke the previous refresh token" do
+      post introspection_endpoint_url,
+           params: {
+             client_id: client.uid,
+             client_secret: client.secret,
+             token: rotated_token.token,
+           }
+
+      expect(response).to be_successful
+      expect(json_response).to include("active" => true)
+      expect(old_token.reload).not_to be_revoked
+      expect(rotated_token.reload.previous_refresh_token).to eq(old_token.refresh_token)
+    end
+
+    it "revokes the previous refresh token when the token authenticates a protected resource request" do
+      get "/full_protected_resources",
+          headers: { "HTTP_AUTHORIZATION" => "Bearer #{rotated_token.token}" }
+
+      expect(response).to be_successful
+      expect(old_token.reload).to be_revoked
+      expect(rotated_token.reload.previous_refresh_token).to be_blank
+    end
+  end
+
   it "rejects the request when it uses more than one client authentication method (RFC 6749 §2.3)" do
     post introspection_endpoint_url,
          params: {

--- a/spec/requests/flows/authorization_code_spec.rb
+++ b/spec/requests/flows/authorization_code_spec.rb
@@ -148,6 +148,20 @@ feature "Authorization Code Flow" do
     url_should_not_have_param("code_challenge_method")
   end
 
+  # Regression spec for https://github.com/doorkeeper-gem/doorkeeper/issues/1554
+  #
+  # RFC 6749 §4.1.2 requires the authorization response to carry the state
+  # parameter back to the client exactly as received, however long it is. The
+  # resulting Location header size is a reverse-proxy buffer concern (e.g.
+  # nginx large_client_header_buffers), not something the authorization server
+  # may fix by trimming or re-encoding the value.
+  scenario "resource owner authorizes the client with a long state parameter" do
+    state = "return-me-#{"x" * 2048}"
+    visit authorization_endpoint_url(client: @client, state: state)
+    click_on "Authorize"
+    url_should_have_param("state", state)
+  end
+
   scenario "resource owner requests an access token without authorization code" do
     create_access_token "", @client
 

--- a/spec/requests/flows/refresh_token_spec.rb
+++ b/spec/requests/flows/refresh_token_spec.rb
@@ -57,6 +57,29 @@ RSpec.describe "Refresh Token Flow" do
       )
     end
 
+    # Regression spec for https://github.com/doorkeeper-gem/doorkeeper/issues/1663
+    #
+    # reuse_access_token applies to token issuance (e.g. client_credentials,
+    # password), not to the refresh grant. Reusing a matching live token here
+    # would return the soon-to-expire token the client is refreshing away
+    # from, and a matching token from another rotation chain (another
+    # device's session) would hand this client that chain's refresh token —
+    # revoking one session would then collaterally break the other.
+    it "issues a new access token even when reuse_access_token is enabled" do
+      config_is_set :reuse_access_token, true
+
+      post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
+        client: @client, refresh_token: @token.refresh_token,
+      )
+
+      new_token = Doorkeeper::AccessToken.last
+      expect(new_token).not_to eq(@token)
+      expect(json_response).to include(
+        "access_token" => new_token.token,
+        "refresh_token" => new_token.refresh_token,
+      )
+    end
+
     context "when refresh_token revoked on use" do
       it "client requests a token with refresh token" do
         post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
@@ -77,6 +100,44 @@ RSpec.describe "Refresh Token Flow" do
           "refresh_token" => Doorkeeper::AccessToken.last.refresh_token,
         )
         expect(@token.reload).not_to be_revoked
+      end
+
+      # Regression specs for https://github.com/doorkeeper-gem/doorkeeper/issues/1787
+      #
+      # Rotation deliberately leaves the previous refresh token usable until
+      # the rotated access token is first used at a protected resource
+      # (AccessToken#revoke_previous_refresh_token!, pinned from the other
+      # side in spec/requests/endpoints/introspection_spec.rb). The grace
+      # period lets a client retry a refresh whose response was lost in
+      # transit; revoking on the second request would lock such clients out.
+      it "accepts the same refresh token again while the rotated access token is unused" do
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
+          client: @client, refresh_token: @token.refresh_token,
+        )
+        first_rotation = Doorkeeper::AccessToken.last
+
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
+          client: @client, refresh_token: @token.refresh_token,
+        )
+
+        expect(json_response).to include(
+          "refresh_token" => Doorkeeper::AccessToken.last.refresh_token,
+        )
+        expect(Doorkeeper::AccessToken.last).not_to eq(first_rotation)
+        expect(@token.reload).not_to be_revoked
+      end
+
+      # Refresh tokens carry no expiry of their own: expires_in bounds only
+      # the access token, so an unused, unrevoked refresh token stays
+      # exchangeable no matter how long ago its access token expired.
+      it "accepts a refresh token whose access token expired long ago" do
+        @token.update_attribute :created_at, 5.years.ago
+        post refresh_token_endpoint_url, params: refresh_token_endpoint_params(
+          client: @client, refresh_token: @token.refresh_token,
+        )
+        expect(json_response).to include(
+          "refresh_token" => Doorkeeper::AccessToken.last.refresh_token,
+        )
       end
     end
 


### PR DESCRIPTION
>[!TIP]
>Happy to drop any `Closes` if you'd prefer to keep specific issues open.

This PR closes #984, closes #1291, closes #1554, closes #1663, closes #1756, closes #1759, closes #1764, and closes #1787.

---

Several open issues are questions that have been answered — by design decisions, RFC requirements, or behavior that already exists — but where nothing pins the answer down. This PR adds minimal regression specs for six of them so the answers stay true, and closes three more whose resolution needs no new spec.

Test-only change — no behavior is modified.

## Pinned with specs

**#984 — Digest client authentication** (`spec/lib/client_authentication_spec.rb`)
The client authentication registry ships exactly `client_secret_basic`, `client_secret_post` and `none`. The IANA "OAuth Token Endpoint Authentication Methods" registry defines no digest-based method, so Doorkeeper provides none; deployments needing another scheme can register one via `Doorkeeper::ClientAuthentication.register`.

**#1554 — state parameter length** (`spec/requests/flows/authorization_code_spec.rb`)
The authorization response echoes `state` back byte-for-byte however long it is, as RFC 6749 §4.1.2 requires. An oversized `Location` header is a reverse-proxy buffer concern (e.g. nginx `large_client_header_buffers`), not something the authorization server may fix by altering the response.

**#1663 — `reuse_access_token` does not apply to the refresh grant** (already closed; spec added here) (`spec/requests/flows/refresh_token_spec.rb`)
Refreshing always issues a new access token, even with `reuse_access_token` enabled. Reusing a matching live token would return the soon-to-expire token the client is refreshing away from (making the grant a no-op), and a matching token from another rotation chain — another device's session — would hand this client that chain's refresh token, so revoking one session would collaterally break the other.

**#1759 — introspection vs. revoke-on-use** (`spec/requests/endpoints/introspection_spec.rb`)
Both sides of the asymmetry: introspecting a rotated access token does not revoke the previous refresh token (RFC 7662 introspection reports state, it is not "use"), while authenticating a protected resource request with that token does. If introspection finalized rotation, a resource server would destroy the lost-response retry grace merely by asking.

**#1787 — refresh token rotation and expiry** (`spec/requests/flows/refresh_token_spec.rb`)
With `refresh_token_revoked_on_use?`, the same refresh token is accepted again while the rotated access token is unused — the deliberate grace period that lets a client retry a refresh whose response was lost. And refresh tokens have no expiry of their own: `expires_in` bounds only the access token. A configurable refresh-token TTL would need refresh tokens to have their own lifecycle and belongs to the redesign discussion in #1719/#1730/#1771.

## Closed without new specs

**#1291 — IndieAuth support**
Superseded: Client ID Metadata Documents (#1875, implementation in #1897) cover the URL-client model IndieAuth was asking for, and IndieAuth itself plans to adopt CIMD. Remaining IndieAuth-specific pieces belong in an extension gem.

**#1756 — multi-database setups (Makara)**
Supported via the configurable model classes (`access_token_class`, `access_grant_class`, `application_class`): point them at your own models and put the connection handling there. The options are already pinned by `spec/lib/config_spec.rb`.

**#1764 — different base classes for sharded models**
Same answer as #1756 — the concrete model classes are configurable, so each can inherit from whatever base its shard needs.