### PR TITLE
Build the private_key_jwt audience only from the server's own identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ User-visible changes worth mentioning.
 - [#1916] Fix broken Coveralls coverage reporting.
 - [#1918] The api_only controller specs no longer `load` the real controller sources, which detached the coverage of every other example that ran them and made the reported coverage depend on the random example order.
 - [#1923] Fix: the fallback secret upgrade no longer writes the matched secret back over a value stored in the meantime, which could undo a concurrent `#renew_secret` and leave the superseded secret valid. Active Record writes the upgrade conditionally on the column still holding the value that matched; other ORMs can implement the new `write_upgraded_secret` hook. The Active Record write is a single `update_all` statement, so model callbacks and validations no longer run on this upgrade (timestamps and optimistic locking are still maintained).
+- **[BREAKING]** Fix: `private_key_jwt` client authentication no longer accepts an audience derived from the request's `Host` header, which let a client assertion minted for another authorization server be replayed here. A server that configures neither `issuer` nor Rails' `default_url_options[:host]` now has no acceptable audience and refuses every assertion, and is warned about it at boot.
 - [#PR ID] Description of the change.
 
 ## 6.0.0.beta2

--- a/lib/doorkeeper/config/validations.rb
+++ b/lib/doorkeeper/config/validations.rb
@@ -10,6 +10,7 @@ module Doorkeeper
       def validate!
         validate_client_authentication_conflict
         validate_client_authentication_registered
+        validate_private_key_jwt_identity
         validate_reuse_access_token_value
         validate_token_reuse_limit
         validate_secret_strategies
@@ -67,6 +68,33 @@ module Doorkeeper
           "(client_authentication resolved to an empty set). All client authentication " \
           "will fail. Configure at least one registered method, e.g. " \
           "client_authentication #{Doorkeeper::ClientAuthentication::DEFAULT_METHODS.inspect}.",
+        )
+      end
+
+      # Warn when private_key_jwt client authentication is enabled on a server
+      # that identifies itself nowhere. An assertion's audience is what keeps
+      # it from being replayed at another authorization server, so it is only
+      # ever checked against the configured +issuer+ or Rails'
+      # +default_url_options+ - never against the request's Host header, which
+      # the client controls. With neither configured there is no acceptable
+      # audience and every assertion is refused, so make that loud at boot
+      # rather than leave it to be discovered request by request.
+      def validate_private_key_jwt_identity
+        # The deprecated client_credentials option only maps onto shared-secret
+        # methods, so a configuration using it alone never enables this one.
+        return if instance_variable_defined?(:@client_credentials_methods) &&
+                  !instance_variable_defined?(:@client_authentication)
+        return unless client_authentication.map(&:to_s).include?("private_key_jwt")
+        return if issuer.present?
+
+        url_options = ::Rails.application&.routes&.default_url_options || {}
+        return if url_options[:host].present?
+
+        ::Rails.logger.error(
+          "[DOORKEEPER] private_key_jwt client authentication is enabled, but the server " \
+          "identifies itself nowhere, so no audience is acceptable and every client " \
+          "assertion will be refused. Configure issuer, or " \
+          "Rails.application.routes.default_url_options[:host].",
         )
       end
 

--- a/lib/doorkeeper/oauth/client_authentication/private_key_jwt.rb
+++ b/lib/doorkeeper/oauth/client_authentication/private_key_jwt.rb
@@ -68,7 +68,13 @@ module Doorkeeper
           jwk_set = KeyResolver.jwk_set_for(application)
           return unless jwk_set
 
-          claims = verified_claims(assertion, client_id, jwk_set, request)
+          # A server that identifies itself nowhere has no audience to check
+          # an assertion against, and aud is the only claim that ties one to
+          # this server rather than to another one.
+          audiences = acceptable_audiences(request)
+          return if audiences.empty?
+
+          claims = verified_claims(assertion, client_id, jwk_set, audiences)
           return unless claims
           return unless replay_guard.first_use?(
             "#{client_id}:#{claims["jti"]}",
@@ -104,7 +110,7 @@ module Doorkeeper
         end
         private_class_method :unverified_client_id
 
-        def self.verified_claims(assertion, client_id, jwk_set, request)
+        def self.verified_claims(assertion, client_id, jwk_set, audiences)
           claims, = ::JWT.decode(
             assertion,
             nil,
@@ -116,7 +122,7 @@ module Doorkeeper
             verify_iss: true,
             sub: client_id,
             verify_sub: true,
-            aud: acceptable_audiences(request),
+            aud: audiences,
             verify_aud: true,
             # Passed explicitly so a host application that globally disabled
             # expiration checking for its own tokens (JWT.configuration.decode)
@@ -152,29 +158,25 @@ module Doorkeeper
         # token endpoint URL is accepted at the revocation and introspection
         # endpoints too, not just at the endpoint being called.
         #
-        # The endpoint URLs are built from the server's own configured
+        # Every acceptable value is built from the server's own configured
         # identity, never from the request: aud is what keeps an assertion
         # minted for another authorization server from being replayed here, so
-        # deriving it from the client-supplied Host header would defeat its
-        # purpose on any deployment that does not filter hosts. Only a server
-        # that identifies itself nowhere falls back to the request, which is
-        # how MetadataResponse derives its issuer as well.
+        # deriving it from the client-supplied Host header would let whoever
+        # sends the assertion choose the audience it is checked against. A
+        # server that identifies itself nowhere therefore accepts no audience
+        # at all, and is warned about that at boot.
         def self.acceptable_audiences(request)
-          options = server_url_options(request)
+          audiences = [Doorkeeper.config.issuer.presence]
+          options = configured_url_options
 
-          [
-            Doorkeeper.config.issuer.presence,
-            "#{base_url(options)}#{request.path}",
-            token_endpoint_url(options),
-          ].compact.uniq
+          if options
+            audiences << "#{base_url(options)}#{request.path}"
+            audiences << token_endpoint_url(options)
+          end
+
+          audiences.compact.uniq
         end
         private_class_method :acceptable_audiences
-
-        def self.server_url_options(request)
-          configured_url_options ||
-            { protocol: request.protocol, host: request.host, port: request.optional_port }
-        end
-        private_class_method :server_url_options
 
         # An explicitly configured canonical host wins; failing that, the
         # issuer, when it is an absolute URL (Doorkeeper allows any string).

--- a/lib/generators/doorkeeper/templates/initializer.rb
+++ b/lib/generators/doorkeeper/templates/initializer.rb
@@ -333,9 +333,11 @@ Doorkeeper.configure do
   # private_key_jwt_jwks_cache Doorkeeper::DocumentCache.new(ttl: 300)
   #
   # The accepted audiences are built from your `issuer` or from Rails'
-  # `default_url_options`; set at least one of them, otherwise Doorkeeper has
-  # nothing but the request's Host header to identify itself with and the
-  # audience check cannot tell your server apart from another one.
+  # `default_url_options`, never from the request's Host header - the audience
+  # is what tells your server apart from another one, so it cannot come from a
+  # value the caller controls. Set at least one of them: with neither
+  # configured no audience is acceptable and every assertion is refused
+  # (Doorkeeper says so in the log at boot).
   #
   # A client's `jwks_uri` is fetched with a hardened HTTP client (HTTPS
   # only, no redirects, hosts resolving to RFC 6890 special-use addresses

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -514,6 +514,62 @@ RSpec.describe Doorkeeper::Config do
     end
   end
 
+  describe "private_key_jwt server identity" do
+    # The audience of a client assertion is built from the server's own
+    # identity, so with none configured no audience is acceptable and the
+    # method authenticates nobody. That is a deployment mistake worth
+    # surfacing at boot rather than one request at a time.
+    it "logs an error when private_key_jwt is enabled and the server names itself nowhere" do
+      expect(Rails.logger).to receive(:error).with(
+        /private_key_jwt client authentication is enabled, but the server identifies itself nowhere/,
+      )
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        client_authentication %i[client_secret_basic private_key_jwt]
+      end
+    end
+
+    it "stays quiet when an issuer identifies the server" do
+      expect(Rails.logger).not_to receive(:error).with(/identifies itself nowhere/)
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        client_authentication %i[client_secret_basic private_key_jwt]
+        issuer "https://as.example.com"
+      end
+    end
+
+    it "stays quiet when Rails' default_url_options identifies the server" do
+      allow(Rails.application.routes).to receive(:default_url_options).and_return(host: "as.example.com")
+      expect(Rails.logger).not_to receive(:error).with(/identifies itself nowhere/)
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        client_authentication %i[client_secret_basic private_key_jwt]
+      end
+    end
+
+    it "stays quiet when private_key_jwt is not enabled" do
+      expect(Rails.logger).not_to receive(:error).with(/identifies itself nowhere/)
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        client_authentication %i[client_secret_basic]
+      end
+    end
+
+    it "stays quiet for a legacy client_credentials configuration" do
+      allow(Kernel).to receive(:warn)
+      expect(Rails.logger).not_to receive(:error).with(/identifies itself nowhere/)
+
+      Doorkeeper.configure do
+        orm DOORKEEPER_ORM
+        client_credentials :from_basic
+      end
+    end
+  end
+
   describe "client_authentication_methods" do
     it "warns at configure time and uses client_authentication when both options are set" do
       allow(Kernel).to receive(:warn)

--- a/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
+++ b/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
@@ -164,13 +164,77 @@ RSpec.describe Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt do
     context "when the server identifies itself nowhere" do
       before { config_is_set(:issuer, nil) }
 
-      it "falls back to the request URL as audience" do
+      # Falling back to the request would let whoever sends the assertion
+      # choose the audience it is checked against, so an assertion minted for
+      # another authorization server could be replayed here behind a forwarded
+      # Host header. With no identity of its own the server accepts no
+      # audience at all instead.
+      it "refuses the assertion rather than falling back to the request URL" do
         request = request_with(build_assertion)
         audience = request.base_url + request.path
 
         credentials = described_class.authenticate(request_with(build_assertion(claims: { "aud" => audience })))
 
+        expect(credentials).to be_nil
+      end
+
+      it "refuses an assertion carrying the request's token endpoint URL" do
+        credentials = described_class.authenticate(
+          request_with(build_assertion(claims: { "aud" => "http://example.org/oauth/token" })),
+        )
+
+        expect(credentials).to be_nil
+      end
+    end
+
+    context "when only Rails' default_url_options identifies the server" do
+      before do
+        config_is_set(:issuer, nil)
+        allow(::Rails.application.routes).to receive(:default_url_options)
+          .and_return(protocol: "https", host: "as.example.com")
+      end
+
+      it "accepts an endpoint URL built from it" do
+        request = request_with(build_assertion)
+
+        credentials = described_class.authenticate(
+          request_with(build_assertion(claims: { "aud" => "https://as.example.com#{request.path}" })),
+        )
+
         expect(credentials).not_to be_nil
+      end
+
+      it "rejects an audience built from the request's Host header" do
+        request = request_with(build_assertion)
+        audience = request.base_url + request.path
+
+        credentials = described_class.authenticate(request_with(build_assertion(claims: { "aud" => audience })))
+
+        expect(credentials).to be_nil
+      end
+    end
+
+    # Doorkeeper allows any string as the issuer, so one that is not an
+    # absolute URL identifies the server for the audience check even though no
+    # endpoint URL can be derived from it.
+    context "when the issuer is not a URL" do
+      before { config_is_set(:issuer, "urn:example:as") }
+
+      it "accepts the issuer itself as audience" do
+        credentials = described_class.authenticate(
+          request_with(build_assertion(claims: { "aud" => "urn:example:as" })),
+        )
+
+        expect(credentials).not_to be_nil
+      end
+
+      it "rejects an audience built from the request's Host header" do
+        request = request_with(build_assertion)
+        audience = request.base_url + request.path
+
+        credentials = described_class.authenticate(request_with(build_assertion(claims: { "aud" => audience })))
+
+        expect(credentials).to be_nil
       end
     end
 

--- a/spec/requests/flows/private_key_jwt_spec.rb
+++ b/spec/requests/flows/private_key_jwt_spec.rb
@@ -13,6 +13,9 @@ feature "private_key_jwt client authentication" do
 
   background do
     config_is_set(:client_authentication, %i[client_secret_basic client_secret_post none private_key_jwt])
+    # The accepted audiences are built from the server's own identity, so the
+    # dummy app has to declare one for an assertion to be acceptable at all.
+    config_is_set(:issuer, "http://www.example.com")
     default_scopes_exist :default
     config_is_set(:authenticate_resource_owner) { User.first || redirect_to("/sign_in") }
     create_resource_owner
@@ -271,6 +274,46 @@ feature "private_key_jwt client authentication" do
 
     expect(page.driver.response.status).to eq(200)
     expect(token.reload).to be_revoked
+  end
+
+  # A server that names itself nowhere has no audience to check an assertion
+  # against, so it authenticates nobody with one rather than trusting the
+  # request to say who it is.
+  context "when the server identifies itself nowhere" do
+    background do
+      config_is_set(:issuer, nil)
+    end
+
+    scenario "an assertion is rejected even though it matches the request URL" do
+      code = authorize_and_return_code
+
+      post_token(
+        code,
+        client_assertion: client_assertion,
+        client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+      )
+
+      expect(page.driver.response.status).to eq(401)
+      expect(json_response["error"]).to eq("invalid_client")
+    end
+
+    # aud is the only claim tying an assertion to this server. While the
+    # audience was built from the request, a forwarded Host header was enough
+    # to choose the value the assertion would be checked against, so one
+    # minted for another authorization server authenticated here.
+    scenario "an assertion matching a forwarded Host header is rejected" do
+      code = authorize_and_return_code
+
+      page.driver.header("X-Forwarded-Host", "as.attacker.example")
+      post_token(
+        code,
+        client_assertion: client_assertion(claims: { "aud" => "http://as.attacker.example/oauth/token" }),
+        client_assertion_type: Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt::CLIENT_ASSERTION_TYPE,
+      )
+
+      expect(page.driver.response.status).to eq(401)
+      expect(json_response["error"]).to eq("invalid_client")
+    end
   end
 
   scenario "an assertion for an unrelated audience is rejected" do


### PR DESCRIPTION
## What

`private_key_jwt` client authentication verifies an assertion's `aud` claim against a list of values that identify this authorization server. Until now that list was built from the request when the server had no identity of its own configured — neither `issuer` nor Rails' `default_url_options[:host]` — so the value an assertion was checked against came from the `Host` header the caller sends.

This PR derives the acceptable audiences only from the server's own configuration. A server that identifies itself nowhere now has no acceptable audience at all and refuses every assertion, and `Doorkeeper::Config` says so at boot rather than leaving it to be discovered one request at a time.

## Why

`aud` is the only claim that ties an assertion to *this* server rather than to another one. RFC 7523 §3 requires the audience to identify the authorization server, and RFC 7523 §3 (and the Security Considerations in §8) treat that check as what stops an assertion issued for one server from being presented to another.

When the audience is derived from a request header, the caller picks the value it will be compared against — so an assertion minted for a *different* authorization server can be presented here and pass the audience check. The assertion still has to verify against the client's published keys, so this affects a client the server already knows; but the audience check exists precisely so that an assertion scoped to another server is not usable here, and it was not doing that job.

Deployments that configure `issuer` or `default_url_options[:host]` — which the initializer already told operators to do for this method — were never affected: the request was only consulted as a fallback.

## Changes

- `Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt` builds the acceptable audiences from `issuer` and `default_url_options` only. The private `server_url_options` helper, which held the request fallback, is removed.
- An assertion is refused outright when no audience is acceptable, rather than being handed an empty audience list to verify against.
- New `Doorkeeper::Config` validation: enabling `private_key_jwt` without an `issuer` and without `default_url_options[:host]` logs an error at boot explaining that every assertion will be refused.
- The initializer template's note on audiences is updated to match.

## Breaking change

A deployment that enables `private_key_jwt` while configuring neither `issuer` nor `default_url_options[:host]` authenticated clients against a request-derived audience before, and now authenticates none until it is given an identity. The boot-time error names both options.

Configuring either one restores authentication; no client-side change is required for a client that already sends the issuer identifier or the token endpoint URL as `aud`.