### PR TITLE
Pin the development dependency on json below 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ User-visible changes worth mentioning.
 - [#1916] Fix broken Coveralls coverage reporting.
 - [#1918] The api_only controller specs no longer `load` the real controller sources, which detached the coverage of every other example that ran them and made the reported coverage depend on the random example order.
 - [#1923] Fix: the fallback secret upgrade no longer writes the matched secret back over a value stored in the meantime, which could undo a concurrent `#renew_secret` and leave the superseded secret valid. Active Record writes the upgrade conditionally on the column still holding the value that matched; other ORMs can implement the new `write_upgraded_secret` hook. The Active Record write is a single `update_all` statement, so model callbacks and validations no longer run on this upgrade (timestamps and optimistic locking are still maintained).
+- [#1925] Internal: pin the development dependency on `json` below 3.0. json 3 removed the positional options Hash from `JSON.parse` and the `quirks_mode` option from `JSON.generate`, both of which Active Support still uses, so the suite could not run on any released Rails version.
 - [#PR ID] Description of the change.
 
 ## 6.0.0.beta2

--- a/Gemfile
+++ b/Gemfile
@@ -38,3 +38,9 @@ gem "irb", "~> 1.8"
 
 # Interactive Debugging tools
 gem "debug", "~> 1.8"
+
+# json 3.0 removed the positional options Hash from JSON.parse and the
+# quirks_mode option from JSON.generate. Active Support still passes both, so
+# every released Rails version raises ArgumentError as soon as it encodes or
+# decodes JSON. Drop this pin once Rails ships releases that support json 3.
+gem "json", "< 3"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -23,4 +23,6 @@ gem "drb"
 gem "mutex_m"
 gem "concurrent-ruby", "1.3.4"
 
+gem "json", "< 3" # Active Support is not compatible with json 3 yet
+
 gemspec path: "../"

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -19,4 +19,6 @@ gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
 
+gem "json", "< 3" # Active Support is not compatible with json 3 yet
+
 gemspec path: "../"

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -19,4 +19,6 @@ gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
 
+gem "json", "< 3" # Active Support is not compatible with json 3 yet
+
 gemspec path: "../"

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -19,4 +19,6 @@ gem "sqlite3", "~> 2.3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
 
+gem "json", "< 3" # Active Support is not compatible with json 3 yet
+
 gemspec path: "../"

--- a/gemfiles/rails_8_0_jwt_2.gemfile
+++ b/gemfiles/rails_8_0_jwt_2.gemfile
@@ -21,4 +21,6 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
 gem "jwt", "2.7.0"
 
+gem "json", "< 3" # Active Support is not compatible with json 3 yet
+
 gemspec path: "../"

--- a/gemfiles/rails_8_1.gemfile
+++ b/gemfiles/rails_8_1.gemfile
@@ -19,4 +19,6 @@ gem "sqlite3", "~> 2.3", platform: [:ruby, :mswin, :mingw, :x64_mingw]
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 gem "timecop"
 
+gem "json", "< 3" # Active Support is not compatible with json 3 yet
+
 gemspec path: "../"


### PR DESCRIPTION
## What

Pins `json` to `< 3` in the root `Gemfile` and in every `gemfiles/*.gemfile` except `rails_edge.gemfile`.

## Why

[json 3.0.0](https://rubygems.org/gems/json/versions/3.0.0) was released on 2026-09-07 at 06:57 UTC and dropped two APIs that Active Support still uses:

- `JSON.parse` no longer accepts a positional options Hash. `ActiveSupport::JSON.decode` calls `::JSON.parse(json, options)` (`active_support/json/decoding.rb:25`), so every decode raises `ArgumentError: wrong number of arguments (given 2, expected 1)`.
- `JSON.generate` no longer accepts `quirks_mode`. `ActiveSupport::JSON::Encoding::JSONGemEncoder` passes it, so every `#to_json` raises `ArgumentError: unknown keyword: quirks_mode`.

Doorkeeper does not depend on `json` directly, but Active Support does (`json >= 2.3`), so a fresh resolution picks up 3.0.0 and the whole suite fails on every supported Rails version. The blast radius is not limited to the JSON endpoints: the session cookie is decoded through `ActiveSupport::JSON.decode`, so anything that touches `flash` or renders a view dies as well.

CI on [run 34113739923](https://github.com/doorkeeper-gem/doorkeeper/actions/runs/34113739923) (10:53 UTC, about four hours after the release) went from all green to all red, for example:

- `Ruby 3.2 (gemfiles/rails_8_0.gemfile)`: 1968 examples, 443 failures
- `Ruby 3.2 (gemfiles/rails_8_1.gemfile)`: 1968 examples, 90 failures

Diffing the resolved dependency list of that run against the last green run of the same job produced exactly one line of difference:

```
< json (2.21.2)
---
> json (3.0.0)
```

Reproduced locally on Ruby 4.0.2 / Rails 8.1.3.1 by upgrading only `json`:

| json    | `spec/requests/flows/authorization_code_errors_spec.rb` |
| ------- | ------------------------------------------------------- |
| 3.0.0   | 11 examples, 7 failures                                  |
| 2.21.2  | 11 examples, 0 failures                                  |

Rails 8.1.3.1 (2026-07-29) is the newest release at the time of writing, and no released version carries a fix.

> [!NOTE]
>
> - The pin is a development dependency only, so it constrains nothing for host applications and is not added to the gemspec.
> - `gemfiles/rails_edge.gemfile` is deliberately left unpinned so the edge job keeps exercising json 3 and shows when Rails main becomes compatible. That job already soft-fails (`bundle exec rake spec || echo ...`), so it cannot break the build either way. Happy to pin it too if you would rather keep the gemfiles uniform.
> - This should be reverted once Rails ships releases that support json 3.
> - The changelog entry is here only because the changelog verifier watches `Gemfile`. If you would rather keep `CHANGELOG.md` to user-visible changes, the `dependencies` label skips the check and I will drop the entry.