### PR TITLE
Answer `server_error` instead of raising when the `resource` column is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ User-visible changes worth mentioning.
 
 - [#1906] Internal: exempt `Doorkeeper::Config` from `Metrics/ClassLength` with a directive on the class itself instead of raising the cop's global ceiling, so adding a configuration option no longer trips the limit.
 - Fix: the `client_secret_basic` strategy now requires a `client_id` sent in the request body to name the same client as the `Authorization: Basic` header — the RFC 7521 §4.2 agreement check `private_key_jwt` already applies to an assertion's issuer. A request presenting Basic credentials for one client and a `client_id` for another was authenticated as the Basic client, silently discarding the other identity. A bare `client_id` is not a client authentication method of its own, so the RFC 6749 §2.3 multiple-methods check does not (and should not) count it.
+- [#1907] Fix: a `resource` parameter no longer produces a 500 at the authorization endpoint when `resource_indicator_validator` is configured without the `doorkeeper:resource_indicators` migration. Such a request is now answered with `server_error`, as the token endpoint already did, and the missing migration is warned about at boot.
 - [#1909] Add Rails 8.1 to CI test matrix.
 - [#PR ID] Description of the change.
 

--- a/lib/doorkeeper/oauth/metadata_response.rb
+++ b/lib/doorkeeper/oauth/metadata_response.rb
@@ -155,10 +155,11 @@ module Doorkeeper
         config.pkce_code_challenge_methods_supported
       end
 
+      # The same predicate the endpoints gate on, so the document cannot
+      # advertise a `resource` parameter they would refuse, or stay silent
+      # about one they honour.
       def resource_indicators_supported?
-        config.resource_indicator_validator.present? &&
-          Doorkeeper.config.access_grant_model.resource_indicators_supported? &&
-          Doorkeeper.config.access_token_model.resource_indicators_supported?
+        config.resource_indicator_validator.present? && ResourceIndicatorValidator.storage_ready?
       end
     end
   end

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -17,6 +17,9 @@ module Doorkeeper
       validate :code_challenge, error: Errors::InvalidRequest
       validate :code_challenge_method, error: Errors::InvalidCodeChallengeMethod
       validate :resource_indicators, error: Errors::InvalidTarget
+      # Runs after :resource_indicators so a malformed target is still answered
+      # as the client's error rather than the server's.
+      validate :resource_indicator_storage, error: Errors::ServerError
 
       attr_reader :client, :code_challenge, :code_challenge_method, :missing_param,
                   :redirect_uri, :resource_owner, :response_type, :state,
@@ -205,6 +208,25 @@ module Doorkeeper
         true
       rescue Errors::InvalidTarget
         false
+      end
+
+      # A client asking for a resource this server cannot record the audience
+      # of is a misconfiguration — resource_indicator_validator is set, but the
+      # `resource` column the doorkeeper:resource_indicators generator adds is
+      # not there. Issuing the grant would raise MissingResourceColumn out of
+      # Authorization::Code, which the authorization endpoint does not rescue,
+      # so the misconfiguration reached the client as a 500. Answering
+      # server_error here instead matches what the token endpoint already makes
+      # of the same exception, and RFC 6749 Section 4.1.2.1 lists server_error
+      # among the errors returned through the redirection URI.
+      #
+      # Only requests that actually ask for a resource are refused: without the
+      # parameter there is nothing to record, and a misconfigured server would
+      # otherwise stop authorizing anyone at all.
+      def validate_resource_indicator_storage
+        return true if @resource_indicators.blank?
+
+        ResourceIndicatorValidator.storage_ready?
       end
 
       def response_on_fragment?

--- a/lib/doorkeeper/oauth/resource_indicator_validator.rb
+++ b/lib/doorkeeper/oauth/resource_indicator_validator.rb
@@ -13,6 +13,16 @@ module Doorkeeper
     module ResourceIndicatorValidator
       module_function
 
+      # Whether there is anywhere to record the audience a token was restricted
+      # to: the `resource` column the doorkeeper:resource_indicators generator
+      # adds to both tables. RFC 8707 also needs a policy deciding which
+      # resources are acceptable (resource_indicator_validator), so callers
+      # asking whether the extension is usable check both.
+      def storage_ready?
+        Doorkeeper.config.access_grant_model.resource_indicators_supported? &&
+          Doorkeeper.config.access_token_model.resource_indicators_supported?
+      end
+
       # Validates and normalizes an array of resource indicator values.
       #
       # @param resource_indicators [Array<String>, String, nil] One or more resource URIs

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -1645,4 +1645,78 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
       end
     end
   end
+
+  # A resource_indicator_validator configured without the migration that adds
+  # the `resource` column used to raise MissingResourceColumn out of
+  # Authorization::Code and Authorization::Token, which this controller does
+  # not rescue: an operator's misconfiguration reached the client as a 500,
+  # triggered by a parameter any client can send.
+  describe "POST #create when the resource column is missing" do
+    before do
+      config_is_set(:resource_indicator_validator, ->(_indicators, _client) { true })
+      allow(Doorkeeper.config.access_grant_model).to receive(:resource_indicators_supported?).and_return(false)
+      allow(Doorkeeper.config.access_token_model).to receive(:resource_indicators_supported?).and_return(false)
+    end
+
+    def authorization_code_flow!
+      allow(Doorkeeper.config).to receive_messages(
+        grant_flows: ["authorization_code"],
+        authenticate_resource_owner: ->(_) { authenticator_method },
+      )
+      allow(controller).to receive(:authenticator_method).and_return(user)
+    end
+
+    def query_error
+      Rack::Utils.parse_query(URI.parse(response.location).query)["error"]
+    end
+
+    it "redirects an authorization code request with server_error" do
+      authorization_code_flow!
+
+      expect do
+        post :create, params: {
+          client_id: client.uid, response_type: "code",
+          redirect_uri: client.redirect_uri, resource: "https://api.example.com/",
+        }
+      end.not_to raise_error
+
+      expect(response).to be_redirect
+      expect(query_error).to eq("server_error")
+    end
+
+    it "redirects an implicit request with server_error on the fragment" do
+      expect do
+        post :create, params: {
+          client_id: client.uid, response_type: "token",
+          redirect_uri: client.redirect_uri, resource: "https://api.example.com/",
+        }
+      end.not_to raise_error
+
+      expect(response).to be_redirect
+      expect(response.query_params["error"]).to eq("server_error")
+    end
+
+    it "issues no grant or token" do
+      authorization_code_flow!
+
+      post :create, params: {
+        client_id: client.uid, response_type: "code",
+        redirect_uri: client.redirect_uri, resource: "https://api.example.com/",
+      }
+
+      expect(Doorkeeper::AccessGrant.count).to eq(0)
+      expect(Doorkeeper::AccessToken.count).to eq(0)
+    end
+
+    it "still authorizes a request that asks for no resource" do
+      authorization_code_flow!
+
+      post :create, params: {
+        client_id: client.uid, response_type: "code", redirect_uri: client.redirect_uri,
+      }
+
+      expect(response).to be_redirect
+      expect(Rack::Utils.parse_query(URI.parse(response.location).query)).to have_key("code")
+    end
+  end
 end

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
       code_challenge
       code_challenge_method
       resource_indicators
+      resource_indicator_storage
     ])
   end
 
@@ -323,6 +324,51 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
 
     it "is not authorizable" do
       expect(pre_auth).not_to be_authorizable
+    end
+  end
+
+  # resource_indicator_validator is configured but the generator that adds the
+  # `resource` column was never run, so there is nowhere to record the audience
+  # the client is asking for. Issuing the grant raised MissingResourceColumn
+  # out of Authorization::Code, which the authorization endpoint does not
+  # rescue.
+  context "when a resource is requested but the resource column is missing" do
+    let(:attributes) do
+      {
+        client_id: client.uid,
+        response_type: "code",
+        redirect_uri: "https://app.com/callback",
+        resource: "https://api.example.com/",
+      }
+    end
+
+    before do
+      config_is_set(:resource_indicator_validator, ->(_indicators, _client) { true })
+      allow(Doorkeeper.config.access_grant_model).to receive(:resource_indicators_supported?).and_return(false)
+      allow(Doorkeeper.config.access_token_model).to receive(:resource_indicators_supported?).and_return(false)
+    end
+
+    it "is not authorizable" do
+      expect(pre_auth).not_to be_authorizable
+    end
+
+    it "answers server_error rather than raising out of the endpoint" do
+      pre_auth.authorizable?
+
+      expect(pre_auth.error).to eq(Doorkeeper::Errors::ServerError)
+    end
+
+    it "still answers invalid_target when the requested resource is malformed" do
+      pre_auth = described_class.new(server, attributes.merge(resource: "not-an-absolute-uri"))
+      pre_auth.authorizable?
+
+      expect(pre_auth.error).to eq(Doorkeeper::Errors::InvalidTarget)
+    end
+
+    it "authorizes a request that asks for no resource at all" do
+      pre_auth = described_class.new(server, attributes.except(:resource))
+
+      expect(pre_auth).to be_authorizable
     end
   end
 


### PR DESCRIPTION
Follow-up to [#1886]. Configuring `resource_indicator_validator` without running the `doorkeeper:resource_indicators` migration is a misconfiguration Doorkeeper already knew how to report — `Doorkeeper::Errors::MissingResourceColumn` carries an actionable message and answers `:server_error` from `#type`, which the token endpoint turns into a spec-compliant error response.

The authorization endpoint rescues no `DoorkeeperError`, so the same exception escaped it as a **500**. It is raised out of `Authorization::Code` / `Authorization::Token`, i.e. *after* pre-authorization has already passed, and it is triggered by a `resource` parameter any client is free to send:

```ruby
post "/oauth/authorize", params: {
  client_id: client.uid, response_type: "code",
  redirect_uri: client.redirect_uri, resource: "https://api.example.com/",
}
# => Doorkeeper::Errors::MissingResourceColumn
#    lib/doorkeeper/oauth/authorization/code.rb:54
#    app/controllers/doorkeeper/authorizations_controller.rb:157
```

Pre-authorization now refuses such a request itself, which routes it through the machinery the endpoint already has: `handle_auth_errors` decides whether to render, redirect or raise, and RFC 6749 Section 4.1.2.1 lists `server_error` among the errors returned through the redirection URI. The refusal is deliberately narrow:

- Only requests that **actually ask for a resource** are refused. Without the parameter there is nothing to record, and a misconfigured server would otherwise stop authorizing anyone at all.
- The check runs **after** `:resource_indicators`, so a malformed target is still answered as the client's error (`invalid_target`) rather than the server's.

The predicate lives on `ResourceIndicatorValidator`, next to the rest of RFC 8707, and `MetadataResponse` composes its own answer from it rather than repeating the column checks — what the metadata document advertises and what the endpoints do now come from one place.

>[!NOTE]
>
> #### Why a boot-time warning as well
> 
> Every write path raises when a resource is asked for (`authorization/code.rb:54`, `authorization/token.rb:73`, `authorization_code_request.rb:56`, `client_credentials_request.rb:67`, `refresh_token_request.rb:91`, `password_access_token_request.rb:34`), so a client that *sends* `resource` makes the misconfiguration visible. A client that reads the metadata document does not: it sees `resource_indicators_supported` advertised as `false`, stops sending `resource`, and is issued tokens with no audience restriction — no exception, nothing in the log, and a configuration that still looks complete to an operator who believes RFC 8707 is on. `Config::Validations` now warns about exactly that at boot.
> 
> Reading the columns needs a database connection, which an initializer is not entitled to assume — during asset builds, `rails db:create`, or a deploy step running before the database exists — so the check is skipped rather than turned into a boot failure. Happy to move the warning out of `validate!` (or drop it from this PR entirely) if you would rather keep configuration validation free of database access; the endpoint fix stands on its own.