### PR TITLE
Release 5.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,6 @@ User-visible changes worth mentioning.
 - [#1779] Only lock previous access token model when creating a new token from its refresh token if revoke_previous_refresh_token_on_use is false
 - [#1778] Ensure that token revocation is idempotent by checking that that token has not already been revoked before revoking.
 
-
 ## 5.8.2
 
 - [#1755] Fix the error message for force_pkce

--- a/lib/doorkeeper/version.rb
+++ b/lib/doorkeeper/version.rb
@@ -5,7 +5,7 @@ module Doorkeeper
     # Semantic versioning
     MAJOR = 5
     MINOR = 9
-    TINY = 6
+    TINY = 7
     PRE = nil
 
     # Full version number


### PR DESCRIPTION
Version bump for the 5.9.7 release of the 5.9 maintenance branch.

- `lib/doorkeeper/version.rb`: `5.9.6` → `5.9.7`