### PR TITLE
Stop revoking client_credentials tokens across resource audiences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ User-visible changes worth mentioning.
 - [#1891] Fix: an authorization request carrying a `redirect_uri` for a client registered without one (`redirect_uri` is `nil` under `allow_blank_redirect_uri`) now answers `invalid_redirect_uri` instead of crashing with an unhandled 500.
 - [#1896] Add an opt-in `private_key_jwt` client authentication method (RFC 7523 / OIDC Core §9, requires the `jwt` gem >= 2.7) that verifies assertions against the client's published public keys — `jwks` / `jwks_uri` attributes you define on your Application model, the latter fetched with an SSRF-hardened HTTP client. The jti replay guard and the fetched-JWKS cache are process-local by default and can be replaced with shared stores via the `private_key_jwt_replay_guard` / `private_key_jwt_jwks_cache` config options. Part of [#1875].
 - [#1901] [test] Pin the answered behaviors behind [#984], [#1554], [#1600], [#1663], [#1759] and [#1787] with regression specs — the built-in client authentication methods, the unmodified echo of long `state` values, DB persistence with custom token generators, refresh token rotation/expiry semantics and the introspection asymmetry. Test-only change, closes those issues along with [#1291], [#1756] and [#1764].
+- [#1903] Fix: `revoke_previous_client_credentials_token` no longer revokes a client's live access token issued for a different `resource` ([#1886]), so a client can keep one audience-restricted token per resource server.
 - Please add here
 
 ## 6.0.0.beta1

--- a/lib/doorkeeper/oauth/client_credentials/creator.rb
+++ b/lib/doorkeeper/oauth/client_credentials/creator.rb
@@ -39,39 +39,36 @@ module Doorkeeper
           end
         end
 
-        # RFC 8707: a token audience-restricted to one resource must not be
-        # handed out for a request targeting another, so the resource takes
-        # part in the lookup itself. Filtering the result afterwards would miss
-        # a reusable token whenever a newer one exists for a different
-        # resource, since the lookup returns only the newest match.
         def find_reusable_token_for(client, scopes, attributes)
-          token = find_active_existing_token_for(client, scopes, attributes) do |candidate|
-            Doorkeeper.config.access_token_model.resource_indicators_match?(
-              candidate, attributes[:resource],
-            )
-          end
+          token = find_active_existing_token_for(client, scopes, attributes)
 
           token if token&.reusable?
         end
 
-        # `revoke_previous_client_credentials_token` keeps a single token per
-        # client whatever audience it was issued for, so this lookup stays
-        # audience-agnostic.
         def find_revocable_token_for(client, scopes, attributes)
           return unless Doorkeeper.config.revoke_previous_client_credentials_token?
 
           find_active_existing_token_for(client, scopes, attributes)
         end
 
-        def find_active_existing_token_for(client, scopes, attributes, &filter)
+        def find_active_existing_token_for(client, scopes, attributes)
           # An empty hash must stay distinct from nil here: nil ignores custom
           # attributes when matching, while an empty hash only matches tokens
           # that have no custom attributes set.
           custom_attributes = Doorkeeper.config.access_token_model
             .extract_custom_attributes(attributes)
           Doorkeeper.config.access_token_model.matching_token_for(
-            client, nil, scopes, custom_attributes: custom_attributes, include_expired: false, &filter
-          )
+            client, nil, scopes, custom_attributes: custom_attributes, include_expired: false,
+          ) do |token|
+            # RFC 8707: a token bound to another audience is a different token.
+            # It must neither be reused for this request nor revoked on its
+            # behalf, so the resource takes part in the lookup both callers use.
+            # It has to be part of the lookup rather than a check on its result,
+            # because only the newest match is returned.
+            Doorkeeper.config.access_token_model.resource_indicators_match?(
+              token, attributes[:resource],
+            )
+          end
         end
       end
     end

--- a/spec/lib/oauth/resource_indicators_spec.rb
+++ b/spec/lib/oauth/resource_indicators_spec.rb
@@ -421,13 +421,26 @@ RSpec.describe "Resource Indicators (RFC 8707)" do
         end
       end
 
-      # Existing behaviour, pinned here so the reuse fix above is seen not to
-      # change it: this option keeps only one token per client, regardless of
-      # the audience the previous one was issued for.
-      it "still revokes a token issued for a different resource" do
+      it "does not revoke a token issued for a different resource" do
         existing_token = issue_token(resource: [resource_uri])
 
         issue_token(resource: [second_resource_uri])
+
+        expect(existing_token.reload).not_to be_revoked
+      end
+
+      it "revokes the previous token issued for the same resource" do
+        existing_token = issue_token(resource: [resource_uri])
+
+        issue_token(resource: [resource_uri])
+
+        expect(existing_token.reload).to be_revoked
+      end
+
+      it "revokes the previous token when no resource is involved" do
+        existing_token = issue_token
+
+        issue_token
 
         expect(existing_token.reload).to be_revoked
       end


### PR DESCRIPTION
## Problem

`revoke_previous_client_credentials_token` keeps one access token per client, but until now it did so regardless of the audience each token was issued for: requesting a token for one resource revoked the client's live token for another.

A client talking to two resource servers could not hold both tokens at once, which makes the option hard to combine with resource indicators. RFC 9700 §4.10.2 notes that a client accessing several resource servers needs a separate token per server.

## Solution

Treat tokens bound to different audiences as different tokens: move the resource match into the shared `find_active_existing_token_for` lookup, where both the reuse path and the revocation path pick it up.

- **Same resource** → previous token is still revoked (unchanged)
- **Different resource** → previous token is left alone (new)
- **No resource indicators** → behaviour is unchanged