### PR TITLE
Keep the api_only controller specs from resetting the controllers' coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ User-visible changes worth mentioning.
 
 ## main
 
-- [#1906] Internal: exempt `Doorkeeper::Config` from `Metrics/ClassLength` with a directive on the class itself instead of raising the cop's global ceiling, so adding a configuration option no longer trips the limit.
 - Fix: the `client_secret_basic` strategy now requires a `client_id` sent in the request body to name the same client as the `Authorization: Basic` header — the RFC 7521 §4.2 agreement check `private_key_jwt` already applies to an assertion's issuer. A request presenting Basic credentials for one client and a `client_id` for another was authenticated as the Basic client, silently discarding the other identity. A bare `client_id` is not a client authentication method of its own, so the RFC 6749 §2.3 multiple-methods check does not (and should not) count it.
+- [#1906] Internal: exempt `Doorkeeper::Config` from `Metrics/ClassLength` with a directive on the class itself instead of raising the cop's global ceiling, so adding a configuration option no longer trips the limit.
 - [#1907] Fix: a `resource` parameter no longer produces a 500 at the authorization endpoint when `resource_indicator_validator` is configured without the `doorkeeper:resource_indicators` migration. Such a request is now answered with `server_error`, as the token endpoint already did, and the missing migration is warned about at boot.
 - [#1909] Add Rails 8.1 to CI test matrix.
 - [#1910] Add opt-in `validate_client_before_resource_owner_authentication` configuration option: the authorization endpoint validates `client_id` and `redirect_uri` before authenticating the resource owner, so users are not sent through login for a request that can only fail.
 - [#1916] Fix broken Coveralls coverage reporting.
+- [#1918] The api_only controller specs no longer `load` the real controller sources, which detached the coverage of every other example that ran them and made the reported coverage depend on the random example order.
 - [#PR ID] Description of the change.
 
 ## 6.0.0.beta2

--- a/spec/requests/applications/api_only_spec.rb
+++ b/spec/requests/applications/api_only_spec.rb
@@ -8,9 +8,16 @@ require "spec_helper"
 # place, where `flash` exists. To exercise the real API-only hierarchy
 # in-process, these specs stub the controller constants with bare
 # ActionController::API subclasses and re-evaluate the real controller sources
-# into them (`load` reopens the stubbed constants, and their superclasses
-# match what `resolve_controller` returns while `api_only` is stubbed).
-# rspec-mocks restores the original controllers after each example.
+# into them (reopening the stubbed constants, whose superclasses match what
+# `resolve_controller` returns while `api_only` is stubbed). rspec-mocks
+# restores the original controllers after each example.
+#
+# The sources are evaluated under a file name of their own rather than
+# `load`ed. Coverage is recorded per file name and attached to the code as
+# compiled: `load` would compile the real file again, and every method the
+# other examples run — the ones of the original controllers — would keep
+# counting into an array the report no longer reads, so the controllers'
+# coverage would depend on which examples happened to run after this file.
 RSpec.describe "Doorkeeper::ApplicationsController in api_only mode", type: :request do
   before do
     allow(Doorkeeper.config).to receive_messages(
@@ -22,7 +29,8 @@ RSpec.describe "Doorkeeper::ApplicationsController in api_only mode", type: :req
     stub_const("Doorkeeper::ApplicationsController", Class.new(Doorkeeper::ApplicationController))
 
     %w[application_controller applications_controller].each do |file|
-      load Doorkeeper::Engine.root.join("app", "controllers", "doorkeeper", "#{file}.rb")
+      path = Doorkeeper::Engine.root.join("app", "controllers", "doorkeeper", "#{file}.rb").to_s
+      eval(File.read(path), TOPLEVEL_BINDING, "#{path} (api_only)") # rubocop:disable Security/Eval
     end
   end
 


### PR DESCRIPTION
Coveralls has started reporting per-job coverage today (#1915/#1916 follow-ups), and #1917 immediately got "Coverage decreased (-0.02%)" on a random subset of jobs — 2 of 20 on one push, 7 of 20 on the next, with the set of jobs changing each time — for a change that touches nothing near the lines in question.

## What is going on

The lines that flip are in `app/controllers/doorkeeper/applications_controller.rb`, and the cause is `spec/requests/applications/api_only_spec.rb` (mine, #1887): it re-evaluates the real controller sources into stubbed `ActionController::API` subclasses with `load`, in a `before` that runs for every example.

Ruby records coverage per file name and attaches the counters to the code *as compiled*. Each `load` compiles the file again and points the file's entry in the coverage result at a fresh array. The original controllers — the ones every other example runs — keep counting into the array the report no longer reads. So after this spec has run, nothing the original controllers do is reported any more, and the controllers' coverage depends on which examples happened to run after it. Locally, three seeds on `main` give three different sets of uncovered lines in that file; the total moves between 98.38% and 98.41%.

## The fix

Evaluate the sources under a file name of their own (`eval(File.read(path), TOPLEVEL_BINDING, "#{path} (api_only)")`) instead of `load`ing them. The stubbed constants are reopened exactly as before; the eval'd copy is not part of the report (eval'd code is not covered by default), and the original controllers keep their counters.

After the change, the suite's line coverage is identical on every seed tried (1, 3, 7), and about a percentage point higher than the best order used to report — 99.39% vs 98.41% on `main` — since the controllers' coverage is now counted in full.

No behaviour change in the specs themselves: same stubs, same examples, all green.
