### PR TITLE
Make the fallback secret upgrade conditional on the value it matched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ User-visible changes worth mentioning.
 - [#1909] Add Rails 8.1 to CI test matrix.
 - [#1910] Add opt-in `validate_client_before_resource_owner_authentication` configuration option: the authorization endpoint validates `client_id` and `redirect_uri` before authenticating the resource owner, so users are not sent through login for a request that can only fail.
 - [#1916] Fix broken Coveralls coverage reporting.
+- [#1917] Fix: the fallback secret upgrade no longer writes the matched secret back over a value stored in the meantime, which could undo a concurrent `#renew_secret` and leave the superseded secret valid. The upgrade is now conditional on the column still holding the value that matched.
 - [#1918] The api_only controller specs no longer `load` the real controller sources, which detached the coverage of every other example that ran them and made the reported coverage depend on the random example order.
 - [#PR ID] Description of the change.
 

--- a/lib/doorkeeper/models/concerns/secret_storable.rb
+++ b/lib/doorkeeper/models/concerns/secret_storable.rb
@@ -82,18 +82,153 @@ module Doorkeeper
         # @param plain_secret
         #   The plain secret to upgrade.
         #
+        # @return [Boolean]
+        #   Whether the stored value was upgraded. False means the row no
+        #   longer holds the value that was matched.
+        #
         def upgrade_fallback_value(instance, attr, plain_secret)
+          # The value the fallback strategy matched against. The upgrade is a
+          # write on what is otherwise a read path, so the row can move between
+          # the match and this write — another request renewing the secret, or
+          # the application replacing it. Writing by id alone would put the
+          # matched value back over whatever replaced it, so the write is
+          # conditional on the column still holding it.
+          matched = instance.public_send(attr)
           upgraded = secret_strategy.store_secret(instance, attr, plain_secret)
 
-          # The upgrade is a write on what is otherwise a read path (finding a
-          # record by its secret), so it must reach the primary database when
-          # automatic role switching would route the surrounding request to a
-          # read replica.
-          if respond_to?(:with_primary_role)
-            with_primary_role { instance.update(attr => upgraded) }
-          else
-            instance.update(attr => upgraded)
+          changes = { attr => upgraded }
+          # `update_all` does not maintain timestamps, which `#update` did.
+          changes[:updated_at] = Time.now.utc if stamps_updated_at?(instance)
+
+          scope = matched_row_scope(instance, attr, matched)
+
+          # Under optimistic locking, `update_all` bumps the lock column on
+          # its own, which would leave the instance stale and have its next
+          # `save` refused. Write the bump explicitly instead — `update_all`
+          # leaves the column alone when it is among the changes — so that the
+          # instance can be brought in step below, and make the write
+          # conditional on the version too: bumping from a version the row no
+          # longer holds would set it backwards.
+          if optimistic_locking?
+            version = instance.public_send(locking_column) || 0
+            scope = scope.where(locking_column => version)
+            changes[locking_column] = version + 1
           end
+
+          # The write must reach the primary database when automatic role
+          # switching would route the surrounding request to a read replica.
+          written =
+            if respond_to?(:with_primary_role)
+              with_primary_role { update_matched_rows(scope, changes) }
+            else
+              update_matched_rows(scope, changes)
+            end
+
+          if written.zero?
+            # Nothing was written. `store_secret` has already assigned the
+            # upgraded value in memory, so put the instance back rather than
+            # leave it carrying a secret that was never stored — and withdraw
+            # the assignment from the ORMs that record one having been made.
+            instance.public_send(:"#{attr}=", matched)
+            forget_assigned_columns(instance, [attr])
+            return false
+          end
+
+          sync_upgraded_instance(instance, changes)
+          true
+        end
+
+        # The row that held +matched+ in +attr+, identified by the model's
+        # configured primary key rather than a hard-coded `id`.
+        def matched_row_scope(instance, attr, matched)
+          where(primary_key_conditions(instance).merge(attr => matched))
+        end
+
+        # The columns identifying +instance+'s row and the values it holds in
+        # them, taken from the model's configured primary key: it may be named
+        # something other than `id`, and Active Record answers with an array
+        # of column names where the key is composed of several — passing that
+        # array on as a single column name is a TypeError. An ORM with no
+        # notion of a primary key has `id` as the fallback.
+        def primary_key_conditions(instance)
+          keys = respond_to?(:primary_key) && primary_key ? Array(primary_key) : [:id]
+
+          keys.index_with { |key| instance.public_send(key) }
+        end
+
+        # Whether the upgrade stamps +updated_at+, which `#update` did for it
+        # before the write became conditional — including its deference to
+        # `record_timestamps`, which a model that stamps its own timestamps
+        # turns off. An ORM that does not know the setting is taken to be
+        # stamping, as it was.
+        def stamps_updated_at?(instance)
+          return false unless instance.respond_to?(:updated_at)
+
+          !respond_to?(:record_timestamps) || record_timestamps
+        end
+
+        def optimistic_locking?
+          respond_to?(:locking_enabled?) && locking_enabled?
+        end
+
+        # The row was written past the instance, so bring the dirty tracking
+        # back in step: left as it is, a caller that later reloads or locks
+        # the record is refused over a change that is already persisted. Only
+        # what was written is marked clean — a `reload` would also discard
+        # every unrelated unsaved change the caller had on the instance, and
+        # this is nominally a read path.
+        def sync_upgraded_instance(instance, changes)
+          instance.updated_at = changes[:updated_at] if changes.key?(:updated_at)
+          instance.public_send(:"#{locking_column}=", changes[locking_column]) if optimistic_locking?
+          # Each ORM is told in its own terms; one with no dirty tracking at
+          # all has nothing to correct here.
+          instance.clear_attribute_changes(changes.keys) if instance.respond_to?(:clear_attribute_changes)
+          forget_assigned_columns(instance, changes.keys)
+        end
+
+        # Withdraws +keys+ from the columns Sequel records as assigned since
+        # the last save, which is what it decides `#modified?` and the columns
+        # `#save_changes` writes from — and which it does not take a column
+        # off when the value it held is assigned back.
+        #
+        # Active Record wants no equivalent: it decides dirtiness by comparing
+        # against the values the row was loaded with, so an attribute put back
+        # is clean again on its own, and clearing it there would forget a
+        # change the caller had made to the same column before the lookup.
+        def forget_assigned_columns(instance, keys)
+          return unless instance.respond_to?(:changed_columns)
+
+          columns = keys.map(&:to_sym)
+          instance.changed_columns.reject! { |column| columns.include?(column) }
+        end
+
+        # Writes +changes+ to the rows +scope+ still matches and answers how
+        # many there were. Spelled `update_all` by Active Record and Mongoid,
+        # `update` by a Sequel dataset: this concern is included by the ORM
+        # extensions too, and the value it decides on — whether the row still
+        # held the value that was matched — is the same either way.
+        def update_matched_rows(scope, changes)
+          written =
+            if scope.respond_to?(:update_all)
+              scope.update_all(changes)
+            else
+              scope.update(changes)
+            end
+
+          matched_row_count(written)
+        end
+
+        # How many rows a write reached, however the ORM chose to answer it.
+        # Active Record and Sequel answer with the count itself; Mongoid
+        # answers with the driver's update result, which carries it as
+        # +matched_count+ — and answers +false+ when it wrote nothing at all.
+        # An ORM whose answer says neither is taken at its word, as it was
+        # before the write became conditional.
+        def matched_row_count(written)
+          return written.matched_count if written.respond_to?(:matched_count)
+          return written if written.respond_to?(:zero?)
+
+          written ? 1 : 0
         end
 
         ##

--- a/spec/lib/models/secret_storable_spec.rb
+++ b/spec/lib/models/secret_storable_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Doorkeeper::Models::SecretStorable do
         raise "stub this"
       end
 
+      def self.where(*)
+        raise "stub this"
+      end
+
       def update_column(*)
         raise "stub this"
       end
@@ -70,32 +74,283 @@ RSpec.describe Doorkeeper::Models::SecretStorable do
       end
 
       context "when resource is defined" do
-        let(:resource) { double("Token model") }
+        # A real object rather than a double: what matters is the state the
+        # resource is left in, not the messages it received.
+        let(:resource) do
+          Class.new do
+            attr_accessor :attr
+            attr_reader :cleared_changes
 
-        it "calls the strategy for lookup" do
-          expect(clazz)
+            def initialize
+              @attr = "old value"
+              @cleared_changes = []
+            end
+
+            def id
+              1
+            end
+
+            def clear_attribute_changes(attr_names)
+              @cleared_changes.concat(attr_names.map(&:to_s))
+            end
+          end.new
+        end
+        let(:scope) { double("Relation") }
+
+        before do
+          allow(clazz)
             .to receive(:find_by)
             .with("attr" => "fallback")
             .and_return(resource)
 
-          expect(fallback)
+          allow(fallback)
             .to receive(:transform_secret)
             .with("input")
             .and_return("fallback")
 
-          # store_secret will call the resource
-          expect(resource)
-            .to receive(:attr=)
-            .with("new value")
-
           # It will upgrade the secret automatically using the current strategy
-          expect(strategy)
+          allow(strategy)
             .to receive(:transform_secret)
             .with("input")
             .and_return("new value")
+        end
 
-          expect(resource).to receive(:update).with("attr" => "new value")
+        # The stubs are narrow: an upgrade written with anything other than the
+        # value that matched falls through to the class, which raises.
+        it "upgrades the stored value while the row still holds the matched one" do
+          allow(clazz).to receive(:where).with({ id: 1, "attr" => "old value" }).and_return(scope)
+          allow(scope).to receive(:update_all).with({ "attr" => "new value" }).and_return(1)
+
           expect(result).to eq resource
+          expect(resource.attr).to eq "new value"
+          expect(resource.cleared_changes).to eq %w[attr]
+        end
+
+        it "leaves the resource as it was when the row no longer holds the matched value" do
+          allow(clazz).to receive(:where).and_return(scope)
+          allow(scope).to receive(:update_all).and_return(0)
+
+          expect(result).to eq resource
+          expect(resource.attr).to eq "old value"
+          expect(resource.cleared_changes).to be_empty
+        end
+      end
+
+      # This concern is included by the ORM extensions too, so the upgrade may
+      # only use what every ORM provides: a Sequel dataset spells `update_all`
+      # `update`, and its records have no Active Record dirty tracking to put
+      # back in step.
+      context "when the ORM provides neither update_all nor dirty tracking" do
+        let(:resource) do
+          Class.new do
+            attr_accessor :attr
+
+            def initialize
+              @attr = "old value"
+            end
+
+            def id
+              1
+            end
+          end.new
+        end
+        let(:scope) { double("Dataset") }
+
+        before do
+          allow(clazz).to receive(:find_by).with("attr" => "fallback").and_return(resource)
+          allow(fallback).to receive(:transform_secret).with("input").and_return("fallback")
+          allow(strategy).to receive(:transform_secret).with("input").and_return("new value")
+          allow(clazz).to receive(:where).with({ id: 1, "attr" => "old value" }).and_return(scope)
+        end
+
+        it "upgrades the stored value through the write the ORM does provide" do
+          allow(scope).to receive(:update).with({ "attr" => "new value" }).and_return(1)
+
+          expect(result).to eq resource
+          expect(resource.attr).to eq "new value"
+        end
+
+        it "leaves the resource as it was when the row no longer holds the matched value" do
+          allow(scope).to receive(:update).and_return(0)
+
+          expect(result).to eq resource
+          expect(resource.attr).to eq "old value"
+        end
+      end
+
+      # Sequel records the columns assigned since the last save and does not
+      # take one off that list when the value it held is assigned back, so the
+      # concern has to withdraw its own assignments itself.
+      context "when the ORM tracks assigned columns the way Sequel does" do
+        let(:resource) do
+          Class.new do
+            attr_reader :attr, :changed_columns
+
+            def initialize
+              @attr = "old value"
+              @changed_columns = []
+            end
+
+            def attr=(value)
+              @changed_columns << :attr unless @changed_columns.include?(:attr)
+              @attr = value
+            end
+
+            def id
+              1
+            end
+          end.new
+        end
+        let(:scope) { double("Dataset") }
+
+        before do
+          allow(clazz).to receive(:find_by).with("attr" => "fallback").and_return(resource)
+          allow(fallback).to receive(:transform_secret).with("input").and_return("fallback")
+          allow(strategy).to receive(:transform_secret).with("input").and_return("new value")
+          allow(clazz).to receive(:where).with({ id: 1, "attr" => "old value" }).and_return(scope)
+        end
+
+        it "withdraws the columns it wrote once the upgrade is stored" do
+          allow(scope).to receive(:update).with({ "attr" => "new value" }).and_return(1)
+
+          expect(result).to eq resource
+          expect(resource.attr).to eq "new value"
+          expect(resource.changed_columns).to be_empty
+        end
+
+        it "withdraws its own assignment when the row no longer holds the matched value" do
+          allow(scope).to receive(:update).and_return(0)
+
+          expect(result).to eq resource
+          expect(resource.attr).to eq "old value"
+          expect(resource.changed_columns).to be_empty
+        end
+      end
+
+      # `update_all` is spelled the same by Mongoid but answered differently:
+      # with the driver's update result rather than a row count.
+      context "when the ORM answers the write with a driver result" do
+        let(:resource) do
+          Class.new do
+            attr_accessor :attr
+
+            def initialize
+              @attr = "old value"
+            end
+
+            def id
+              1
+            end
+          end.new
+        end
+        let(:scope) { double("Criteria") }
+
+        before do
+          allow(clazz).to receive(:find_by).with("attr" => "fallback").and_return(resource)
+          allow(fallback).to receive(:transform_secret).with("input").and_return("fallback")
+          allow(strategy).to receive(:transform_secret).with("input").and_return("new value")
+          allow(clazz).to receive(:where).with({ id: 1, "attr" => "old value" }).and_return(scope)
+        end
+
+        it "reads the row count out of the result" do
+          allow(scope)
+            .to receive(:update_all)
+            .with({ "attr" => "new value" })
+            .and_return(double("Mongo::Operation::Update::Result", matched_count: 1))
+
+          expect(result).to eq resource
+          expect(resource.attr).to eq "new value"
+        end
+
+        it "leaves the resource as it was when the result counts no rows" do
+          allow(scope)
+            .to receive(:update_all)
+            .and_return(double("Mongo::Operation::Update::Result", matched_count: 0))
+
+          expect(result).to eq resource
+          expect(resource.attr).to eq "old value"
+        end
+
+        it "leaves the resource as it was when the ORM declines the write" do
+          allow(scope).to receive(:update_all).and_return(false)
+
+          expect(result).to eq resource
+          expect(resource.attr).to eq "old value"
+        end
+      end
+
+      # Row identity is the model's configured primary key, which need not
+      # be `id` — and need not exist as a notion at all.
+      context "when the ORM names its primary key" do
+        let(:resource) do
+          Class.new do
+            attr_accessor :attr
+
+            def initialize
+              @attr = "old value"
+            end
+
+            def code
+              "app-1"
+            end
+          end.new
+        end
+        let(:scope) { double("Relation") }
+
+        before do
+          allow(clazz).to receive(:primary_key).and_return("code")
+          allow(clazz).to receive(:find_by).with("attr" => "fallback").and_return(resource)
+          allow(fallback).to receive(:transform_secret).with("input").and_return("fallback")
+          allow(strategy).to receive(:transform_secret).with("input").and_return("new value")
+        end
+
+        it "identifies the row by that key" do
+          allow(clazz).to receive(:where).with({ "code" => "app-1", "attr" => "old value" }).and_return(scope)
+          allow(scope).to receive(:update_all).with({ "attr" => "new value" }).and_return(1)
+
+          expect(result).to eq resource
+          expect(resource.attr).to eq "new value"
+        end
+      end
+
+      # A primary key can be composed of several columns, which Active Record
+      # answers with as an array of their names.
+      context "when the ORM composes its primary key" do
+        let(:resource) do
+          Class.new do
+            attr_accessor :attr
+
+            def initialize
+              @attr = "old value"
+            end
+
+            def shop_id
+              7
+            end
+
+            def seq
+              3
+            end
+          end.new
+        end
+        let(:scope) { double("Relation") }
+
+        before do
+          allow(clazz).to receive(:primary_key).and_return(%w[shop_id seq])
+          allow(clazz).to receive(:find_by).with("attr" => "fallback").and_return(resource)
+          allow(fallback).to receive(:transform_secret).with("input").and_return("fallback")
+          allow(strategy).to receive(:transform_secret).with("input").and_return("new value")
+        end
+
+        it "identifies the row by every column the key names" do
+          allow(clazz)
+            .to receive(:where)
+            .with({ "shop_id" => 7, "seq" => 3, "attr" => "old value" })
+            .and_return(scope)
+          allow(scope).to receive(:update_all).with({ "attr" => "new value" }).and_return(1)
+
+          expect(result).to eq resource
+          expect(resource.attr).to eq "new value"
         end
       end
 

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -336,6 +336,215 @@ RSpec.describe Doorkeeper::Application do
         expect(app.secret).to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
       end
 
+      # The upgrade is a write on a read path, decided from a value read before
+      # the comparison, so the row can move underneath it.
+      it "does not write the matched secret back over one replaced meanwhile" do
+        in_flight = described_class.find(app.id)
+
+        app.renew_secret
+        app.save!
+        new_secret = app.plaintext_secret
+
+        expect(in_flight.secret_matches?(plain_secret)).to be(true)
+
+        app.reload
+        expect(app.secret_matches?(new_secret)).to be(true)
+        expect(app.secret_matches?(plain_secret)).to be(false)
+      end
+
+      it "leaves the instance clean when the upgrade finds the row moved" do
+        in_flight = described_class.find(app.id)
+        app.update_column(:secret, Doorkeeper::SecretStoring::Sha256Hash.transform_secret("elsewhere"))
+
+        in_flight.secret_matches?(plain_secret)
+
+        expect(in_flight).not_to be_changed
+        expect(in_flight.secret).to eq(plain_secret)
+      end
+
+      it "leaves the instance clean once the upgrade is written" do
+        expect(app.secret_matches?(plain_secret)).to be(true)
+
+        expect(app).not_to be_changed
+      end
+
+      # The upgrade happens on a read path, so it must not take unrelated
+      # unsaved changes with it the way a `reload` would.
+      it "keeps unrelated unsaved changes once the upgrade is written" do
+        app.name = "renamed but not saved"
+
+        expect(app.secret_matches?(plain_secret)).to be(true)
+
+        expect(app.name).to eq("renamed but not saved")
+        expect(app.changed_attributes.keys).to eq(%w[name])
+        expect(app.secret).to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
+      end
+
+      # `#update` deferred to `record_timestamps`, so the write that replaced
+      # it has to stamp `updated_at` on the same terms.
+      it "leaves updated_at alone for a model that stamps its own timestamps" do
+        stamped_at = app.reload.updated_at
+        allow(described_class).to receive(:record_timestamps).and_return(false)
+
+        expect(app.secret_matches?(plain_secret)).to be(true)
+
+        app.reload
+        expect(app.secret).to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
+        expect(app.updated_at).to eq(stamped_at)
+      end
+
+      if DOORKEEPER_ORM == :active_record
+        # The conditional write is an `update_all`, which bumps an optimistic
+        # locking column on its own and would leave the instance one version
+        # behind — refused on its next save over a change already persisted.
+        context "when the schema has an optimistic locking column" do
+          before do
+            ActiveRecord::Base.connection.create_table(:oauth_applications_locked) do |t|
+              t.string :name, null: false
+              t.string :uid, null: false
+              t.string :secret
+              t.text :redirect_uri
+              t.string :scopes, default: "", null: false
+              t.boolean :confidential, default: true, null: false
+              t.integer :lock_version, default: 0, null: false
+              t.timestamps
+            end
+          end
+
+          after do
+            ActiveRecord::Base.connection.drop_table(:oauth_applications_locked)
+          end
+
+          let(:locked_class) do
+            Class.new(::ActiveRecord::Base) do
+              include Doorkeeper::Orm::ActiveRecord::Mixins::Application
+              self.table_name = "oauth_applications_locked"
+            end
+          end
+
+          let(:locked_app) do
+            locked_class.create!(name: "LockedApp", redirect_uri: "https://example.com").tap do |record|
+              record.update_column(:secret, plain_secret)
+            end
+          end
+
+          it "bumps the lock version on the row and the instance alike" do
+            expect(locked_app.secret_matches?(plain_secret)).to be(true)
+
+            expect(locked_app.lock_version).to eq(1)
+            expect(locked_app).not_to be_changed
+            expect(locked_class.find(locked_app.id).lock_version).to eq(1)
+          end
+
+          it "lets an unrelated unsaved change be saved afterwards" do
+            locked_app.name = "renamed but not saved"
+
+            expect(locked_app.secret_matches?(plain_secret)).to be(true)
+
+            expect { locked_app.save! }.not_to raise_error
+            expect(locked_class.find(locked_app.id).name).to eq("renamed but not saved")
+          end
+
+          it "does not upgrade past a version the row no longer holds" do
+            in_flight = locked_class.find(locked_app.id)
+            locked_app.update!(name: "bumped elsewhere")
+
+            expect(in_flight.secret_matches?(plain_secret)).to be(true)
+
+            expect(in_flight.secret).to eq(plain_secret)
+            expect(locked_class.find(locked_app.id).secret).to eq(plain_secret)
+            expect(locked_class.find(locked_app.id).lock_version).to eq(1)
+          end
+        end
+
+        # Row identity has to come from the configured primary key, not `id`.
+        context "when the primary key is not id" do
+          before do
+            ActiveRecord::Base.connection.create_table(:oauth_applications_keyed, id: false) do |t|
+              t.string :code, null: false, primary_key: true
+              t.string :name, null: false
+              t.string :uid, null: false
+              t.string :secret
+              t.text :redirect_uri
+              t.string :scopes, default: "", null: false
+              t.boolean :confidential, default: true, null: false
+              t.timestamps
+            end
+          end
+
+          after do
+            ActiveRecord::Base.connection.drop_table(:oauth_applications_keyed)
+          end
+
+          let(:keyed_class) do
+            Class.new(::ActiveRecord::Base) do
+              include Doorkeeper::Orm::ActiveRecord::Mixins::Application
+              self.table_name = "oauth_applications_keyed"
+              self.primary_key = "code"
+            end
+          end
+
+          let(:keyed_app) do
+            keyed_class.create!(code: "app-1", name: "KeyedApp", redirect_uri: "https://example.com").tap do |record|
+              record.update_column(:secret, plain_secret)
+            end
+          end
+
+          it "upgrades the row found by that key" do
+            expect(keyed_app.secret_matches?(plain_secret)).to be(true)
+
+            expect(keyed_class.find("app-1").secret)
+              .to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
+          end
+        end
+
+        # A primary key can also name several columns, which Active Record
+        # answers with as an array — supported since Rails 7.1.
+        context "when the primary key is composed of several columns",
+                if: ActiveRecord.version >= Gem::Version.new("7.1") do
+          before do
+            ActiveRecord::Base.connection.create_table(:oauth_applications_composite, id: false) do |t|
+              t.integer :shop_id, null: false
+              t.integer :seq, null: false
+              t.string :name, null: false
+              t.string :uid, null: false
+              t.string :secret
+              t.text :redirect_uri
+              t.string :scopes, default: "", null: false
+              t.boolean :confidential, default: true, null: false
+              t.timestamps
+            end
+          end
+
+          after do
+            ActiveRecord::Base.connection.drop_table(:oauth_applications_composite)
+          end
+
+          let(:composite_class) do
+            Class.new(::ActiveRecord::Base) do
+              include Doorkeeper::Orm::ActiveRecord::Mixins::Application
+              self.table_name = "oauth_applications_composite"
+              self.primary_key = %i[shop_id seq]
+            end
+          end
+
+          let(:composite_app) do
+            composite_class.create!(
+              shop_id: 1, seq: 2, name: "CompositeApp", redirect_uri: "https://example.com",
+            ).tap do |record|
+              record.update_column(:secret, plain_secret)
+            end
+          end
+
+          it "upgrades the row found by every column the key names" do
+            expect(composite_app.secret_matches?(plain_secret)).to be(true)
+
+            expect(composite_class.find([1, 2]).secret)
+              .to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
+          end
+        end
+      end
+
       it "performs the fallback upgrade through the primary database role" do
         # The upgrade writes during a lookup, which automatic role switching
         # may route to a read replica.


### PR DESCRIPTION
Split out of #1904 as offered [there](https://github.com/doorkeeper-gem/doorkeeper/pull/1904#issuecomment-5288370039) — this commit fixes a pre-existing race on `main` and is independent of the secret rotation feature that PR adds.

## The problem

When a fallback secret strategy is configured, `SecretStorable.find_by_fallback_token` re-stores a credential in the current format as soon as the fallback strategy matches it:

```ruby
def upgrade_fallback_value(instance, attr, plain_secret)
  upgraded = secret_strategy.store_secret(instance, attr, plain_secret)
  instance.update(attr => upgraded)
end
```

The upgrade is a write on what is otherwise a read path (finding a record by its secret), and it writes **by id alone**, from a value that was read before the comparison that decided to upgrade it. Nothing stops the row moving between the match and the write, and when it does, the matched value is written back over whatever replaced it.

Concretely, this races `#renew_secret`: an authentication that started before the renewal can finish after it and put the superseded secret back. The credential the application believes it has replaced keeps authenticating the client, and the one it just handed out is gone. The write has had this shape since fallback secrets were introduced in a00bcd1a (v5.1.0), so every release since is affected.

The window is narrow — it needs a fallback strategy configured, the column still holding a value in the fallback format, and a concurrent write in that moment — and it closes for good the first time an upgrade succeeds, since the stored value is no longer in the fallback format. It is not something an outside party can drive.

### Reproducing it

No threads needed — a stale instance is enough, because the read that decides the write happened when the instance was loaded:

```ruby
in_flight = Doorkeeper::Application.find(app.id)   # loaded with the old secret

app.renew_secret
app.save!
new_secret = app.plaintext_secret

in_flight.secret_matches?(plain_secret)            # => true, and it writes

app.reload
app.secret_matches?(new_secret)   # => false  (on main)
app.secret_matches?(plain_secret) # => true   (on main)
```

## The fix

Write only while the column still holds the value that matched:

```ruby
scope = where(id: instance.id, attr => matched)
```

Losing the race now means no upgrade rather than a stale write. The credential stays in the fallback format and is upgraded by whichever authentication comes next — which is the state it was already in a moment earlier, so nothing is lost by skipping it.

## What changes along with it

- **`#update` → a conditional `#update_all`.** `update_all` does not maintain timestamps, so `updated_at` is set explicitly where the model has it (applications; access tokens and grants have no such column). Validations no longer gate the upgrade, which I took as the right trade — the storage format of a secret is not something an unrelated invalid attribute should be able to hold back — and the write no longer carries along whatever else was pending on the instance.
- **ORM extensions.** This concern is included by the ORM extensions too, so the conditional write goes through a small `update_matched_rows` helper: `update_all` on an Active Record relation, `update` on a Sequel dataset. Both answer how many rows were written, which is the value the fix needs.
- **Dirty tracking.** Since the write goes past the instance, the columns it wrote are marked clean afterwards (`clear_attribute_changes`, guarded by `respond_to?` for ORMs without dirty tracking), and the in-memory assignment `store_secret` had already made is undone when the write finds the row moved. A caller that goes on to lock or reload the record is then not refused over a change that is either already persisted or was never made. Deliberately not a `reload`: this is nominally a read path, and a `reload` would discard every unrelated unsaved change the caller was holding.
- **Return value.** `upgrade_fallback_value` now documents a boolean — whether the stored value was upgraded. It previously returned whatever `#update` did, so this is the same shape.