### PR TITLE
Cover the error type and the audience fallbacks the last merges left unexercised

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -36,4 +36,8 @@ jobs:
         uses: dangoslen/changelog-enforcer@v3.7.0
         with:
           changeLogPath: CHANGELOG.md
-          skipLabels: "dependencies"
+          # Dependabot PRs are labeled "dependencies" automatically and don't
+          # need a changelog entry; "Skip-Changelog" keeps a manual escape hatch.
+          # It is the action's default, but an explicit list replaces the
+          # default rather than extending it, so it has to be repeated here.
+          skipLabels: "Skip-Changelog,dependencies"

--- a/spec/lib/errors_spec.rb
+++ b/spec/lib/errors_spec.rb
@@ -2,18 +2,39 @@
 
 require "spec_helper"
 
-RSpec.describe Doorkeeper::Errors::MissingConfigurationBuilderClass do
-  it "is a Doorkeeper error" do
-    expect(described_class.ancestors).to include(Doorkeeper::Errors::DoorkeeperError)
+RSpec.describe Doorkeeper::Errors do
+  describe Doorkeeper::Errors::MissingConfigurationBuilderClass do
+    it "is a Doorkeeper error" do
+      expect(described_class.ancestors).to include(Doorkeeper::Errors::DoorkeeperError)
+    end
+
+    # Regression test: `Doorkeeper::Config::Option#extended` referenced an error
+    # class that was never defined, so extending a class without a `builder_class`
+    # raised a NameError ("uninitialized constant") instead of this descriptive
+    # error.
+    it "is raised when the option DSL is extended without a builder_class" do
+      expect do
+        Class.new.extend(Doorkeeper::Config::Option)
+      end.to raise_error(described_class, /Define `self.builder_class` method/)
+    end
   end
 
-  # Regression test: `Doorkeeper::Config::Option#extended` referenced an error
-  # class that was never defined, so extending a class without a `builder_class`
-  # raised a NameError ("uninitialized constant") instead of this descriptive
-  # error.
-  it "is raised when the option DSL is extended without a builder_class" do
-    expect do
-      Class.new.extend(Doorkeeper::Config::Option)
-    end.to raise_error(described_class, /Define `self.builder_class` method/)
+  describe Doorkeeper::Errors::MultipleAccessTokenMethods do
+    it "is a Doorkeeper error" do
+      expect(described_class.ancestors).to include(Doorkeeper::Errors::DoorkeeperError)
+    end
+
+    # RFC 6750 §3.1 lists a request that transmits the token by more than one
+    # method among the conditions answered with invalid_request, so that is the
+    # error type the exception exposes to Helpers::Controller's
+    # get_error_response_from_exception, with the reason that selects the
+    # error_description.
+    it "reports itself as an invalid_request error" do
+      expect(described_class.new.type).to eq(:invalid_request)
+    end
+
+    it "names the reason for the error description" do
+      expect(described_class.new.reason).to eq(:multiple_access_token_methods)
+    end
   end
 end

--- a/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
+++ b/spec/lib/oauth/client_authentication/private_key_jwt_spec.rb
@@ -247,6 +247,59 @@ RSpec.describe Doorkeeper::OAuth::ClientAuthentication::PrivateKeyJwt do
       end
     end
 
+    # An issuer string URI cannot parse is still the server's declared identity:
+    # it is accepted as an audience literally, and no endpoint URL is derived
+    # from it rather than the parse failure bubbling out of authentication.
+    context "when the issuer is not a parseable URI" do
+      before { config_is_set(:issuer, "http://[as.example.com") }
+
+      it "accepts the issuer itself as audience" do
+        credentials = described_class.authenticate(
+          request_with(build_assertion(claims: { "aud" => "http://[as.example.com" })),
+        )
+
+        expect(credentials).not_to be_nil
+      end
+
+      it "rejects an audience built from the request's Host header" do
+        request = request_with(build_assertion)
+        audience = request.base_url + request.path
+
+        credentials = described_class.authenticate(request_with(build_assertion(claims: { "aud" => audience })))
+
+        expect(credentials).to be_nil
+      end
+    end
+
+    # The token endpoint URL is generated through the routes the host
+    # application mounted; when that fails (the tokens controller is skipped
+    # or mapped to something no route reaches) the other audiences still stand
+    # rather than the failure bubbling out of authentication.
+    context "when the token endpoint URL cannot be generated" do
+      before do
+        allow(Doorkeeper::Rails::Routes).to receive(:mapping)
+          .and_return(tokens: { controllers: "doorkeeper/unmounted_tokens" })
+      end
+
+      it "still accepts the called endpoint's URL as audience" do
+        request = request_with(build_assertion)
+
+        credentials = described_class.authenticate(
+          request_with(build_assertion(claims: { "aud" => "#{issuer}#{request.path}" })),
+        )
+
+        expect(credentials).not_to be_nil
+      end
+
+      it "no longer accepts the token endpoint URL as audience" do
+        credentials = described_class.authenticate(
+          request_with(build_assertion(claims: { "aud" => "#{issuer}/oauth/token" })),
+        )
+
+        expect(credentials).to be_nil
+      end
+    end
+
     it "accepts a matching client_id parameter next to the assertion" do
       credentials = described_class.authenticate(request_with(build_assertion, client_id: client_id))
 


### PR DESCRIPTION
Test-only and CI-only change so the Coveralls check on `main` is green again before 6.0.0.rc1.

### Coverage

The suite is all green, but the last merge into `main` (the RFC 6750 §2 multiple-token-methods change) left one line unexercised: `Doorkeeper::Errors::MultipleAccessTokenMethods#type`. The helpers catch that error before it reaches `Helpers::Controller#get_error_response_from_exception`, so the `invalid_request` type it exposes there was never read by the suite, and Coveralls reported the decrease (99.658% → 99.635%). #1926 itself raised coverage (+0.03%).

What this adds:

- `spec/lib/errors_spec.rb` — pins `MultipleAccessTokenMethods` as a `DoorkeeperError` with the `invalid_request` type and the `multiple_access_token_methods` reason. The file is nested under one top-level `describe Doorkeeper::Errors` to satisfy `RSpec/MultipleDescribes`; the existing examples are unchanged apart from indentation (`git diff -w`).
- `spec/lib/oauth/client_authentication/private_key_jwt_spec.rb` — exercises the two rescue branches of the audience construction that had stayed uncovered since `private_key_jwt` landed in #1896: an `issuer` that `URI` cannot parse is still accepted as an audience literally, with no endpoint URL derived from it and no error leaving the authentication; a token endpoint URL that cannot be generated through the mounted routes (tokens controller skipped or unrouted) drops out of the audience list, while the called endpoint's URL is still accepted.

Line coverage 99.635% → 99.713% locally (3820 / 3831 relevant lines, full suite green), above the 99.658% Coveralls reported before the decrease. `bundle exec rubocop` is clean on the changed files.

### Changelog enforcer

The changelog workflow listed only `dependencies` in `skipLabels`, which replaced the action's default `Skip-Changelog` instead of extending it. This meant maintainers had no label to wave through a PR that doesn't need a CHANGELOG entry (release bumps, CI changes, test-only work). Both labels are now listed, matching doorkeeper-openid_connect's workflow. The `Skip-Changelog` label has been created in the repository.