### PR TITLE
Reborn Coverall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ jobs:
     env:
       CI: true
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      COVERALLS_PARALLEL: true
-      COVERALLS_SERVICE_NAME: github
-      COVERALLS_SERVICE_JOB_ID: ${{ github.run_id }}
-      COVERALLS_FLAG_NAME: ruby-${{ matrix.ruby }}-${{ matrix.gemfile }}
     runs-on: ${{ matrix.os }}
     if: |
       !(   contains(github.event.pull_request.title,  '[ci skip]')
@@ -50,6 +45,14 @@ jobs:
       - name: Run tests
         timeout-minutes: 10
         run: bundle exec rake spec
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: coverage/.resultset.json
+          format: simplecov
+          flag-name: ruby-${{ matrix.ruby }}-${{ matrix.gemfile }}
+          parallel: true
 
   # The jwt gem is an optional dependency of the private_key_jwt client
   # authentication method, and the matrix above always resolves its newest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ User-visible changes worth mentioning.
 - [#1907] Fix: a `resource` parameter no longer produces a 500 at the authorization endpoint when `resource_indicator_validator` is configured without the `doorkeeper:resource_indicators` migration. Such a request is now answered with `server_error`, as the token endpoint already did, and the missing migration is warned about at boot.
 - [#1909] Add Rails 8.1 to CI test matrix.
 - [#1910] Add opt-in `validate_client_before_resource_owner_authentication` configuration option: the authorization endpoint validates `client_id` and `redirect_uri` before authenticating the resource owner, so users are not sent through login for a request that can only fail.
+- [#1916] Fix broken Coveralls coverage reporting.
 - [#PR ID] Description of the change.
 
 ## 6.0.0.beta2

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "appraisal"
   gem.add_development_dependency "capybara"
-  gem.add_development_dependency "coveralls_reborn"
+  gem.add_development_dependency "simplecov", "~> 0.22"
   gem.add_development_dependency "database_cleaner", "~> 2.0"
   gem.add_development_dependency "factory_bot", "~> 6.0"
   gem.add_development_dependency "generator_spec", "~> 0.10.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "coveralls"
+require "simplecov"
 
-Coveralls.wear!("rails") do
+SimpleCov.start("rails") do
   add_filter("/spec/")
   add_filter("/lib/generators/doorkeeper/templates/")
 end
@@ -22,8 +22,8 @@ require "database_cleaner"
 require "generator_spec/test_case"
 require "webmock/rspec"
 
-# Coveralls posts its results over HTTP from an at_exit hook in CI.
-WebMock.disable_net_connect!(allow: "coveralls.io")
+# WebMock is used to stub external HTTP requests in tests.
+WebMock.disable_net_connect!
 
 # Load JRuby SQLite3 if in that platform
 if defined? JRUBY_VERSION


### PR DESCRIPTION
The coveralls_reborn gem (v0.29.0) doesn't support GitHub Actions natively. Its README explicitly says "you don't need this gem on GitHub Actions" and recommends using SimpleCov + the official Coveralls GitHub Action instead.
