### PR TITLE
Require Ruby >= 3.2 in the gemspec, matching the CI matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ User-visible changes worth mentioning.
 
 ## main
 
+- Require Ruby >= 3.2 in the gemspec, matching the CI matrix (3.2 / 3.3 / 3.4 / 4.0). Ruby 2.7, 3.0 and 3.1 have reached end-of-life.
 - Fix: the `client_secret_basic` strategy now requires a `client_id` sent in the request body to name the same client as the `Authorization: Basic` header — the RFC 7521 §4.2 agreement check `private_key_jwt` already applies to an assertion's issuer. A request presenting Basic credentials for one client and a `client_id` for another was authenticated as the Basic client, silently discarding the other identity. A bare `client_id` is not a client authentication method of its own, so the RFC 6749 §2.3 multiple-methods check does not (and should not) count it.
 - [#1906] Internal: exempt `Doorkeeper::Config` from `Metrics/ClassLength` with a directive on the class itself instead of raising the cop's global ceiling, so adding a configuration option no longer trips the limit.
 - [#1907] Fix: a `resource` parameter no longer produces a 500 at the authorization endpoint when `resource_indicator_validator` is configured without the `doorkeeper:resource_indicators` migration. Such a request is now answered with `server_error`, as the token endpoint already did, and the missing migration is warned about at boot.

--- a/doorkeeper.gemspec
+++ b/doorkeeper.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   }
 
   gem.add_dependency "railties", ">= 5"
-  gem.required_ruby_version = ">= 2.7"
+  gem.required_ruby_version = ">= 3.2"
 
   gem.add_development_dependency "appraisal"
   gem.add_development_dependency "capybara"


### PR DESCRIPTION
Since 37034516 updated the CI matrix to 3.2 / 3.3 / 3.4 / 4.0 (dropping 3.1 as EOL), the gemspec still has `required_ruby_version = ">= 2.7"`. This brings it in line with the matrix so the two stay in sync.

Ruby 2.7, 3.0 and 3.1 have all reached end-of-life, and 6.0.0 hasn't shipped yet, so a major version feels like a natural moment to tighten the floor. 3.2 is also the minimum Rails 8.0 requires.

>[!NOTE]
>
> ### Relation to #1837
> 
> I opened #1837 for the same line back in June and closed it myself once ruby-i18n/i18n#739 resolved the 3.1 breakage that motivated it. This time the reasoning is simpler — just aligning the gemspec with where the CI matrix already is after 37034516.
> 
> Happy to close this if you'd rather keep the wider bound — just wanted to flag the gap 😊

### Changes

- `doorkeeper.gemspec`: `required_ruby_version` `>= 2.7` → `>= 3.2`
- `CHANGELOG.md`: entry under `## main`

No CI or source changes — the matrix already reflects the new floor.

### Verification

```
$ bundle exec rake spec
1937 examples, 0 failures
```
