### PR TITLE
Fix the fallback secret upgrade race through an ORM write hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ User-visible changes worth mentioning.
 - [#1910] Add opt-in `validate_client_before_resource_owner_authentication` configuration option: the authorization endpoint validates `client_id` and `redirect_uri` before authenticating the resource owner, so users are not sent through login for a request that can only fail.
 - [#1916] Fix broken Coveralls coverage reporting.
 - [#1918] The api_only controller specs no longer `load` the real controller sources, which detached the coverage of every other example that ran them and made the reported coverage depend on the random example order.
+- [#1923] Fix: the fallback secret upgrade no longer writes the matched secret back over a value stored in the meantime, which could undo a concurrent `#renew_secret` and leave the superseded secret valid. Active Record writes the upgrade conditionally on the column still holding the value that matched; other ORMs can implement the new `write_upgraded_secret` hook. The Active Record write is a single `update_all` statement, so model callbacks and validations no longer run on this upgrade (timestamps and optimistic locking are still maintained).
 - [#PR ID] Description of the change.
 
 ## 6.0.0.beta2

--- a/lib/doorkeeper/models/concerns/secret_storable.rb
+++ b/lib/doorkeeper/models/concerns/secret_storable.rb
@@ -70,8 +70,9 @@ module Doorkeeper
           end
         end
 
-        # Allow implementations in ORMs to replace a plain
-        # value falling back to to avoid it remaining as plain text.
+        # Replaces a value found through the fallback strategy with its
+        # upgraded form, so it does not remain stored under the old strategy
+        # (e.g. as plain text).
         #
         # @param instance
         #   An instance of this model with a plain value token.
@@ -82,13 +83,54 @@ module Doorkeeper
         # @param plain_secret
         #   The plain secret to upgrade.
         #
+        # @return [Boolean]
+        #   Whether the stored value was upgraded.
+        #
         def upgrade_fallback_value(instance, attr, plain_secret)
+          # The value the fallback strategy matched against, read before
+          # `store_secret` assigns the upgraded one over it.
+          matched = instance.public_send(attr)
           upgraded = secret_strategy.store_secret(instance, attr, plain_secret)
 
-          # The upgrade is a write on what is otherwise a read path (finding a
-          # record by its secret), so it must reach the primary database when
-          # automatic role switching would route the surrounding request to a
-          # read replica.
+          return true if write_upgraded_secret(instance, attr, matched, upgraded)
+
+          # Nothing was written: put the instance back rather than leave it
+          # carrying a secret that was never stored.
+          instance.public_send(:"#{attr}=", matched)
+          false
+        end
+
+        # ORM hook: writes the upgraded value to storage and answers whether
+        # it was written.
+        #
+        # The upgrade is a write on what is otherwise a read path (finding a
+        # record by its secret), so the row can move between the match and
+        # this write — another request renewing the secret, or the
+        # application replacing it. An ORM can therefore make the write
+        # conditional on +attr+ still holding +matched+, answering false when
+        # it no longer does, as the Active Record implementation does
+        # (Doorkeeper::Orm::ActiveRecord::Mixins::SecretStorable). This
+        # default keeps the historical unconditional write for ORMs that have
+        # not implemented a conditional one.
+        #
+        # @param instance
+        #   The instance whose row to write, already carrying +upgraded+.
+        #
+        # @param attr
+        #   The secret attribute name being upgraded.
+        #
+        # @param matched
+        #   The stored value the fallback lookup matched.
+        #
+        # @param upgraded
+        #   The upgraded value to store.
+        #
+        # @return [Boolean]
+        #   Whether the value was written.
+        #
+        def write_upgraded_secret(instance, attr, _matched, upgraded)
+          # The write must reach the primary database when automatic role
+          # switching would route the surrounding request to a read replica.
           if respond_to?(:with_primary_role)
             with_primary_role { instance.update(attr => upgraded) }
           else

--- a/lib/doorkeeper/models/concerns/secret_storable.rb
+++ b/lib/doorkeeper/models/concerns/secret_storable.rb
@@ -96,8 +96,29 @@ module Doorkeeper
 
           # Nothing was written: put the instance back rather than leave it
           # carrying a secret that was never stored.
-          instance.public_send(:"#{attr}=", matched)
+          restore_matched_secret(instance, attr, matched)
           false
+        end
+
+        # ORM hook: puts +matched+ back on +instance+ after nothing was
+        # written. This default assigns through the attribute writer, which
+        # an ORM can bypass the way the Active Record implementation does:
+        # a custom writer can transform +matched+ on the way in, leaving the
+        # attribute dirty with a value the row never held, and a later save
+        # would write that over whatever replaced the matched secret — the
+        # stale write the conditional upgrade exists to prevent.
+        #
+        # @param instance
+        #   The instance to restore, still carrying the unwritten upgrade.
+        #
+        # @param attr
+        #   The secret attribute name being restored.
+        #
+        # @param matched
+        #   The stored value the fallback lookup matched.
+        #
+        def restore_matched_secret(instance, attr, matched)
+          instance.public_send(:"#{attr}=", matched)
         end
 
         # ORM hook: writes the upgraded value to storage and answers whether
@@ -123,7 +144,10 @@ module Doorkeeper
         #   The stored value the fallback lookup matched.
         #
         # @param upgraded
-        #   The upgraded value to store.
+        #   The upgraded value to store, as returned by the strategy. The
+        #   instance carries it too, assigned through the attribute writer —
+        #   an implementation that writes past the writer should persist the
+        #   value the writer left on the instance rather than this one.
         #
         # @return [Boolean]
         #   Whether the value was written.

--- a/lib/doorkeeper/orm/active_record.rb
+++ b/lib/doorkeeper/orm/active_record.rb
@@ -26,6 +26,7 @@ module Doorkeeper
         autoload :AccessGrant, "doorkeeper/orm/active_record/mixins/access_grant"
         autoload :AccessToken, "doorkeeper/orm/active_record/mixins/access_token"
         autoload :Application, "doorkeeper/orm/active_record/mixins/application"
+        autoload :SecretStorable, "doorkeeper/orm/active_record/mixins/secret_storable"
       end
 
       # Kept as a no-op so `Doorkeeper.run_orm_hooks` (and any plugin that

--- a/lib/doorkeeper/orm/active_record/mixins/access_grant.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/access_grant.rb
@@ -9,6 +9,7 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
       self.strict_loading_by_default = false if respond_to?(:strict_loading_by_default)
 
       include ::Doorkeeper::AccessGrantMixin
+      include ::Doorkeeper::Orm::ActiveRecord::Mixins::SecretStorable
       include ::Doorkeeper::Models::PolymorphicResourceOwner::ForAccessGrant
 
       belongs_to :application, class_name: Doorkeeper.config.application_class.to_s,

--- a/lib/doorkeeper/orm/active_record/mixins/access_token.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/access_token.rb
@@ -9,6 +9,7 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
       self.strict_loading_by_default = false if respond_to?(:strict_loading_by_default)
 
       include ::Doorkeeper::AccessTokenMixin
+      include ::Doorkeeper::Orm::ActiveRecord::Mixins::SecretStorable
       include ::Doorkeeper::Models::PolymorphicResourceOwner::ForAccessToken
 
       belongs_to :application, class_name: Doorkeeper.config.application_class.to_s,

--- a/lib/doorkeeper/orm/active_record/mixins/application.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/application.rb
@@ -9,6 +9,7 @@ module Doorkeeper::Orm::ActiveRecord::Mixins
       self.strict_loading_by_default = false if respond_to?(:strict_loading_by_default)
 
       include ::Doorkeeper::ApplicationMixin
+      include ::Doorkeeper::Orm::ActiveRecord::Mixins::SecretStorable
       # `enable_application_owner?` is read once, at parent-class autoload
       # time (#1831): with the feature off the model exposes no `:owner`
       # association — avoiding a misleading reflection on schemas that lack

--- a/lib/doorkeeper/orm/active_record/mixins/secret_storable.rb
+++ b/lib/doorkeeper/orm/active_record/mixins/secret_storable.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module Doorkeeper::Orm::ActiveRecord::Mixins
+  # Active Record implementation of the SecretStorable write hook: the
+  # fallback secret upgrade only writes while the column still holds the
+  # value the lookup matched, so losing a race against a concurrent write —
+  # another request renewing the secret, or the application replacing it —
+  # cannot put the superseded secret back.
+  #
+  # The write is a single conditional statement, so unlike the historical
+  # `#update` it runs no model callbacks: what it writes is the value the
+  # lookup already matched, re-encoded into the current storage format.
+  module SecretStorable
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Writes the upgraded secret over +matched+ on +instance+'s row,
+      # conditional on +attr+ still holding +matched+, and answers whether
+      # the row was written.
+      def write_upgraded_secret(instance, attr, matched, _upgraded)
+        # The value written is the one `store_secret` left on the instance:
+        # it assigns through the attribute writer, which `#update` then ran
+        # again on assignment, so a custom writer override reached storage.
+        # `update_all` does not go through writers, so writing the strategy's
+        # pre-writer return value would both skip the override and leave the
+        # instance out of step with its row.
+        upgraded = instance.read_attribute(attr)
+
+        # `update_all` does not maintain timestamps, which `#update` did —
+        # see `upgrade_timestamps` for the terms it did that on.
+        changes = { attr => upgraded }.merge!(upgrade_timestamps(instance))
+
+        scope = where(primary_key_conditions(instance).merge(attr => matched))
+
+        # Under optimistic locking, `update_all` bumps the lock column on
+        # its own, which would leave the instance stale and have its next
+        # `save` refused. Write the bump explicitly instead — `update_all`
+        # leaves the column alone when it is among the changes — so that the
+        # instance can be brought in step below, and make the write
+        # conditional on the version too: bumping from a version the row no
+        # longer holds would set it backwards.
+        if locking_enabled?
+          version = instance.public_send(locking_column) || 0
+          scope = scope.where(locking_column => version)
+          changes[locking_column] = version + 1
+        end
+
+        # The write must reach the primary database when automatic role
+        # switching would route the surrounding request to a read replica.
+        written = with_primary_role { scope.update_all(changes) }
+        return false if written.zero?
+
+        sync_upgraded_instance(instance, changes)
+        true
+      end
+
+      # Restores +matched+ on the attribute directly, past any custom
+      # writer: re-running a writer that transforms its input would leave
+      # the attribute dirty with a value the row never held, and a later
+      # save would write that over whatever replaced the matched secret.
+      # The change is then cleared — the attribute holds what it held when
+      # the row was read, so there is nothing left to save.
+      def restore_matched_secret(instance, attr, matched)
+        instance.write_attribute(attr, matched)
+        instance.clear_attribute_changes([attr])
+      end
+
+      private
+
+      # The columns identifying +instance+'s row and the values it holds in
+      # them, taken from the configured primary key: it may be named
+      # something other than `id`, or be composed of several columns. A
+      # model with no primary key at all is left to the value condition
+      # alone, which reaches every row still holding the matched secret.
+      def primary_key_conditions(instance)
+        # Spelled without `index_with`, which the gemspec's Rails floor
+        # predates.
+        Array(primary_key).to_h { |key| [key, instance.public_send(key)] } # rubocop:disable Rails/IndexWith
+      end
+
+      # The timestamps `#update` maintained for this write, derived on its
+      # terms through Active Record's own helpers: the model's actual update
+      # timestamp columns (`updated_on` and aliased names as well as
+      # `updated_at`), the connection's timezone, and `record_timestamps`
+      # read on the instance, where a model that stamps its own timestamps
+      # can turn it off per record. A timestamp the caller had already
+      # changed is left out entirely, as `#update` leaves it to the caller —
+      # stamping it and then marking it clean below would silently drop that
+      # pending change.
+      def upgrade_timestamps(instance)
+        return {} unless instance.record_timestamps
+
+        touch_attributes_with_time.reject do |column, _time|
+          instance.will_save_change_to_attribute?(column)
+        end
+      end
+
+      # The row was written past the instance, so bring it back in step:
+      # left as it is, a caller that later saves or locks the record is
+      # refused over a change that is already persisted. Only what was
+      # written is marked clean — a `reload` would also discard every
+      # unrelated unsaved change the caller had on the instance, and this is
+      # nominally a read path.
+      def sync_upgraded_instance(instance, changes)
+        timestamp_attributes_for_update_in_model.each do |column|
+          instance.public_send(:"#{column}=", changes[column]) if changes.key?(column)
+        end
+        instance.public_send(:"#{locking_column}=", changes[locking_column]) if locking_enabled?
+        instance.clear_attribute_changes(changes.keys)
+      end
+    end
+  end
+end

--- a/spec/lib/models/secret_storable_spec.rb
+++ b/spec/lib/models/secret_storable_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Doorkeeper::Models::SecretStorable do
         raise "stub this"
       end
 
-      def update_column(*)
+      def update(*)
         raise "stub this"
       end
 
@@ -70,32 +70,83 @@ RSpec.describe Doorkeeper::Models::SecretStorable do
       end
 
       context "when resource is defined" do
-        let(:resource) { double("Token model") }
+        # A real object rather than a double: what matters is the state the
+        # resource is left in, not the messages it received.
+        let(:resource) do
+          Class.new do
+            attr_accessor :attr
+            attr_reader :updates
 
-        it "calls the strategy for lookup" do
-          expect(clazz)
+            def initialize
+              @attr = "old value"
+              @updates = []
+            end
+
+            def update(changes)
+              @updates << changes
+              true
+            end
+          end.new
+        end
+
+        before do
+          allow(clazz)
             .to receive(:find_by)
             .with("attr" => "fallback")
             .and_return(resource)
 
-          expect(fallback)
+          allow(fallback)
             .to receive(:transform_secret)
             .with("input")
             .and_return("fallback")
 
-          # store_secret will call the resource
-          expect(resource)
-            .to receive(:attr=)
-            .with("new value")
-
           # It will upgrade the secret automatically using the current strategy
-          expect(strategy)
+          allow(strategy)
             .to receive(:transform_secret)
             .with("input")
             .and_return("new value")
+        end
 
-          expect(resource).to receive(:update).with("attr" => "new value")
+        it "upgrades the stored value through the instance, as it always has" do
           expect(result).to eq resource
+          expect(resource.attr).to eq "new value"
+          expect(resource.updates).to eq [{ "attr" => "new value" }]
+        end
+
+        it "routes the write through the primary database role when the class knows one" do
+          roles = []
+          clazz.define_singleton_method(:with_primary_role) do |&block|
+            roles << :writing
+            block.call
+          end
+
+          expect(result).to eq resource
+          expect(roles).to eq [:writing]
+          expect(resource.updates).to eq [{ "attr" => "new value" }]
+        end
+
+        # The write itself is an ORM hook, so an ORM able to write
+        # conditionally can refuse when the row has moved on from the value
+        # the lookup matched.
+        context "when the ORM implements the write hook" do
+          it "hands the hook the value that matched, read before the upgrade was assigned" do
+            received = nil
+            clazz.define_singleton_method(:write_upgraded_secret) do |instance, attr, matched, upgraded|
+              received = [instance, attr, matched, upgraded]
+              true
+            end
+
+            expect(result).to eq resource
+            expect(received).to eq [resource, "attr", "old value", "new value"]
+            expect(resource.attr).to eq "new value"
+          end
+
+          it "puts the instance back when the hook answers that nothing was written" do
+            clazz.define_singleton_method(:write_upgraded_secret) { |*| false }
+
+            expect(result).to eq resource
+            expect(resource.attr).to eq "old value"
+          end
         end
       end
 

--- a/spec/models/doorkeeper/application_spec.rb
+++ b/spec/models/doorkeeper/application_spec.rb
@@ -336,6 +336,401 @@ RSpec.describe Doorkeeper::Application do
         expect(app.secret).to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
       end
 
+      # The conditional write below is implemented by the Active Record
+      # mixin; other ORMs keep their historical unconditional write until
+      # they implement the hook.
+      if DOORKEEPER_ORM == :active_record
+        # The upgrade is a write on a read path, decided from a value read
+        # before the comparison, so the row can move underneath it.
+        it "does not write the matched secret back over one replaced meanwhile" do
+          in_flight = described_class.find(app.id)
+
+          app.renew_secret
+          app.save!
+          new_secret = app.plaintext_secret
+
+          expect(in_flight.secret_matches?(plain_secret)).to be(true)
+
+          app.reload
+          expect(app.secret_matches?(new_secret)).to be(true)
+          expect(app.secret_matches?(plain_secret)).to be(false)
+        end
+
+        it "leaves the instance clean when the upgrade finds the row moved" do
+          in_flight = described_class.find(app.id)
+          app.update_column(:secret, Doorkeeper::SecretStoring::Sha256Hash.transform_secret("elsewhere"))
+
+          in_flight.secret_matches?(plain_secret)
+
+          expect(in_flight).not_to be_changed
+          expect(in_flight.secret).to eq(plain_secret)
+        end
+
+        it "leaves the instance clean once the upgrade is written" do
+          expect(app.secret_matches?(plain_secret)).to be(true)
+
+          expect(app).not_to be_changed
+        end
+
+        # The upgrade happens on a read path, so it must not take unrelated
+        # unsaved changes with it the way a `reload` would.
+        it "keeps unrelated unsaved changes once the upgrade is written" do
+          app.name = "renamed but not saved"
+
+          expect(app.secret_matches?(plain_secret)).to be(true)
+
+          expect(app.name).to eq("renamed but not saved")
+          expect(app.changed_attributes.keys).to eq(%w[name])
+          expect(app.secret).to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
+        end
+
+        # `#update` deferred to `record_timestamps`, so the write that
+        # replaced it has to stamp `updated_at` on the same terms.
+        it "leaves updated_at alone for a model that stamps its own timestamps" do
+          stamped_at = app.reload.updated_at
+          allow(described_class).to receive(:record_timestamps).and_return(false)
+
+          expect(app.secret_matches?(plain_secret)).to be(true)
+
+          app.reload
+          expect(app.secret).to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
+          expect(app.updated_at).to eq(stamped_at)
+        end
+
+        # `record_timestamps` can also be turned off on the instance alone,
+        # which `#update` honored.
+        it "leaves updated_at alone for an instance that turned its timestamps off" do
+          stamped_at = app.reload.updated_at
+          app.record_timestamps = false
+
+          expect(app.secret_matches?(plain_secret)).to be(true)
+
+          app.reload
+          expect(app.secret).to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
+          expect(app.updated_at).to eq(stamped_at)
+        end
+
+        # `#update` leaves a timestamp the caller had already changed to the
+        # caller, so the upgrade neither writes over it nor marks it clean.
+        it "keeps a pending updated_at change the caller had made" do
+          stamped_at = app.reload.updated_at
+          pending_at = stamped_at + 1.hour
+          app.updated_at = pending_at
+
+          expect(app.secret_matches?(plain_secret)).to be(true)
+
+          expect(app.updated_at).to eq(pending_at)
+          expect(app.changed_attributes.keys).to eq(%w[updated_at])
+          expect(described_class.find(app.id).updated_at).to eq(stamped_at)
+          expect(described_class.find(app.id).secret)
+            .to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
+        end
+
+        # `#update` derived the columns to stamp from the model, so a model
+        # keeping its timestamp in `updated_on` is stamped the same way.
+        context "when the model keeps its timestamp in updated_on" do
+          before do
+            ActiveRecord::Base.connection.create_table(:oauth_applications_on) do |t|
+              t.string :name, null: false
+              t.string :uid, null: false
+              t.string :secret
+              t.text :redirect_uri
+              t.string :scopes, default: "", null: false
+              t.boolean :confidential, default: true, null: false
+              t.datetime :updated_on
+            end
+          end
+
+          after do
+            ActiveRecord::Base.connection.drop_table(:oauth_applications_on)
+          end
+
+          let(:on_class) do
+            Class.new(::ActiveRecord::Base) do
+              include Doorkeeper::Orm::ActiveRecord::Mixins::Application
+              self.table_name = "oauth_applications_on"
+            end
+          end
+
+          let(:on_app) do
+            on_class.create!(name: "OnApp", redirect_uri: "https://example.com").tap do |record|
+              record.update_column(:secret, plain_secret)
+              record.update_column(:updated_on, 1.day.ago)
+            end
+          end
+
+          it "stamps updated_on and brings the instance in step" do
+            stamped_on = on_app.updated_on
+
+            expect(on_app.secret_matches?(plain_secret)).to be(true)
+
+            expect(on_app.updated_on).to be > stamped_on
+            expect(on_app).not_to be_changed
+            expect(on_class.find(on_app.id).updated_on).to eq(on_app.updated_on)
+          end
+        end
+
+        # `#update` assigned the upgraded value, running a custom attribute
+        # writer override; the conditional write has to persist what the
+        # writer left on the instance, not the strategy's pre-writer value.
+        context "when the model overrides the secret writer" do
+          before do
+            ActiveRecord::Base.connection.create_table(:oauth_applications_writer) do |t|
+              t.string :name, null: false
+              t.string :uid, null: false
+              t.string :secret
+              t.text :redirect_uri
+              t.string :scopes, default: "", null: false
+              t.boolean :confidential, default: true, null: false
+              t.timestamps
+            end
+          end
+
+          after do
+            ActiveRecord::Base.connection.drop_table(:oauth_applications_writer)
+          end
+
+          let(:writer_class) do
+            Class.new(::ActiveRecord::Base) do
+              include Doorkeeper::Orm::ActiveRecord::Mixins::Application
+              self.table_name = "oauth_applications_writer"
+
+              def secret=(value)
+                super(value && "wrapped-#{value}")
+              end
+            end
+          end
+
+          let(:writer_app) do
+            writer_class.create!(name: "WriterApp", redirect_uri: "https://example.com").tap do |record|
+              record.update_column(:secret, plain_secret)
+            end
+          end
+
+          it "persists the value the writer stored, in step with the instance" do
+            expect(writer_app.secret_matches?(plain_secret)).to be(true)
+
+            stored = writer_class.find(writer_app.id).read_attribute(:secret)
+            expect(stored).to eq("wrapped-#{Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret)}")
+            expect(writer_app.read_attribute(:secret)).to eq(stored)
+            expect(writer_app).not_to be_changed
+          end
+
+          # A lost race must not leave the writer's transformation of the
+          # matched value dirty on the instance — a later save would write
+          # it over the secret that replaced the matched one.
+          it "restores the matched value without re-running the writer on a lost race" do
+            in_flight = writer_class.find(writer_app.id)
+            writer_class.where(id: writer_app.id).update_all(secret: "renewed elsewhere")
+
+            expect(in_flight.secret_matches?(plain_secret)).to be(true)
+
+            expect(in_flight).not_to be_changed
+            expect(in_flight.read_attribute(:secret)).to eq(plain_secret)
+
+            in_flight.name = "still saveable"
+            in_flight.save!
+            expect(writer_class.find(writer_app.id).read_attribute(:secret)).to eq("renewed elsewhere")
+          end
+        end
+
+        # A model with no primary key is documented to be left to the value
+        # condition alone: the write reaches every row still holding the
+        # matched secret.
+        context "when the model has no primary key" do
+          before do
+            ActiveRecord::Base.connection.create_table(:oauth_applications_nopk, id: false) do |t|
+              t.string :name, null: false
+              t.string :uid, null: false
+              t.string :secret
+              t.text :redirect_uri
+              t.string :scopes, default: "", null: false
+              t.boolean :confidential, default: true, null: false
+              t.timestamps
+            end
+          end
+
+          after do
+            ActiveRecord::Base.connection.drop_table(:oauth_applications_nopk)
+          end
+
+          let(:nopk_class) do
+            Class.new(::ActiveRecord::Base) do
+              include Doorkeeper::Orm::ActiveRecord::Mixins::Application
+              self.table_name = "oauth_applications_nopk"
+              self.primary_key = nil
+            end
+          end
+
+          it "upgrades every row still holding the matched secret" do
+            nopk_class.create!(name: "NoPkOne", redirect_uri: "https://example.com")
+            nopk_class.create!(name: "NoPkTwo", redirect_uri: "https://example.com")
+            nopk_class.update_all(secret: plain_secret, updated_at: 1.day.ago)
+
+            record = nopk_class.find_by(name: "NoPkOne")
+            stamped_at = record.updated_at
+
+            expect(record.secret_matches?(plain_secret)).to be(true)
+
+            hashed = Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret)
+            expect(nopk_class.where(secret: hashed).count).to eq(2)
+            expect(record).not_to be_changed
+            expect(record.read_attribute(:secret)).to eq(hashed)
+            expect(nopk_class.find_by(name: "NoPkTwo").updated_at).to be > stamped_at
+          end
+        end
+
+        # The conditional write is an `update_all`, which bumps an optimistic
+        # locking column on its own and would leave the instance one version
+        # behind — refused on its next save over a change already persisted.
+        context "when the schema has an optimistic locking column" do
+          before do
+            ActiveRecord::Base.connection.create_table(:oauth_applications_locked) do |t|
+              t.string :name, null: false
+              t.string :uid, null: false
+              t.string :secret
+              t.text :redirect_uri
+              t.string :scopes, default: "", null: false
+              t.boolean :confidential, default: true, null: false
+              t.integer :lock_version, default: 0, null: false
+              t.timestamps
+            end
+          end
+
+          after do
+            ActiveRecord::Base.connection.drop_table(:oauth_applications_locked)
+          end
+
+          let(:locked_class) do
+            Class.new(::ActiveRecord::Base) do
+              include Doorkeeper::Orm::ActiveRecord::Mixins::Application
+              self.table_name = "oauth_applications_locked"
+            end
+          end
+
+          let(:locked_app) do
+            locked_class.create!(name: "LockedApp", redirect_uri: "https://example.com").tap do |record|
+              record.update_column(:secret, plain_secret)
+            end
+          end
+
+          it "bumps the lock version on the row and the instance alike" do
+            expect(locked_app.secret_matches?(plain_secret)).to be(true)
+
+            expect(locked_app.lock_version).to eq(1)
+            expect(locked_app).not_to be_changed
+            expect(locked_class.find(locked_app.id).lock_version).to eq(1)
+          end
+
+          it "lets an unrelated unsaved change be saved afterwards" do
+            locked_app.name = "renamed but not saved"
+
+            expect(locked_app.secret_matches?(plain_secret)).to be(true)
+
+            expect { locked_app.save! }.not_to raise_error
+            expect(locked_class.find(locked_app.id).name).to eq("renamed but not saved")
+          end
+
+          it "does not upgrade past a version the row no longer holds" do
+            in_flight = locked_class.find(locked_app.id)
+            locked_app.update!(name: "bumped elsewhere")
+
+            expect(in_flight.secret_matches?(plain_secret)).to be(true)
+
+            expect(in_flight.secret).to eq(plain_secret)
+            expect(locked_class.find(locked_app.id).secret).to eq(plain_secret)
+            expect(locked_class.find(locked_app.id).lock_version).to eq(1)
+          end
+        end
+
+        # Row identity has to come from the configured primary key, not `id`.
+        context "when the primary key is not id" do
+          before do
+            ActiveRecord::Base.connection.create_table(:oauth_applications_keyed, id: false) do |t|
+              t.string :code, null: false, primary_key: true
+              t.string :name, null: false
+              t.string :uid, null: false
+              t.string :secret
+              t.text :redirect_uri
+              t.string :scopes, default: "", null: false
+              t.boolean :confidential, default: true, null: false
+              t.timestamps
+            end
+          end
+
+          after do
+            ActiveRecord::Base.connection.drop_table(:oauth_applications_keyed)
+          end
+
+          let(:keyed_class) do
+            Class.new(::ActiveRecord::Base) do
+              include Doorkeeper::Orm::ActiveRecord::Mixins::Application
+              self.table_name = "oauth_applications_keyed"
+              self.primary_key = "code"
+            end
+          end
+
+          let(:keyed_app) do
+            keyed_class.create!(code: "app-1", name: "KeyedApp", redirect_uri: "https://example.com").tap do |record|
+              record.update_column(:secret, plain_secret)
+            end
+          end
+
+          it "upgrades the row found by that key" do
+            expect(keyed_app.secret_matches?(plain_secret)).to be(true)
+
+            expect(keyed_class.find("app-1").secret)
+              .to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
+          end
+        end
+
+        # A primary key can also name several columns, which Active Record
+        # answers with as an array — supported since Rails 7.1.
+        context "when the primary key is composed of several columns",
+                if: ActiveRecord.version >= Gem::Version.new("7.1") do
+          before do
+            ActiveRecord::Base.connection.create_table(:oauth_applications_composite, id: false) do |t|
+              t.integer :shop_id, null: false
+              t.integer :seq, null: false
+              t.string :name, null: false
+              t.string :uid, null: false
+              t.string :secret
+              t.text :redirect_uri
+              t.string :scopes, default: "", null: false
+              t.boolean :confidential, default: true, null: false
+              t.timestamps
+            end
+          end
+
+          after do
+            ActiveRecord::Base.connection.drop_table(:oauth_applications_composite)
+          end
+
+          let(:composite_class) do
+            Class.new(::ActiveRecord::Base) do
+              include Doorkeeper::Orm::ActiveRecord::Mixins::Application
+              self.table_name = "oauth_applications_composite"
+              self.primary_key = %i[shop_id seq]
+            end
+          end
+
+          let(:composite_app) do
+            composite_class.create!(
+              shop_id: 1, seq: 2, name: "CompositeApp", redirect_uri: "https://example.com",
+            ).tap do |record|
+              record.update_column(:secret, plain_secret)
+            end
+          end
+
+          it "upgrades the row found by every column the key names" do
+            expect(composite_app.secret_matches?(plain_secret)).to be(true)
+
+            expect(composite_class.find([1, 2]).secret)
+              .to eq(Doorkeeper::SecretStoring::Sha256Hash.transform_secret(plain_secret))
+          end
+        end
+      end
+
       it "performs the fallback upgrade through the primary database role" do
         # The upgrade writes during a lookup, which automatic role switching
         # may route to a read replica.


### PR DESCRIPTION
### Summary

Supersedes #1917, restructured per the review feedback there: the shared concern no longer tries to absorb every ORM's way of writing conditionally.

The bug is unchanged from #1917. `upgrade_fallback_value` writes the upgraded secret by id alone, from a value read before the comparison that decided to upgrade it. The write sits on what is otherwise a read path, so the row can move in between — most notably racing `#renew_secret`: an authentication that started before the renewal can finish after it and put the superseded secret back, leaving a credential the application believes it has replaced still able to authenticate the client, and the one it just handed out gone. Pre-existing since fallback secrets were introduced in a00bcd1a (v5.1.0).

### Structure

- `Doorkeeper::Models::SecretStorable` keeps only what every ORM shares: read the matched value before `store_secret` assigns the upgraded one over it, hand both to a single hook — `write_upgraded_secret(instance, attr, matched, upgraded)` — and put the instance back when the hook answers that nothing was written. The default implementation of the hook is the historical unconditional `#update`, so the ORM extensions (doorkeeper-mongodb, doorkeeper-sequel) behave exactly as they do on every released version until they implement a conditional write in their own terms.
- `Doorkeeper::Orm::ActiveRecord::Mixins::SecretStorable` (new) implements the conditional write for the three Active Record models, relying on what Active Record guarantees instead of feature-sniffing for it: `update_all` answering a row count, the configured `primary_key` (scalar, composite, or absent), `record_timestamps`, optimistic locking, `clear_attribute_changes`, `with_primary_role`.

### Behaviour (Active Record)

- The upgrade writes only while the column still holds the value that matched. Losing the race means no upgrade rather than a stale write: the credential stays in the fallback format and is upgraded by whichever authentication comes next.
- Row identity comes from every column the configured primary key names; a model with no primary key is left to the value condition alone.
- `update_all` does not maintain timestamps, so `updated_at` is stamped explicitly, deferring to `record_timestamps` the way `#update` did.
- Under optimistic locking the version joins the condition and is bumped explicitly, and the instance is brought in step afterwards, so a subsequent save is not refused over a change that is already persisted.
- The lookup still returns the resource either way — the fallback value did match at read time — but a lost race leaves the instance holding the value that is actually stored, with unrelated unsaved changes intact (no `reload`).

Three deliberate behaviour notes: validations no longer gate the upgrade on this path (the storage format of a secret should not be held back by an unrelated invalid attribute), the write no longer carries along other pending changes on the instance (both same as #1917), and model callbacks do not run on the upgrade write — it is a single conditional statement, and what it writes is the value the lookup already matched, re-encoded into the current storage format.