### PR TITLE
Add opt-in `validate_client_before_resource_owner_authentication` to validate the client before resource owner authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-visible changes worth mentioning.
 - Fix: the `client_secret_basic` strategy now requires a `client_id` sent in the request body to name the same client as the `Authorization: Basic` header — the RFC 7521 §4.2 agreement check `private_key_jwt` already applies to an assertion's issuer. A request presenting Basic credentials for one client and a `client_id` for another was authenticated as the Basic client, silently discarding the other identity. A bare `client_id` is not a client authentication method of its own, so the RFC 6749 §2.3 multiple-methods check does not (and should not) count it.
 - [#1907] Fix: a `resource` parameter no longer produces a 500 at the authorization endpoint when `resource_indicator_validator` is configured without the `doorkeeper:resource_indicators` migration. Such a request is now answered with `server_error`, as the token endpoint already did, and the missing migration is warned about at boot.
 - [#1909] Add Rails 8.1 to CI test matrix.
+- [#1910] Add opt-in `validate_client_before_resource_owner_authentication` configuration option: the authorization endpoint validates `client_id` and `redirect_uri` before authenticating the resource owner, so users are not sent through login for a request that can only fail.
 - [#PR ID] Description of the change.
 
 ## 6.0.0.beta2

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -2,6 +2,9 @@
 
 module Doorkeeper
   class AuthorizationsController < Doorkeeper::ApplicationController
+    before_action :validate_client,
+                  only: :new,
+                  if: -> { Doorkeeper.config.validate_client_before_resource_owner_authentication? }
     before_action :authenticate_resource_owner!
 
     def new
@@ -45,11 +48,57 @@ module Doorkeeper
 
       if Doorkeeper.configuration.redirect_on_errors? && pre_auth.error_response.redirectable?
         redirect_or_render(pre_auth.error_response)
-      elsif Doorkeeper.configuration.api_only
-        render json: pre_auth.error_response.body, status: pre_auth.error_response.status
       else
-        render :error, locals: { error_response: pre_auth.error_response }, status: pre_auth.error_response.status
+        render_error_response(pre_auth.error_response)
       end
+    end
+
+    def render_error_response(error_response)
+      if Doorkeeper.configuration.api_only
+        render json: error_response.body, status: error_response.status
+      else
+        render :error, locals: { error_response: error_response }, status: error_response.status
+      end
+    end
+
+    # Refuses the request before resource owner authentication when the
+    # client_id or redirect_uri is missing or invalid. Errors are rendered,
+    # never redirected, regardless of `handle_auth_errors :redirect`: no
+    # failure this check can produce leaves a redirect target worth trusting.
+    # Either the client failed first, so the redirect URI was never reached,
+    # or the redirect URI is itself the invalid one — and RFC 6749
+    # Section 3.1.2.4 forbids redirecting the user-agent to an invalid
+    # redirection URI.
+    #
+    # Host applications that need to refuse a client on their own terms (an
+    # allow-list, a registry lookup) can override this and call +super+ first:
+    #
+    #   class AuthorizationsController < Doorkeeper::AuthorizationsController
+    #     private
+    #
+    #     def validate_client
+    #       super
+    #       return if performed?
+    #       return if MyRegistry.allowed?(client_pre_auth.client.application)
+    #
+    #       head :forbidden
+    #     end
+    #   end
+    def validate_client
+      return if client_pre_auth.client_valid?
+
+      error_response = client_pre_auth.error_response
+      error_response.raise_exception! if Doorkeeper.config.raise_on_errors?
+
+      render_error_response(error_response)
+    end
+
+    # The pre-authentication view of the request. It carries no resource owner
+    # (nobody is authenticated yet), so it is kept apart from #pre_auth:
+    # owner-dependent validations (authorize_resource_owner_for_client) and the
+    # views need the one built with current_resource_owner.
+    def client_pre_auth
+      @client_pre_auth ||= OAuth::PreAuthorization.new(Doorkeeper.configuration, pre_auth_params)
     end
 
     def can_authorize_response?

--- a/lib/doorkeeper/config.rb
+++ b/lib/doorkeeper/config.rb
@@ -182,6 +182,13 @@ module Doorkeeper
         @config.instance_variable_set(:@force_pkce, true)
       end
 
+      # Validate the authorization request's client_id and redirect_uri before
+      # authenticating the resource owner, so users are not sent through login
+      # for a request that can only fail (disabled by default)
+      def validate_client_before_resource_owner_authentication
+        @config.instance_variable_set(:@validate_client_before_resource_owner_authentication, true)
+      end
+
       # Use an API mode for applications generated with --api argument
       # It will skip applications controller, disable forgery protection
       def api_only
@@ -627,6 +634,10 @@ module Doorkeeper
 
     def force_pkce?
       option_set? :force_pkce
+    end
+
+    def validate_client_before_resource_owner_authentication?
+      option_set? :validate_client_before_resource_owner_authentication
     end
 
     def enforce_configured_scopes?

--- a/lib/doorkeeper/oauth/pre_authorization.rb
+++ b/lib/doorkeeper/oauth/pre_authorization.rb
@@ -5,6 +5,16 @@ module Doorkeeper
     class PreAuthorization
       include Validations
 
+      # The validations that identify the client and its redirect URI. None of
+      # them depend on the resource owner, so the authorization endpoint can
+      # run them before authenticating anyone and spare the user a login that
+      # can only end on an error page. RFC 6749 Section 4.1.2.1 (Section 4.2.2.1
+      # for the implicit flow) asks for the resource owner to be informed when
+      # the client_id is missing or invalid, and Section 3.1.2.4 asks the same
+      # for the redirect URI; running these first is what lets the endpoint
+      # inform them without a detour through the login form.
+      CLIENT_VALIDATIONS = %i[client_id client redirect_uri].freeze
+
       validate :client_id, error: Errors::InvalidRequest
       validate :client, error: Errors::InvalidClient
       validate :redirect_uri, error: Errors::InvalidRedirectUri
@@ -43,6 +53,24 @@ module Doorkeeper
 
       def authorizable?
         valid?
+      end
+
+      # Runs only CLIENT_VALIDATIONS, in declared order, so a request
+      # from an unknown client or with an invalid redirect URI can be refused
+      # without a resource owner. Error precedence matches a full #validate
+      # run because these are the first validations declared.
+      def client_valid?
+        @error = nil
+        @missing_param = nil
+
+        self.class.validations.each do |validation|
+          next unless CLIENT_VALIDATIONS.include?(validation[:attribute])
+
+          @error = validation[:options][:error] unless send("validate_#{validation[:attribute]}")
+          break if @error
+        end
+
+        @error.nil?
       end
 
       def scopes

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -202,6 +202,18 @@ Doorkeeper.configure do
   #
   # force_pkce
 
+  # Validate the authorization request's client_id and redirect_uri before
+  # authenticating the resource owner, so users are not sent through login for
+  # a request that can only fail (RFC 6749 Section 4.1.2.1 asks for the
+  # resource owner to be informed of an invalid client_id, Section 3.1.2.4 of
+  # an invalid redirect URI). Disabled by default: enabling it changes when
+  # your `resource_owner_authenticator` block runs, and lets an unauthenticated
+  # party learn whether a client_id is registered (client identifiers are not
+  # confidential per RFC 6749 Section 2.2). To refuse clients on your own terms
+  # as well, override Doorkeeper::AuthorizationsController#validate_client.
+  #
+  # validate_client_before_resource_owner_authentication
+
   # Hash access and refresh tokens before persisting them.
   # This will disable the possibility to use +reuse_access_token+
   # since plain values can no longer be retrieved.

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -1068,6 +1068,110 @@ RSpec.describe Doorkeeper::AuthorizationsController, type: :controller do
     end
   end
 
+  describe "GET #new with validate_client_before_resource_owner_authentication" do
+    before do
+      allow(Doorkeeper.config).to receive(:validate_client_before_resource_owner_authentication?).and_return(true)
+    end
+
+    context "when the client is not registered" do
+      it "refuses the request without authenticating the resource owner" do
+        allow(Doorkeeper.config)
+          .to receive(:authenticate_resource_owner)
+          .and_return(->(*) { raise "resource owner authentication must not run" })
+
+        get :new, params: { client_id: "unknown", response_type: "token" }
+
+        expect(response).not_to be_redirect
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.body).to include(ERB::Util.html_escape(translated_error_message(:invalid_client)))
+      end
+
+      it "renders a JSON error in API mode" do
+        allow(Doorkeeper.configuration).to receive(:api_only).and_return(true)
+
+        get :new, params: { client_id: "unknown", response_type: "token" }
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response_json_body["error"]).to eq("invalid_client")
+      end
+
+      it "raises with handle_auth_errors :raise" do
+        allow(Doorkeeper.configuration).to receive(:handle_auth_errors).and_return(:raise)
+
+        expect do
+          get :new, params: { client_id: "unknown", response_type: "token" }
+        end.to raise_error(Doorkeeper::Errors::InvalidClient)
+      end
+    end
+
+    context "when the request is valid" do
+      # Regression: the pre-authentication check builds a PreAuthorization
+      # without a resource owner. It must not leak into @pre_auth, or a
+      # configured authorize_resource_owner_for_client hook would see a nil
+      # owner and refuse the request with access_denied.
+      it "authorizes with an authorize_resource_owner_for_client hook that requires the owner" do
+        allow(Doorkeeper.configuration)
+          .to receive(:authorize_resource_owner_for_client)
+          .and_return(->(_client, owner) { owner == user })
+
+        get :new, params: {
+          client_id: client.uid,
+          response_type: "token",
+          redirect_uri: client.redirect_uri,
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Authorize")
+      end
+    end
+  end
+
+  describe "GET #new with a host application overriding #validate_client" do
+    # A host app that has to refuse clients on its own terms (an allow-list, a
+    # registry lookup) subclasses the controller and calls +super+ first. It is
+    # given #client_pre_auth so it does not have to build a second
+    # PreAuthorization — and so it never touches #pre_auth, which would
+    # authenticate the resource owner and defeat the point of the option.
+    controller(described_class) do
+      private
+
+      def validate_client
+        super
+        return if performed?
+        return if client_pre_auth.client.application.uid == allowed_client_uid
+
+        head :forbidden
+      end
+    end
+
+    before do
+      allow(Doorkeeper.config).to receive_messages(
+        validate_client_before_resource_owner_authentication?: true,
+        authenticate_resource_owner: ->(*) { raise "resource owner authentication must not run" },
+      )
+      allow(controller).to receive(:allowed_client_uid).and_return(client.uid)
+      routes.draw { get "new" => "doorkeeper/authorizations#new" }
+    end
+
+    it "still refuses an unknown client with Doorkeeper's own error" do
+      get :new, params: { client_id: "unknown", response_type: "token" }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "lets the override refuse a registered client before authentication" do
+      allow(controller).to receive(:allowed_client_uid).and_return("something-else")
+
+      get :new, params: {
+        client_id: client.uid,
+        response_type: "token",
+        redirect_uri: client.redirect_uri,
+      }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   describe "GET #new in API mode with errors" do
     before do
       allow(Doorkeeper.configuration).to receive(:api_only).and_return(true)

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -1557,6 +1557,15 @@ RSpec.describe Doorkeeper::Config do
       expect(config.force_pkce?).to be(true)
     end
 
+    it "enables validate_client_before_resource_owner_authentication" do
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        validate_client_before_resource_owner_authentication
+      end
+
+      expect(config.validate_client_before_resource_owner_authentication?).to be(true)
+    end
+
     it "enables use_polymorphic_resource_owner" do
       Doorkeeper.configure do
         orm DOORKEEPER_ORM

--- a/spec/lib/oauth/pre_authorization_spec.rb
+++ b/spec/lib/oauth/pre_authorization_spec.rb
@@ -327,6 +327,49 @@ RSpec.describe Doorkeeper::OAuth::PreAuthorization do
     end
   end
 
+  describe "#client_valid?" do
+    it "is valid for a registered client with a matching redirect_uri" do
+      expect(pre_auth.client_valid?).to be(true)
+      expect(pre_auth.error).to be_nil
+    end
+
+    it "is invalid with invalid_request when the client_id is missing" do
+      attributes[:client_id] = nil
+
+      expect(pre_auth.client_valid?).to be(false)
+      expect(pre_auth.error).to eq(Doorkeeper::Errors::InvalidRequest)
+      expect(pre_auth.missing_param).to eq(:client_id)
+    end
+
+    it "is invalid with invalid_client when the client is not registered" do
+      attributes[:client_id] = "unknown-client"
+
+      expect(pre_auth.client_valid?).to be(false)
+      expect(pre_auth.error).to eq(Doorkeeper::Errors::InvalidClient)
+    end
+
+    it "is invalid with invalid_redirect_uri when the redirect_uri does not match" do
+      attributes[:redirect_uri] = "https://other.example/callback"
+
+      expect(pre_auth.client_valid?).to be(false)
+      expect(pre_auth.error).to eq(Doorkeeper::Errors::InvalidRedirectUri)
+    end
+
+    it "does not run validations that depend on the resource owner" do
+      allow(Doorkeeper.configuration).to receive(:authorize_resource_owner_for_client).and_return(->(*_) { false })
+
+      expect(pre_auth.client_valid?).to be(true)
+    end
+
+    it "does not validate the remaining request parameters" do
+      attributes[:response_type] = "bogus"
+      attributes[:scope] = "unknown"
+
+      expect(pre_auth.client_valid?).to be(true)
+      expect(pre_auth).not_to be_authorizable
+    end
+  end
+
   # resource_indicator_validator is configured but the generator that adds the
   # `resource` column was never run, so there is nowhere to record the audience
   # the client is asking for. Issuing the grant raised MissingResourceColumn

--- a/spec/requests/endpoints/authorization_spec.rb
+++ b/spec/requests/endpoints/authorization_spec.rb
@@ -15,6 +15,61 @@ feature "Authorization endpoint" do
     i_should_be_on "/"
   end
 
+  scenario "requires resource owner to be authenticated even for an unknown client by default" do
+    visit authorization_endpoint_url(client_id: "unknown", redirect_uri: "https://app.example/callback")
+    i_should_see "Sign in"
+    i_should_be_on "/"
+  end
+
+  context "when validate_client_before_resource_owner_authentication is enabled" do
+    background do
+      config_is_set(:validate_client_before_resource_owner_authentication, true)
+    end
+
+    scenario "still requires authentication for a valid request" do
+      visit authorization_endpoint_url(client: @client)
+      i_should_see "Sign in"
+      i_should_be_on "/"
+    end
+
+    scenario "displays invalid_client error without requiring sign in" do
+      visit authorization_endpoint_url(client_id: "unknown", redirect_uri: "https://app.example/callback")
+      i_should_be_on "/oauth/authorize"
+      i_should_not_see "Authorize"
+      i_should_see_translated_error_message :invalid_client
+    end
+
+    scenario "displays invalid_request error without requiring sign in when the client_id is missing" do
+      visit authorization_endpoint_url(client: nil, response_type: "code")
+      i_should_be_on "/oauth/authorize"
+      i_should_not_see "Authorize"
+      i_should_see_translated_invalid_request_error_message :missing_param, :client_id
+    end
+
+    scenario "displays invalid_redirect_uri error without requiring sign in" do
+      visit authorization_endpoint_url(client: @client, redirect_uri: "https://mismatch.example/callback")
+      i_should_be_on "/oauth/authorize"
+      i_should_not_see "Authorize"
+      i_should_see_translated_error_message :invalid_redirect_uri
+    end
+
+    context "with handle_auth_errors :redirect" do
+      background do
+        config_is_set(:handle_auth_errors, :redirect)
+      end
+
+      # RFC 6749 §4.1.2.1: with the client_id missing the redirect_uri cannot
+      # be validated, so the error must be shown to the resource owner and
+      # never sent to the unvalidated URI (§3.1.2.4 says the same for a
+      # redirect URI that fails validation on its own).
+      scenario "renders the error instead of redirecting to an unvalidated redirect_uri" do
+        visit authorization_endpoint_url(client_id: nil, redirect_uri: "https://attacker.example/callback", response_type: "code")
+        i_should_be_on "/oauth/authorize"
+        i_should_see_translated_invalid_request_error_message :missing_param, :client_id
+      end
+    end
+  end
+
   context "with authenticated resource owner" do
     background do
       create_resource_owner


### PR DESCRIPTION
## Summary

Fixes #1711.

The authorization endpoint runs `authenticate_resource_owner!` before looking at the request, so a request with an unknown `client_id` or an invalid `redirect_uri` sends the user through the whole login flow only to be shown an error that was already determined before they typed a password. RFC 6749 §4.1.2.1 (§4.2.2.1 for the implicit flow) asks for the resource owner to be informed when the `client_id` is missing or invalid, and §3.1.2.4 asks the same for the redirect URI; running these checks first is what lets the endpoint inform the user without a detour through the login form.

This PR adds an opt-in configuration option:

```ruby
Doorkeeper.configure do
  validate_client_before_resource_owner_authentication
end
```

When enabled, the authorization endpoint's `new` action validates the resource-owner-independent client settings (`client_id` present, client registered, `redirect_uri` matching) **before** authenticating the resource owner, and renders the error page without asking the user to log in. Valid requests keep the exact current behavior.

> [!NOTE]
>
> ### Cost when enabled
>
> `OAuth::Client.find` runs twice for a valid `new` request (once pre-authentication, once in the memoized `pre_auth`). Accepted to keep the nil-owner instance strictly out of the request's later lifecycle.

<details>

<summary>Design notes</summary>

- **Opt-in, disabled by default.** Enabling it changes when the configured `resource_owner_authenticator` runs, and lets an unauthenticated party learn whether a `client_id` is registered. Client identifiers are not confidential (RFC 6749 §2.2), but the default stays as-is for backward compatibility. The option could become the default in a future major release if desired.
- **Only the leading owner-independent validations run early.** `PreAuthorization#client_settings_valid?` runs `client_id` / `client` / `redirect_uri` in their declared order, so error precedence matches a full validation run. `authorize_resource_owner_for_client` and everything after it still run post-authentication, keeping the existing precedence (e.g. `access_denied` before `invalid_scope`) intact.
- **The nil-owner `PreAuthorization` is never memoized.** The pre-authentication check builds its own instance and discards it when the request proceeds, so a configured `authorize_resource_owner_for_client` hook keeps seeing the real resource owner (naively reusing the instance would answer `access_denied` to every logged-out user on such apps — this is the bug in the workaround code posted on the issue).
- **Pre-authentication errors are rendered, never redirected**, even under `handle_auth_errors :redirect`: with a missing `client_id` the `redirect_uri` cannot be validated, and RFC 6749 §3.1.2.4 forbids redirecting the user-agent to an invalid redirection URI (`invalid_client` / `invalid_redirect_uri` were already non-redirectable). `handle_auth_errors :raise` keeps raising the same exceptions as before.
- Compatible with doorkeeper-openid_connect: its `authenticate_resource_owner!` override (prepended on `Doorkeeper::Helpers::Controller`) never runs when the filter chain halts here, which only happens for requests that could not produce a redirectable OIDC response anyway.

</details>