### PR TITLE
Exempt `Doorkeeper::Config` from `Metrics/ClassLength` locally

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,8 +29,6 @@ Metrics/BlockLength:
     - spec/**/*
     - lib/doorkeeper/rake/*
     - doorkeeper.gemspec
-Metrics/ClassLength:
-  Max: 300
 Metrics/MethodLength:
   Exclude:
     - spec/dummy/db/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- [#1906] Internal: exempt `Doorkeeper::Config` from `Metrics/ClassLength` with a directive on the class itself instead of raising the cop's global ceiling, so adding a configuration option no longer trips the limit.
 - [#PR ID] Description of the change.
 
 ## 6.0.0.beta2

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -10,7 +10,7 @@ module Doorkeeper
   # that returns configuration Builder class. This exception raises when they don't
   # define it.
   #
-  class Config
+  class Config # rubocop:disable Metrics/ClassLength
     # Default Doorkeeper configuration builder
     class Builder < AbstractBuilder
       # Provide support for an owner to be assigned to each registered


### PR DESCRIPTION
`Doorkeeper::Config` measures exactly 300 lines, which is the ceiling `.rubocop.yml` sets for `Metrics/ClassLength`. The next configuration option added to it trips the cop no matter what that option is.

```console
$ bundle exec rubocop --only Metrics/ClassLength --force-default-config lib/doorkeeper/config.rb
lib/doorkeeper/config.rb:13:3: C: Metrics/ClassLength: Class has too many lines. [300/100]
```

The class is a registry rather than a unit of behaviour: it grows by one `option` declaration per configurable feature, so its length reflects how much of Doorkeeper a host application can configure, not how complex the class itself is.

Taking @kmayer's suggestion and @nbulaj's request: a local directive on the class instead of a broad rule change.

```ruby
class Config # rubocop:disable Metrics/ClassLength
```

Two things that turned out to come with it:

**The `Max: 300` override has to go with it.** At that ceiling the class sits exactly on the limit without offending, so the directive is reported as `Lint/RedundantCopDisableDirective` and the file no longer lints. Removing the override is what makes the directive legitimate. The cop's global ceiling then comes from the `Max: 242` already recorded in `.rubocop_todo.yml` — lower than today's, so nothing is relaxed by it. The longest remaining class in `lib/` and `app/` is `OAuth::PreAuthorization` at 174 lines, so no other class is affected.

**The directive sits at the end of the `class Config` line** rather than wrapping the body in a `disable`/`enable` pair, so it applies to that class alone. The nested `Builder` (106 lines) stays subject to the cop, which a surrounding pair would have exempted as well.

`bundle exec rubocop lib app` reports the same 155 offenses before and after.