### PR TITLE
Don't use old "spec_helper_integration"

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper_integration"
+require "spec_helper"
 
 RSpec.describe Doorkeeper::ApplicationController, type: :controller do
   describe "current_resource_owner view helper" do

--- a/spec/controllers/application_metal_controller_spec.rb
+++ b/spec/controllers/application_metal_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper_integration"
+require "spec_helper"
 
 RSpec.describe Doorkeeper::ApplicationMetalController, type: :controller do
   render_views


### PR DESCRIPTION
This is a very old spec file which is left only for compatibility with old extensions. Maybe we will remove it completely soon